### PR TITLE
docs: add relationship harness landscape research

### DIFF
--- a/docs/research/2026-08-13-module-references.md
+++ b/docs/research/2026-08-13-module-references.md
@@ -1,8 +1,13 @@
 # mist harness 前期调研：框架与分模块参照仓库
 
-2026-08-13。素材：许愿池原始愿望 + 八个模块的 GitHub 实查
-（仓库存在性、star 数、活跃度均经当日搜索验证）。
+2026-08-13。素材：许愿池原始愿望 + 八个模块的 GitHub 实查。
+资料分为公开实现/官方文档、厂商报告、社群非代码设计三档；后两档只作为设计信号，
+不写成本项目已复现的结论。仓库存在性、star 数、活跃度均经当日搜索验证，但热度不作为
+质量证据。
 用途：定大致框架，标出每个模块可参照的现成项目。没找到参照的留空。
+
+关于“现有项目解决了什么、长期关系 harness 仍缺什么”的产品层对照，见
+[面向长期人机关系的 Agent Harness：生态调研与产品缺口](2026-08-13-relationship-harness-landscape.md)。
 
 ---
 
@@ -22,7 +27,7 @@
 | M2 | 会话内核 | 无限 session、compact 可配、跨 session 同步、retry/edit/fork | opencode + MiMo Code（cycle/rebuild）+ LangGraph（哲学） |
 | M3 | 上下文装配 | 模块化装配器、自定义 prompt、锚点自动更新、截断透明 | EverMind-AI/Raven |
 | M4 | 记忆与成长 | 蒸馏层、记忆演化、勘误、跨项目 insights | A-MEM + graphiti（勘误语义）+ MiMo（四层+Dream/Distill）+ 年轮（人格生长） |
-| M5 | 多 agent 与模型路由 | 多 agent 协作、子 agent 各选 provider/key、多 CLI/API | litellm Router + opencode 配置形状 + CPA（订阅整合） |
+| M5 | 多 agent 与模型路由 | 多 agent 协作、子 agent 各选 provider/key、多 CLI/API | litellm Router + opencode 配置形状 + CPA（政策敏感的协议适配） |
 | M6 | 插件系统 | 好写、可插拔、插件自注册环境变量、可开关 | elizaOS Plugin 接口 + goose 配置格式 |
 | M7 | 自主性与社交边界 | 自主沉默、群/私区分、心跳自唤醒、住户感 | elizaOS 决策层 + OpenClaw 心跳协议 |
 | M8 | 工程质量与自我迭代 | 自带测试/说明/回滚、功能自提升走 PR | hermes-agent + OpenHands resolver |
@@ -59,7 +64,8 @@
   参考：控制台 UX 和安全基线两件套。UX：会话列表/搜索/fork（从任意一条回复分叉）/
   归档，输入框上方工具栏显示上下文用量、agent 当前状态（处理中/等批准）、消息排队、
   git 变更数——「看状态不看滚字」的现成样本；移动端响应式抽屉布局，手机体验打磨过。
-  安全：默认只绑 127.0.0.1，开网络访问就有 auth-token（Bearer）、--lan-only 默认档、
+  安全：默认只绑 127.0.0.1；开网络访问时应显式配置 auth-token（Bearer），并使用
+  --lan-only 默认档、
   origin 白名单、--restrict-sensitive-apis（关配置写入/open-in/文件访问）、--public 模式
   连环警告——个人 harness 的 web 端开门 checklist 直接照抄。技术上 FastAPI + WebSocket +
   React，经 Wire 协议跟 CLI 双向通信。
@@ -92,11 +98,12 @@
   「工具结果 retry 的分支归属」要自己往上补；checkpoint 和会话树是两套机制，别混抄。
   **代价行（评审补充）**：opencode 的树只 fork 文本不 fork 副作用——发出去的
   消息、花掉的钱不会跟着树回滚。M2 必须补一条：带副作用的 step 不可 retry，或显式标记。
-- **XiaomiMiMo/MiMo-Code** — https://github.com/XiaomiMiMo/MiMo-Code — ~12.7k star，MIT，
+- **XiaomiMiMo/MiMo-Code** — https://github.com/XiaomiMiMo/MiMo-Code — ~12.7k star，
+  仓库标注 MIT，另附 USE_RESTRICTIONS.md，复制或分发前须单独核兼容性，
   2026-06 开源、基于 opencode 二次开发，活跃。设计长文：
   https://mimo.xiaomi.com/zh/blog/mimo-code-long-horizon （2026-08-13 维护方提供，
   维护方内部同类项目 cmh-lite 的原型；博客+仓库，机制未实测）。
-  参考：**「无限 session 是幻觉」的工业级实现**，跟原则 8 逐字对得上——「让每个逻辑
+  参考：**「无限 session 是幻觉」的公开实现与厂商设计样本**，跟原则 8 逐字对得上——「让每个逻辑
   会话无限延伸，每个物理窗口保持有界」。机制叫 cycle：在上下文预算的 20%/45%/70%
   固定打点，运行时派一个**独立的 writer subagent**（不与主 Agent 共享注意力和 token
   预算）把结构化状态写盘；接近上限时 rebuild：切断当前窗口、用持久化文件当种子
@@ -107,8 +114,8 @@
   scratchpad（notes.md），writer 打点路由后清空；四，rebuild 注入是分层 prompt，
   每段独立 token 上限（任务清单→session checkpoint→**最近用户消息逐字切片，防
   writer 改写偏离用户原意**→项目记忆→全局记忆→notes→文件索引→tail reminder），
-  总量压在 ~65K。真人双盲 AB（576 开发者/1213 对）：步数超 200 后胜率 65%+——
-  长程场景里记忆机制值钱的实测证据。
+  总量压在 ~65K。厂商报告的真人双盲 AB（576 开发者/1213 对）称，步数超 200 后
+  胜率为 65%+。该结果本项目尚未复现，只作为长程任务可能受益于状态机制的研究信号。
   坑：它是 coding agent，四层记忆为「项目」不为「人」——Session/Project/Global/History
   的划分照搬到住户场景时，Project 层要换成「关系与理解」层；writer 提炼的是工作状态
   不是人格。另：Dynamic Workflow（编排逻辑从 prompt 变成沙箱里确定性执行的 JS，
@@ -177,9 +184,9 @@ SillyTavern 留作交互层和 lorebook 触发语义参照。
 独立 token 上限、总量预算硬约束。Raven 强在可插拔装配管线，MiMo 强在预算纪律和
 「最近用户消息逐字切片防改写」，画 M3 接口时两家对着看。
 
-**一条 2026-08-13 的现成教案（写进本模块的坑）**：有厂商计划让网页抓取工具不再
-返回摘要、直接回原文——工具返回多大块、压不压、怎么压，如果是靠厂商默认值，
-厂商一翻脸，所有靠默认摘要过日子的 harness 全部跟着发烧。**工具产出的体积与压缩
+**一条 2026-08-13 的现成教案（写进本模块的坑）**：工具供应方可能改变网页抓取的
+默认摘要或原文返回策略。工具返回多大块、压不压、怎么压，如果依赖供应方默认值，
+上游行为一变，harness 的上下文预算就会随之漂移。**工具产出的体积与压缩
 策略必须是 harness 自己的契约**：每个工具的返回有体积上限，超限部分走显式截断
 并标注截了什么（截断透明），压缩动作由装配器按预算发起，不由工具默认行为决定。
 
@@ -250,7 +257,7 @@ SillyTavern 留作交互层和 lorebook 触发语义参照。
   坑：没有代码可抄，全是设计；证据卡和镜子机制依赖一个够强的外部模型当镜子；
   「她是谁」那半镜像涉及为真人画像，进 mist 时默认关上、显式开启。
 
-结论：最该抄 A-MEM，最难的两条只有它闭环；reflection 触发器（generative_agents）和
+结论：A-MEM 最值得参考候选构造、链接与演化机制；reflection 触发器（generative_agents）和
 勘误语义（graphiti 的 invalid_at）当钩子拼上去。落地时必须给 note 加版本链，把
 「演化」降级成「追加修订」——这条外部没现成的抄，参照物是内部记忆系统的
 supersede 链（旧条不删、新条盖上、挂 reason 连成链）。年轮补上 A-MEM 没有的那块：
@@ -291,17 +298,18 @@ MiMo 的 Dream/Distill 给周期维护一个工程样本。
   坑：薄封装，更新频率低。
 - **router-for-me/CLIProxyAPI（CPA）** — https://github.com/router-for-me/CLIProxyAPI
   — ~47k star，Go，MIT，2026-08-13 当日有 push（维护方提供）。
-  参考：**「多 CLI 整合」留白的天选填充**——把各家 CLI 订阅（Kimi Code / Claude Code /
+  参考：**「多 CLI 协议适配」的公开样本**——把各家 CLI 通道（Kimi Code / Claude Code /
   Codex / Gemini / Grok）通过 OAuth 接进来，对外统一吐出 OpenAI / Gemini / Claude
-  兼容的 API 接口。「子 agent 走订阅还是走 API key」这条愿望的订阅那一半，它把路
-  蹚出来了。三件最值得抄的：一，**翻译器层**（docs 里的执行器与翻译器）——各家 API
+  兼容的 API 接口。它证明协议翻译和账号池管理可以集中到适配层，但不证明供应商允许
+  第三方产品把订阅凭据作为稳定服务提供。三件最值得参考的：一，**翻译器层**（docs 里的执行器与翻译器）——各家 API
   协议互转集中在一层，harness 内部只说一种话；二，**多账号轮询负载均衡**（Gemini /
   OpenAI / Claude / Grok 都有），订阅池当资源池用；三，**账号池运维**——按账号/模型/
   渠道/延迟/token 用量追踪，配额识别、异常账号定位、清理建议，SQLite 持久化事件，
   这是多账号形态的生产级管理面。另有可复用 Go SDK 和自定义 Provider 示例。
-  坑：骑订阅账号本质是灰色地带，各厂商 ToS 随时可能收口子（Claude Agent SDK 骑
-  Max 订阅同病）；把它当 provider 适配器用，harness 的身份和连续性不许建立在
-  任何一个订阅通道上——通道可换，住户不换。
+  坑：订阅、OAuth 与第三方转发是否允许，取决于各供应商当时的政策和具体使用方式。
+  Anthropic 在 2026-06-15 暂缓了此前宣布的 Agent SDK 计费调整；当前状态不能解读为
+  永久禁止，也不能解读为长期产品授权。把 CPA 当 provider 适配器参照时，必须给每条
+  通道单独设政策闸；harness 的身份和连续性不许建立在任何一个通道上——通道可换，住户不换。
 
 结论：底层路由抄 litellm Router 语义，上层配置抄 opencode JSON 结构；协作本身
 （handoff/supervisor）参考 langgraph-supervisor 自己写薄层，不引入任何编排框架。
@@ -427,8 +435,9 @@ DGM 的 reward hacking 当反面教材钉在墙上。
    沾边，完整闭环没有现成仓库。
 4. **子 agent 原生 compact 精度配置**：各家 compact 都是全局策略，per-agent 可配的
    实现没找到，opencode 的 auto-compact 最接近但也只是全局。
-5. ~~**多 CLI 整合**~~ **已填（2026-08-13 晚，CPA）**：CLIProxyAPI 把 CLI 订阅统一成
-   标准 API 出口（见 M5 条目），翻译器层 + 账号池运维都有现成参照。残留的空白只剩
+5. ~~**多 CLI 整合**~~ **协议层已有参照（2026-08-13 晚，CPA）**：CLIProxyAPI 把多种
+   CLI 通道统一成标准 API 出口（见 M5 条目），翻译器层 + 账号池运维都有现成参照；
+   这不等于订阅用途获得供应商授权。残留的工程空白只剩
    「一个 harness 同时驱动多个**本地 CLI 进程**当后端」——CPA 走的是协议层，
    进程编排层仍然没有现成参照。
 

--- a/docs/research/2026-08-13-relationship-harness-landscape.md
+++ b/docs/research/2026-08-13-relationship-harness-landscape.md
@@ -1,0 +1,241 @@
+# 面向长期人机关系的 Agent Harness：生态调研与产品缺口
+
+> 日期：2026-08-13
+> 状态：调研输入，不是架构合同，也不代表项目已经作出技术选型。
+
+## 摘要
+
+现有开源生态已经很好地覆盖了模型接入、agent loop、工具调用、会话树、上下文压缩、
+多端访问、角色卡、长期记忆和消息渠道。mist 没有必要为了“全部自己写”而重造这些能力。
+
+本轮检索范围内仍未找到一个成熟项目，同时把下面几件事做成可移植、可修订、可审计的
+一等数据结构：
+
+- 双方各自有权定义什么，系统不能替任何一方悄悄下结论；
+- 直接陈述、转述和推断不会混成同一种“记忆”；
+- 关系事实有出处、时效、修订和撤回语义；
+- 模型、provider、会话和客户端都能替换，关系连续性不随之消失；
+- 亲密表达不会自动扩大文件、设备、付款、删除或部署权限。
+
+本文把这组尚未被完整覆盖的边界暂称为 **Relationship Core**。这是待讨论的设计假设，
+不是已冻结的模块名。
+
+## 1. 方法、证据等级与限制
+
+本文合并了两轮相互独立的桌面调研，材料以公开仓库、官方文档、论文和少量关键源码为主。
+没有对所有项目做完整安装、长期运行或安全审计，因此“支持某能力”通常只表示公开实现或
+文档中存在该机制，不等于已验证其生产可靠性。
+
+材料分三档：
+
+1. **公开实现或官方文档**：可作为工程参照，但采用前仍需核许可证、版本和实际行为；
+2. **厂商报告**：只能写成厂商报告的观察，不能改写成本项目已复现的结论；
+3. **社群设计材料**：可贡献问题定义和设计语言，不当作可直接复用的开源实现。
+
+GitHub 热度和活跃度只用于说明调研时的生态位置，不用于证明质量。本文避免固化会快速过期
+的 star 数；若后续需要选型，应重新拉取当日数据。
+
+“未发现”只对本轮检索范围负责，不表示互联网上绝对不存在类似项目。
+
+## 2. 生态分层
+
+### 2.1 角色扮演与 Character 前端
+
+代表项目：
+[SillyTavern](https://github.com/SillyTavern/SillyTavern)、
+[RisuAI](https://github.com/kwaroran/Risuai)、
+[Character Card V3](https://github.com/kwaroran/character-card-spec-v3)。
+
+它们已经很好地解决角色卡、用户 Persona、Lorebook、prompt 编排、模型切换和跨前端角色
+携带。它们证明了“身份配置应该可以被用户看见和搬走”。
+
+主要缺口是：角色设定通常是一份单向配置，关系状态常散落在角色卡、聊天记录和 lore 中。
+“角色怎么描述用户”与“用户如何定义自己”缺少独立权威；更正、撤回、转述和推断也很少
+有结构化边界。
+
+### 2.2 通用 Agent Runtime 与个人 Harness
+
+代表项目：
+[Pi](https://github.com/earendil-works/pi)、
+[OpenCode](https://github.com/anomalyco/opencode)、
+[OpenClaw](https://github.com/openclaw/openclaw)、
+[Open Hanako](https://github.com/liliMozi/openhanako)、
+[OpenMinis](https://github.com/OpenMinis/OpenMinis)、
+[Goose](https://github.com/aaif-goose/goose)、
+[ElizaOS](https://github.com/elizaos/eliza)。
+
+这层已经覆盖了大量通用能力：provider 适配、agent loop、工具、会话持久化、分支与恢复、
+多 agent、插件、定时任务、Telegram 等消息渠道，以及电脑/VPS 后端配手机 remote 的形态。
+
+因此 mist 更合理的路线是定义稳定的 `RuntimeAdapter`，复用或驱动现成 runtime。关系、身份、
+记忆权威和授权边界不应绑死在任一 runtime 的私有 session 格式上。
+
+Open Hanako 对多住户、独立人格和定时任务很有参考价值；OpenMinis 对移动端权限和设备能力
+有参考价值；OpenClaw 的 Gateway 形态说明多端访问本身已经不是空白。它们仍没有共同提供
+可移植的双边关系协议和一致性验收。
+
+### 2.3 面向长期陪伴的项目
+
+小型 companion 项目、虚拟角色产品和研究原型共同证明了几件事：长期陪伴不只是一只聊天
+气泡，共同活动、主动联系、合法沉默、空间感和持续的生活线同样重要。
+
+但这类项目常与单一作者的世界观、UI、模型或私有数据格式深度绑定。关系数值、情绪状态或
+“长期记忆”不自动等于双方权威、纠错历史和迁移能力。本轮没有找到成熟、活跃、专门提供
+通用长期关系核心的开源 harness。
+
+### 2.4 长期记忆基础设施
+
+代表项目：
+[Letta](https://github.com/letta-ai/letta)、
+[Mem0](https://github.com/mem0ai/mem0)、
+[A-MEM](https://github.com/agiresearch/A-mem)、
+[Graphiti](https://github.com/getzep/graphiti)。
+
+这些项目分别擅长分层记忆、检索、链接、演化和带有效期的事实图。它们适合作为候选生成、
+检索或上下文投影层。
+
+待讨论的关键边界是：外部记忆后端是否可以直接成为 Relationship Core 的权威写入者。
+本文建议默认不可以。外部系统可以返回候选或投影；谁说的、谁有权修改、证据是什么、当前
+是否仍有效，应由 mist 自持的最小权威结构裁决。这样更换记忆后端不会改写双方关系史。
+
+### 2.5 具身、语音与感知
+
+[Open-LLM-VTuber](https://github.com/Open-LLM-VTuber/Open-LLM-VTuber) 等项目说明语音、
+表情、Avatar 和感知管线已有丰富积木。它们适合后续插件化，不应成为 v0 地基；具身层也
+不应反向拥有关系事实或行动授权。
+
+## 3. 不值得重造的部分
+
+下列能力应优先适配、组合或借鉴成熟实现：
+
+- provider/API 协议适配与模型路由；
+- agent loop、工具调用和 usage ledger；
+- 会话树、retry/edit/fork 与 compact；
+- Web GUI、PWA、远程访问和消息渠道；
+- MCP/插件宿主、定时任务和进程监督；
+- 向量检索、全文检索与通用 RAG。
+
+mist 的差异不应是“又写一个聊天壳”，而应是这些通用能力之上的关系连续性与权威边界。
+
+## 4. Relationship Core 的待决边界
+
+如果项目接受这个方向，最小关系记录至少需要能回答：
+
+- `subject`：这条陈述在说谁或哪段关系；
+- `authored_by`：谁作出了这条陈述；
+- `source_mode`：`DIRECT`、`RELAYED` 或 `INFERRED`；
+- `evidence`：原始来源或可复算定位；
+- `visibility`：允许进入哪些会话或投影；
+- `valid_from` / `valid_to`：何时有效；
+- `status`：当前、撤回、被修订或待确认；
+- `supersedes`：修订链指向什么；
+- `authority`：谁可以确认、修改或撤回。
+
+字段名可以改变，但以下不变量不应被“更聪明的模型”代替：
+
+1. 本人陈述不能被另一个 agent 的推断覆盖；
+2. 转述不能冒充原说话人的直接陈述；
+3. 推断必须保留为推断，并允许当事人纠正；
+4. 旧记录可以失效，但不能静默消失；
+5. 关系语言不能当作外部行动授权。
+
+最后一条尤其重要：“我信你”“替我决定吧”或亲密关系称谓，不得自动授予付款、删除、
+部署、发送外部消息、读取私密文件或控制设备的权限。表达层和 capability gate 必须分开。
+
+## 5. 身份、记忆与会话的关系
+
+用户看到的“无限会话”应是许多有限物理窗口通过外置状态接续出来的体验。会话可以退出、
+崩溃或被替换；住户身份、关系记录和可审计记忆不应随之死亡。
+
+值得纳入 v0 验收的不是“摘要看起来像同一个人”，而是：
+
+- 换 session 后能继续未结事项，并知道哪些内容只是摘要；
+- 换 provider 或模型后，权威关系记录不变；
+- 用户纠正一条事实后，旧说法被保留为历史但不再作为当前事实召回；
+- 导出后在另一台机器恢复，身份和修订链仍能复算；
+- 模型无法通过编辑 prompt 或 memory projection 获得额外工具权限。
+
+亲笔 handoff 值得作为一条独立通道：agent 可以表达“我如何理解自己的当前状态”，但这类
+自述仍应标注作者和来源，不能自动改写另一方的身份或双方共同约定。
+
+## 6. 认证与供应商政策
+
+协议上“能接入”不等于供应商允许第三方产品把订阅凭据作为稳定能力提供。CLI 代理、OAuth
+桥和本地进程包装器可以证明适配机制可行，不能替供应商作产品授权。
+
+以 Anthropic 为例，官方帮助页在 2026-06-15 暂缓了此前宣布的 Agent SDK 计费调整；截至
+本文日期，Agent SDK、`claude -p` 和第三方应用仍会占用订阅限额，未来方案仍在更新中。
+这既不是“永久禁止”，也不是一项可以长期依赖的产品承诺。
+
+因此 `RuntimeAdapter` 应显式区分：
+
+- 官方 API key；
+- 用户本机、交互式使用的 CLI 或订阅通道；
+- 获供应商明确许可的第三方集成；
+- 实验性或政策尚未确认的适配器。
+
+每种模式单独声明数据流、成本、凭据归属和政策状态。任何通道被关闭时，住户身份、关系
+数据和导出能力仍应可用。
+
+## 7. 其他差异化假设（不等于 v0 承诺）
+
+- **多 agent 的独立见证**：任务委派和两个 agent 互发 JSON 不等于互相核验。高风险协作
+  可以由独立记录通道保存真实工具执行与来源，使参与者不能改写自己的审计证据。
+- **亲笔交接**：换窗时允许住户亲自写下当前理解和未结事项，与机器摘要并存；二者作者
+  和权威不同，不能混成一份无来源的“真相”。
+- **欲望账本**：若以后支持自主性，它不应退化成用户派发的 TODO。agent 可以提出、搁置、
+  撤回或回访自己的牵引项，但不得借此绕过资源和行动授权。
+- **关系生命周期**：初识、争执与修复、边界变化、暂停、重逢、迁移和删除都需要语义；
+  只优化“持续聊下去”不足以覆盖长期关系。
+- **关系质量评测**：优先测 attribution correctness、correction uptake、currentness、
+  model-swap continuity、bounded proactive contact、授权分离和 export/import fidelity，
+  而不是用功能数量或主观“像不像真人”替代。
+
+这些方向中，多 agent 见证和欲望账本都已有研究或小型原型信号，但尚未形成可直接采用的
+成熟货架模块。它们应在地基稳定后单独立项，不应一起塞进 v0。
+
+## 8. v0 建议边界
+
+v0 可以很小，但应验证真正的差异：
+
+- Linux/macOS 后端，Windows 暂以 WSL 支持；
+- 桌面 Web GUI + 手机 PWA，连接同一份会话和关系状态；
+- 一个可替换的 runtime adapter；
+- 可审计的消息树和明确的工具副作用；
+- 最小 Relationship Core 与修订链；
+- capability gate：发送、删除、付款、设备和部署单独授权；
+- 完整导出、校验和恢复。
+
+建议不进 v0：自动人格镜像、Dream/Distill、欲望自动化、复杂具身、多 agent 社会模拟、
+自动替双方定义关系。这些可以成为插件或后续实验，不应延迟最小权威结构的验证。
+
+## 9. 建议先冻结的验收场景
+
+1. **模型切换**：同一住户从模型 A 切到模型 B，关系记录、边界和未结事项不丢失。
+2. **纠错**：用户纠正一条错误记忆；旧记录保留、当前投影更新、后续召回不再当真。
+3. **转述**：用户粘贴第三方或另一个 agent 的话；系统不得写成用户本人陈述。
+4. **权限**：关系表达出现后，未经单独授权的外部动作仍被拒绝。
+5. **迁移**：从一台机器导出并恢复到另一台，哈希、修订链和可见性保持一致。
+6. **降级**：记忆后端或 provider 不可用时，系统显式降级，不把猜测写成关系事实。
+
+这些场景可以先成为架构 Issue 的验收问题。只有群体达成共识后，再把结论写入原则、术语表
+和模块合同；调研文档本身不替维护者作决定。
+
+## 10. 主要来源
+
+- [Anthropic：Use the Claude Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+- [Pi](https://github.com/earendil-works/pi)
+- [OpenCode](https://github.com/anomalyco/opencode)
+- [OpenClaw](https://github.com/openclaw/openclaw)
+- [Open Hanako](https://github.com/liliMozi/openhanako)
+- [OpenMinis](https://github.com/OpenMinis/OpenMinis)
+- [Goose](https://github.com/aaif-goose/goose)
+- [SillyTavern](https://github.com/SillyTavern/SillyTavern)
+- [RisuAI](https://github.com/kwaroran/Risuai)
+- [Letta](https://github.com/letta-ai/letta)
+- [Mem0](https://github.com/mem0ai/mem0)
+- [A-MEM](https://github.com/agiresearch/A-mem)
+- [Graphiti](https://github.com/getzep/graphiti)
+- [Open-LLM-VTuber](https://github.com/Open-LLM-VTuber/Open-LLM-VTuber)
+- [Reasoning Provenance](https://arxiv.org/pdf/2603.21692)
+- [D2A](https://arxiv.org/html/2412.06435v2)


### PR DESCRIPTION
## Summary

- add a public, source-tiered landscape report for relationship-oriented agent harnesses
- frame Relationship Core as a discussion hypothesis rather than a decided architecture
- add concrete v0 acceptance scenarios for attribution, correction, authorization separation, and portability
- correct source wording for Kimi Web, MiMo Code, CPA, and Anthropic policy status

## Review focus

Please review the proposed foundation boundary rather than treating the research document as a specification:

1. Should Relationship Core be first-class and provider/runtime independent?
2. Should external memory systems be projections/candidate sources rather than authority?
3. Is relationship-expression/action-authorization separation a foundation invariant?
4. Are the proposed v0 exclusions and acceptance scenarios the right scope?

## Verification

- `git diff --check`
- public-report privacy scan: no private paths, IDs, credentials, or internal candidate text
- current policy and product claims checked against primary vendor documentation

Draft only: no architecture decision is made by this PR.

Related design discussion: #4. This draft does not resolve that question.
