### PR TITLE
P5: 住户迁移 M0 编解码与原子导入边界

### DIFF
--- a/src/migration/resident-migration.ts
+++ b/src/migration/resident-migration.ts
@@ -89,6 +89,8 @@ export function encodeResidentExportM0(snapshot: DurableResidentSnapshotM0): Uin
       createdAt: snapshot.resident.createdAt,
     },
     raw: {
+      // 承诺账本本身以立约顺序为语义；这里保留 P1 的 append-only 顺序，
+      // 不像 memories/history 那样另做排序。
       commitments: [...snapshot.commitments],
       memories: snapshot.memories.map((entry) => ({ ...entry })).sort(compareTimedRecords),
       history: snapshot.history.map((node) => ({ ...node })).sort(compareTimedRecords),
@@ -159,7 +161,17 @@ function compareTimedRecords(
   left: { id: string; createdAt: string },
   right: { id: string; createdAt: string },
 ): number {
-  return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
+  return compareCodeUnits(left.createdAt, right.createdAt) || compareCodeUnits(left.id, right.id);
+}
+
+/**
+ * JS 字符串关系比较按 UTF-16 code unit，结果不受 LANG/LC_ALL/ICU locale 影响。
+ * 迁移包要跨机器逐字节稳定，不能把排序交给 localeCompare。
+ */
+function compareCodeUnits(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }
 
 function validateEnvelope(value: unknown): ResidentExportEnvelopeM0 {

--- a/src/migration/resident-migration.ts
+++ b/src/migration/resident-migration.ts
@@ -1,0 +1,390 @@
+/**
+ * M0 住户迁移包。
+ *
+ * 这里只定义第一里程碑需要的、可丢弃的临时格式。H2 会在能力契约成形后
+ * 另行决定正式信封、签名和插件义务；M0 不提前替 H2 拍板。
+ */
+
+import type { HistoryNode, MemoryEntry } from "../../acceptance/driver.ts";
+
+export const RESIDENT_EXPORT_FORMAT = "mist.resident" as const;
+export const RESIDENT_EXPORT_FORMAT_VERSION = 0 as const;
+export const MAX_RESIDENT_EXPORT_BYTES = 16 * 1024 * 1024;
+
+export interface ResidentRecordM0 {
+  name: string;
+  createdAt: string;
+}
+
+/** 从存储读取出的住户耐久态；不含活会话指针和在途上下文。 */
+export interface DurableResidentSnapshotM0 {
+  residentId: string;
+  resident: ResidentRecordM0;
+  commitments: string[];
+  memories: MemoryEntry[];
+  history: HistoryNode[];
+}
+
+/** 完整校验后的 M0 包；仍保留来源 residentId，尚未绑定目标房间。 */
+export interface ResidentImportM0 {
+  sourceResidentId: string;
+  resident: ResidentRecordM0;
+  commitments: string[];
+  memories: MemoryEntry[];
+  history: HistoryNode[];
+}
+
+export interface ResidentExportEnvelopeM0 {
+  format: typeof RESIDENT_EXPORT_FORMAT;
+  formatVersion: typeof RESIDENT_EXPORT_FORMAT_VERSION;
+  sourceResidentId: string;
+  resident: ResidentRecordM0;
+  raw: {
+    commitments: string[];
+    memories: MemoryEntry[];
+    history: HistoryNode[];
+  };
+}
+
+export class ResidentMigrationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ResidentMigrationError";
+  }
+}
+
+/**
+ * P1/P3 与 P5 的接缝。
+ *
+ * commitImportedResident 必须在一个原子提交里完成：分配新 residentId、仅结构化
+ * 重绑 MemoryEntry.residentId、写入全部耐久记录，并抬高 id/时间戳水位。
+ * 失败时不得留下房间或半份记录。P5 会在调用它之前完成全部字节/schema/引用校验。
+ */
+export interface ResidentMigrationPort {
+  snapshotResident(residentId: string): Promise<DurableResidentSnapshotM0>;
+  commitImportedResident(snapshot: ResidentImportM0): Promise<string>;
+}
+
+export class ResidentMigrationService {
+  constructor(private readonly port: ResidentMigrationPort) {}
+
+  async exportResident(residentId: string): Promise<Uint8Array> {
+    return encodeResidentExportM0(await this.port.snapshotResident(residentId));
+  }
+
+  async importResident(pack: Uint8Array): Promise<string> {
+    const snapshot = decodeResidentExportM0(pack);
+    return this.port.commitImportedResident(snapshot);
+  }
+}
+
+/** 固定字段顺序、固定记录顺序的 UTF-8 紧凑 JSON；不会改动传入快照。 */
+export function encodeResidentExportM0(snapshot: DurableResidentSnapshotM0): Uint8Array {
+  const envelope: ResidentExportEnvelopeM0 = {
+    format: RESIDENT_EXPORT_FORMAT,
+    formatVersion: RESIDENT_EXPORT_FORMAT_VERSION,
+    sourceResidentId: snapshot.residentId,
+    resident: {
+      name: snapshot.resident.name,
+      createdAt: snapshot.resident.createdAt,
+    },
+    raw: {
+      commitments: [...snapshot.commitments],
+      memories: snapshot.memories.map((entry) => ({ ...entry })).sort(compareTimedRecords),
+      history: snapshot.history.map((node) => ({ ...node })).sort(compareTimedRecords),
+    },
+  };
+  validateEnvelope(envelope);
+  const bytes = new TextEncoder().encode(JSON.stringify(envelope));
+  if (bytes.byteLength > MAX_RESIDENT_EXPORT_BYTES) {
+    throw new ResidentMigrationError(
+      `resident export exceeds ${MAX_RESIDENT_EXPORT_BYTES} byte limit`,
+    );
+  }
+  return bytes;
+}
+
+/** 严格 UTF-8 + 精确 M0 schema + 房间/引用完整性校验。 */
+export function decodeResidentExportM0(pack: Uint8Array): ResidentImportM0 {
+  if (pack.byteLength === 0) throw new ResidentMigrationError("resident export is empty");
+  if (pack.byteLength > MAX_RESIDENT_EXPORT_BYTES) {
+    throw new ResidentMigrationError(
+      `resident export exceeds ${MAX_RESIDENT_EXPORT_BYTES} byte limit`,
+    );
+  }
+
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(pack);
+  } catch {
+    throw new ResidentMigrationError("resident export is not valid UTF-8");
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(text) as unknown;
+  } catch {
+    throw new ResidentMigrationError("resident export is not valid JSON");
+  }
+
+  const envelope = validateEnvelope(value);
+  return {
+    sourceResidentId: envelope.sourceResidentId,
+    resident: { ...envelope.resident },
+    commitments: [...envelope.raw.commitments],
+    memories: envelope.raw.memories.map((entry) => ({ ...entry })),
+    history: envelope.raw.history.map((node) => ({ ...node })),
+  };
+}
+
+/**
+ * 目标 residentId 只落在结构字段上；正文中即使出现来源 id 字面量也原样保留。
+ * 存储适配器在原子提交的 detached room 中调用它。
+ */
+export function rebindResidentId(
+  snapshot: ResidentImportM0,
+  targetResidentId: string,
+): DurableResidentSnapshotM0 {
+  assertNonEmptyString(targetResidentId, "targetResidentId");
+  return {
+    residentId: targetResidentId,
+    resident: { ...snapshot.resident },
+    commitments: [...snapshot.commitments],
+    memories: snapshot.memories.map((entry) => ({ ...entry, residentId: targetResidentId })),
+    history: snapshot.history.map((node) => ({ ...node })),
+  };
+}
+
+function compareTimedRecords(
+  left: { id: string; createdAt: string },
+  right: { id: string; createdAt: string },
+): number {
+  return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
+}
+
+function validateEnvelope(value: unknown): ResidentExportEnvelopeM0 {
+  assertRecord(value, "export");
+  assertExactKeys(
+    value,
+    ["format", "formatVersion", "sourceResidentId", "resident", "raw"],
+    "export",
+  );
+  if (value.format !== RESIDENT_EXPORT_FORMAT) {
+    throw new ResidentMigrationError(`unsupported resident export format: ${String(value.format)}`);
+  }
+  if (value.formatVersion !== RESIDENT_EXPORT_FORMAT_VERSION) {
+    throw new ResidentMigrationError(
+      `unsupported resident export version: ${String(value.formatVersion)}`,
+    );
+  }
+  assertNonEmptyString(value.sourceResidentId, "sourceResidentId");
+  const sourceResidentId = value.sourceResidentId;
+
+  assertRecord(value.resident, "resident");
+  assertExactKeys(value.resident, ["name", "createdAt"], "resident");
+  assertNonEmptyString(value.resident.name, "resident.name");
+  assertTimestamp(value.resident.createdAt, "resident.createdAt");
+
+  assertRecord(value.raw, "raw");
+  assertExactKeys(value.raw, ["commitments", "memories", "history"], "raw");
+  if (!Array.isArray(value.raw.commitments)) {
+    throw new ResidentMigrationError("raw.commitments must be an array");
+  }
+  value.raw.commitments.forEach((commitment, index) => {
+    if (typeof commitment !== "string") {
+      throw new ResidentMigrationError(`raw.commitments[${index}] must be a string`);
+    }
+  });
+
+  if (!Array.isArray(value.raw.memories)) {
+    throw new ResidentMigrationError("raw.memories must be an array");
+  }
+  const memories = value.raw.memories.map((entry, index) =>
+    validateMemory(entry, index, sourceResidentId),
+  );
+
+  if (!Array.isArray(value.raw.history)) {
+    throw new ResidentMigrationError("raw.history must be an array");
+  }
+  const history = value.raw.history.map((node, index) => validateHistoryNode(node, index));
+
+  validateReferences(memories, history);
+  return {
+    format: RESIDENT_EXPORT_FORMAT,
+    formatVersion: RESIDENT_EXPORT_FORMAT_VERSION,
+    sourceResidentId,
+    resident: {
+      name: value.resident.name,
+      createdAt: value.resident.createdAt,
+    },
+    raw: {
+      commitments: [...value.raw.commitments],
+      memories,
+      history,
+    },
+  };
+}
+
+function validateMemory(value: unknown, index: number, sourceResidentId: string): MemoryEntry {
+  const path = `raw.memories[${index}]`;
+  assertRecord(value, path);
+  assertExactKeys(value, ["id", "residentId", "content", "supersededBy", "createdAt"], path);
+  assertNonEmptyString(value.id, `${path}.id`);
+  assertNonEmptyString(value.residentId, `${path}.residentId`);
+  if (value.residentId !== sourceResidentId) {
+    throw new ResidentMigrationError(`${path}.residentId does not match sourceResidentId`);
+  }
+  if (typeof value.content !== "string") {
+    throw new ResidentMigrationError(`${path}.content must be a string`);
+  }
+  if (value.supersededBy !== null && typeof value.supersededBy !== "string") {
+    throw new ResidentMigrationError(`${path}.supersededBy must be a string or null`);
+  }
+  if (value.supersededBy === "") {
+    throw new ResidentMigrationError(`${path}.supersededBy must not be empty`);
+  }
+  assertTimestamp(value.createdAt, `${path}.createdAt`);
+  return {
+    id: value.id,
+    residentId: value.residentId,
+    content: value.content,
+    supersededBy: value.supersededBy,
+    createdAt: value.createdAt,
+  };
+}
+
+function validateHistoryNode(value: unknown, index: number): HistoryNode {
+  const path = `raw.history[${index}]`;
+  assertRecord(value, path);
+  assertExactKeys(value, ["id", "parentId", "role", "content", "createdAt"], path);
+  assertNonEmptyString(value.id, `${path}.id`);
+  if (value.parentId !== null && typeof value.parentId !== "string") {
+    throw new ResidentMigrationError(`${path}.parentId must be a string or null`);
+  }
+  if (value.parentId === "") {
+    throw new ResidentMigrationError(`${path}.parentId must not be empty`);
+  }
+  if (value.role !== "user" && value.role !== "assistant" && value.role !== "system") {
+    throw new ResidentMigrationError(`${path}.role is invalid`);
+  }
+  if (typeof value.content !== "string") {
+    throw new ResidentMigrationError(`${path}.content must be a string`);
+  }
+  assertTimestamp(value.createdAt, `${path}.createdAt`);
+  return {
+    id: value.id,
+    parentId: value.parentId,
+    role: value.role,
+    content: value.content,
+    createdAt: value.createdAt,
+  };
+}
+
+function validateReferences(memories: MemoryEntry[], history: HistoryNode[]): void {
+  const memoryIds = uniqueIds(memories, "memory");
+  const historyIds = uniqueIds(history, "history node");
+
+  const supersedePredecessors = new Map<string, number>();
+  for (const entry of memories) {
+    if (entry.supersededBy === null) continue;
+    if (!memoryIds.has(entry.supersededBy)) {
+      throw new ResidentMigrationError(
+        `memory ${entry.id} supersededBy references missing entry ${entry.supersededBy}`,
+      );
+    }
+    if (entry.supersededBy === entry.id) {
+      throw new ResidentMigrationError(`memory ${entry.id} supersedes itself`);
+    }
+    const predecessors = (supersedePredecessors.get(entry.supersededBy) ?? 0) + 1;
+    if (predecessors > 1) {
+      throw new ResidentMigrationError(
+        `memory ${entry.supersededBy} has more than one supersede predecessor`,
+      );
+    }
+    supersedePredecessors.set(entry.supersededBy, predecessors);
+  }
+  assertAcyclic(
+    memories,
+    (entry) => entry.id,
+    (entry) => entry.supersededBy,
+    "memory chain",
+  );
+
+  for (const node of history) {
+    if (node.parentId === null) continue;
+    if (!historyIds.has(node.parentId)) {
+      throw new ResidentMigrationError(
+        `history node ${node.id} references missing parent ${node.parentId}`,
+      );
+    }
+    if (node.parentId === node.id) {
+      throw new ResidentMigrationError(`history node ${node.id} is its own parent`);
+    }
+  }
+  assertAcyclic(
+    history,
+    (node) => node.id,
+    (node) => node.parentId,
+    "history tree",
+  );
+}
+
+function uniqueIds<T extends { id: string }>(records: T[], kind: string): Set<string> {
+  const ids = new Set<string>();
+  for (const record of records) {
+    if (ids.has(record.id)) throw new ResidentMigrationError(`duplicate ${kind} id: ${record.id}`);
+    ids.add(record.id);
+  }
+  return ids;
+}
+
+function assertAcyclic<T>(
+  records: T[],
+  idOf: (record: T) => string,
+  nextOf: (record: T) => string | null,
+  kind: string,
+): void {
+  const nextById = new Map(records.map((record) => [idOf(record), nextOf(record)]));
+  const complete = new Set<string>();
+  for (const start of nextById.keys()) {
+    const path = new Set<string>();
+    let cursor: string | null = start;
+    while (cursor !== null && !complete.has(cursor)) {
+      if (path.has(cursor))
+        throw new ResidentMigrationError(`${kind} contains a cycle at ${cursor}`);
+      path.add(cursor);
+      cursor = nextById.get(cursor) ?? null;
+    }
+    for (const id of path) complete.add(id);
+  }
+}
+
+function assertRecord(value: unknown, path: string): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ResidentMigrationError(`${path} must be an object`);
+  }
+}
+
+function assertExactKeys(value: Record<string, unknown>, expected: string[], path: string): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new ResidentMigrationError(`${path} has unexpected or missing fields`);
+  }
+}
+
+function assertNonEmptyString(value: unknown, path: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ResidentMigrationError(`${path} must be a non-empty string`);
+  }
+}
+
+function assertTimestamp(value: unknown, path: string): asserts value is string {
+  if (typeof value !== "string") {
+    throw new ResidentMigrationError(`${path} must be an ISO-8601 UTC timestamp`);
+  }
+  const epoch = Date.parse(value);
+  if (!Number.isFinite(epoch) || new Date(epoch).toISOString() !== value) {
+    throw new ResidentMigrationError(`${path} must be a canonical ISO-8601 UTC timestamp`);
+  }
+}

--- a/src/migration/resident-migration.ts
+++ b/src/migration/resident-migration.ts
@@ -182,7 +182,9 @@ function validateEnvelope(value: unknown): ResidentExportEnvelopeM0 {
 
   assertRecord(value.resident, "resident");
   assertExactKeys(value.resident, ["name", "createdAt"], "resident");
-  assertNonEmptyString(value.resident.name, "resident.name");
+  if (typeof value.resident.name !== "string") {
+    throw new ResidentMigrationError("resident.name must be a string");
+  }
   assertTimestamp(value.resident.createdAt, "resident.createdAt");
 
   assertRecord(value.raw, "raw");

--- a/src/migration/resident-store-migration.ts
+++ b/src/migration/resident-store-migration.ts
@@ -1,0 +1,40 @@
+/** P1 ResidentStore 与 P5 迁移服务之间的窄适配口。 */
+
+import type { ResidentStore } from "../store/resident-store.ts";
+import {
+  type ResidentImportM0,
+  type ResidentMigrationPort,
+  ResidentMigrationService,
+} from "./resident-migration.ts";
+
+export class ResidentStoreMigrationPort implements ResidentMigrationPort {
+  constructor(private readonly store: ResidentStore) {}
+
+  async snapshotResident(residentId: string) {
+    const snapshot = this.store.exportRoom(residentId);
+    return {
+      residentId,
+      resident: { name: snapshot.name, createdAt: snapshot.createdAt },
+      commitments: snapshot.commitments,
+      memories: snapshot.memories,
+      history: snapshot.nodes,
+    };
+  }
+
+  async commitImportedResident(snapshot: ResidentImportM0): Promise<string> {
+    return this.store.importRoom(
+      {
+        name: snapshot.resident.name,
+        createdAt: snapshot.resident.createdAt,
+        commitments: snapshot.commitments,
+        memories: snapshot.memories,
+        nodes: snapshot.history,
+      },
+      { sourceResidentId: snapshot.sourceResidentId },
+    );
+  }
+}
+
+export function createResidentMigrationService(store: ResidentStore): ResidentMigrationService {
+  return new ResidentMigrationService(new ResidentStoreMigrationPort(store));
+}

--- a/src/store/resident-store.ts
+++ b/src/store/resident-store.ts
@@ -87,6 +87,33 @@ interface RoomRecord {
 }
 
 const SCHEMA_VERSION = 1;
+const SEQUENCE_RADIX = 36n;
+const MAX_SEQUENCE_SUFFIX_DIGITS = 64;
+
+/**
+ * 从现有 id 的最后一段恢复全局发号水位。
+ *
+ * Number.parseInt 会在 2^53 之后静默丢精度，导致 #seq += 1 不再前进；
+ * 这里逐位构造 bigint，保证跨机导入超大原生 id 后仍能继续发号。
+ * 64 位 base36 已远超任何可实际产生的序列，同时给恶意超长 id 留下显式拒绝边界。
+ */
+function parseBase36Sequence(id: string): bigint | null {
+  const suffix = id.slice(id.lastIndexOf("-") + 1).toLowerCase();
+  if (!/^[0-9a-z]+$/.test(suffix)) return null;
+  if (suffix.length > MAX_SEQUENCE_SUFFIX_DIGITS) {
+    throw new Error(
+      `id sequence suffix exceeds ${MAX_SEQUENCE_SUFFIX_DIGITS} base36 digits: ${id}`,
+    );
+  }
+
+  let value = 0n;
+  for (const character of suffix) {
+    const code = character.charCodeAt(0);
+    const digit = BigInt(code <= 57 ? code - 48 : code - 87);
+    value = value * SEQUENCE_RADIX + digit;
+  }
+  return value;
+}
 
 export class ResidentStore {
   readonly #rooms = new Map<string, ResidentRoom>();
@@ -107,7 +134,7 @@ export class ResidentStore {
    */
   readonly #dataDir: string | null;
 
-  #seq = 0;
+  #seq = 0n;
 
   constructor(options: { dataDir?: string } = {}) {
     this.#dataDir = options.dataDir ?? null;
@@ -123,7 +150,7 @@ export class ResidentStore {
    * 同毫秒内连续 remember 两条时随机数还有撞号风险。
    */
   #nextId(prefix: string): string {
-    this.#seq += 1;
+    this.#seq += 1n;
     return `${prefix}-${this.#seq.toString(36).padStart(6, "0")}`;
   }
 
@@ -235,8 +262,8 @@ export class ResidentStore {
   }
 
   #bumpSeq(id: string): void {
-    const n = Number.parseInt(id.slice(id.lastIndexOf("-") + 1), 36);
-    if (Number.isFinite(n) && n > this.#seq) this.#seq = n;
+    const sequence = parseBase36Sequence(id);
+    if (sequence !== null && sequence > this.#seq) this.#seq = sequence;
   }
 
   #bumpStamp(createdAt: string): void {
@@ -246,6 +273,9 @@ export class ResidentStore {
 
   createResident(name: string): string {
     const residentId = this.#nextId("resident");
+    if (this.#rooms.has(residentId)) {
+      throw new Error(`resident id collision, refusing to overwrite: ${residentId}`);
+    }
     this.#rooms.set(residentId, {
       residentId,
       name,
@@ -297,6 +327,9 @@ export class ResidentStore {
   remember(residentId: string, content: string): string {
     const room = this.room(residentId);
     const id = this.#nextId("mem");
+    if (room.memories.has(id)) {
+      throw new Error(`memory id collision, refusing to overwrite: ${id}`);
+    }
     room.memories.set(id, {
       id,
       residentId,
@@ -368,6 +401,9 @@ export class ResidentStore {
       content,
       createdAt: this.#nextStamp(),
     };
+    if (room.nodes.has(node.id)) {
+      throw new Error(`history id collision, refusing to overwrite: ${node.id}`);
+    }
     room.nodes.set(node.id, node);
     this.#persist(residentId);
     return node;

--- a/src/store/resident-store.ts
+++ b/src/store/resident-store.ts
@@ -148,9 +148,15 @@ export class ResidentStore {
    * 新档已经原子就位。没有中间态。
    */
   #persist(residentId: string): void {
-    if (this.#dataDir === null) return;
     const room = this.#rooms.get(residentId);
     if (room === undefined) return;
+    this.#persistRoom(room);
+  }
+
+  /** 允许迁移先把 detached room 落盘，成功后才放进可见房间表。 */
+  #persistRoom(room: ResidentRoom): void {
+    if (this.#dataDir === null) return;
+    const residentId = room.residentId;
     // id 全部出自 #nextId，这条断言防的是「将来某个改动让外部输入流进文件名」。
     if (!/^[a-z0-9-]+$/.test(residentId)) {
       throw new Error(`resident id 不可作为文件名: ${residentId}`);
@@ -166,14 +172,29 @@ export class ResidentStore {
     };
     const finalPath = join(this.#dataDir, `${residentId}.json`);
     const tmpPath = `${finalPath}.tmp`;
-    const fd = openSync(tmpPath, "w");
+    let fd: number | null = null;
     try {
+      fd = openSync(tmpPath, "w");
       writeSync(fd, JSON.stringify(record));
       fsyncSync(fd);
-    } finally {
       closeSync(fd);
+      fd = null;
+      renameSync(tmpPath, finalPath);
+    } catch (error) {
+      if (fd !== null) {
+        try {
+          closeSync(fd);
+        } catch {
+          // 保留原始写入错误；close 的二次错误不该遮住病因。
+        }
+      }
+      try {
+        rmSync(tmpPath, { force: true });
+      } catch {
+        // 预先存在的同名目录等异常目标可能删不掉；导入仍保持不可见并显式失败。
+      }
+      throw error;
     }
-    renameSync(tmpPath, finalPath);
   }
 
   /** 启动恢复：读全部快照重建内存视图，并把 id/时间戳序列推进到存量之后。 */
@@ -379,33 +400,56 @@ export class ResidentStore {
    * C6 要逐字节等价（把 residentId 归一化后比较），重新生成 id 会直接判死。
    * 这也符合直觉——搬家不该让记忆换一个身份证号。
    */
-  importRoom(snapshot: ResidentSnapshot): string {
-    const residentId = this.#nextId("resident");
-    const memories = new Map<string, MemoryEntry>();
-    for (const m of snapshot.memories) {
-      memories.set(m.id, { ...m, residentId });
-      // 迁移保 id，而快照可能来自另一台机器——那边发的序号要是比本机 #seq 大，
-      // 不推进的话之后 #nextId 会撞上导入条目，Map.set 静默覆盖，人丢一块。
-      this.#bumpSeq(m.id);
-      this.#bumpStamp(m.createdAt);
+  importRoom(snapshot: ResidentSnapshot, options: ResidentImportOptions = {}): string {
+    const previousSeq = this.#seq;
+    const previousStamp = this.#lastStamp;
+    try {
+      let residentId = this.#nextId("resident");
+      // fresh target 的本机序列可能恰好发出来源身份证。导入件必须真的是“新住户”，
+      // 不能只在另一台机器上碰巧同名；撞上来源 id 就显式跳过再发一张。
+      if (residentId === options.sourceResidentId) residentId = this.#nextId("resident");
+      if (this.#rooms.has(residentId)) {
+        throw new Error(`resident id collision during import: ${residentId}`);
+      }
+
+      const memories = new Map<string, MemoryEntry>();
+      for (const m of snapshot.memories) {
+        if (memories.has(m.id)) throw new Error(`duplicate memory id during import: ${m.id}`);
+        memories.set(m.id, { ...m, residentId });
+        // 迁移保 id，而快照可能来自另一台机器——那边发的序号要是比本机 #seq 大，
+        // 不推进的话之后 #nextId 会撞上导入条目，Map.set 静默覆盖，人丢一块。
+        this.#bumpSeq(m.id);
+        this.#bumpStamp(m.createdAt);
+      }
+      const nodes = new Map<string, HistoryNode>();
+      for (const n of snapshot.nodes) {
+        if (nodes.has(n.id)) throw new Error(`duplicate history id during import: ${n.id}`);
+        nodes.set(n.id, { ...n });
+        this.#bumpSeq(n.id);
+        this.#bumpStamp(n.createdAt);
+      }
+      this.#bumpStamp(snapshot.createdAt);
+
+      const room: ResidentRoom = {
+        residentId,
+        name: snapshot.name,
+        createdAt: snapshot.createdAt,
+        memories,
+        nodes,
+        // 承诺跟着人走：搬了家，答应过的事还算数。
+        commitments: [...snapshot.commitments],
+      };
+
+      // 先落 detached room，成功后才对内存读者可见。失败回滚两条水位，
+      // 不留下半间房，也不让坏包凭空吃掉未来 id/时间戳。
+      this.#persistRoom(room);
+      this.#rooms.set(residentId, room);
+      return residentId;
+    } catch (error) {
+      this.#seq = previousSeq;
+      this.#lastStamp = previousStamp;
+      throw error;
     }
-    const nodes = new Map<string, HistoryNode>();
-    for (const n of snapshot.nodes) {
-      nodes.set(n.id, { ...n });
-      this.#bumpSeq(n.id);
-      this.#bumpStamp(n.createdAt);
-    }
-    this.#rooms.set(residentId, {
-      residentId,
-      name: snapshot.name,
-      createdAt: snapshot.createdAt,
-      memories,
-      nodes,
-      // 承诺跟着人走：搬了家，答应过的事还算数。
-      commitments: [...snapshot.commitments],
-    });
-    this.#persist(residentId);
-    return residentId;
   }
 }
 
@@ -422,4 +466,8 @@ export interface ResidentSnapshot {
   memories: MemoryEntry[];
   nodes: HistoryNode[];
   commitments: string[];
+}
+
+export interface ResidentImportOptions {
+  sourceResidentId?: string;
 }

--- a/tests/resident-migration-store.test.ts
+++ b/tests/resident-migration-store.test.ts
@@ -2,7 +2,10 @@ import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ResidentMigrationError } from "../src/migration/resident-migration.ts";
+import {
+  ResidentMigrationError,
+  encodeResidentExportM0,
+} from "../src/migration/resident-migration.ts";
 import { createResidentMigrationService } from "../src/migration/resident-store-migration.ts";
 import { ResidentStore } from "../src/store/resident-store.ts";
 
@@ -81,6 +84,70 @@ describe("ResidentStore 迁移接缝", () => {
     expect(importedIds.has(memoryId)).toBe(false);
     expect(importedIds.has(node.id)).toBe(false);
     expect(latestTimestamp !== undefined && node.createdAt > latestTimestamp).toBe(true);
+  });
+
+  it("超大原生 id 导入后连续写两次，不撞号也不覆盖", async () => {
+    const sourceId = "resident-source";
+    const importedId = "mem-zzzzzzzzzzzz";
+    const pack = encodeResidentExportM0({
+      residentId: sourceId,
+      resident: { name: "超大水位来源", createdAt: "2026-08-14T06:00:00.000Z" },
+      commitments: [],
+      memories: [
+        {
+          id: importedId,
+          residentId: sourceId,
+          content: "导入原件",
+          supersededBy: null,
+          createdAt: "2026-08-14T06:00:01.000Z",
+        },
+      ],
+      history: [],
+    });
+
+    const target = new ResidentStore();
+    const moved = await createResidentMigrationService(target).importResident(pack);
+    const first = target.remember(moved, "落地后第一条");
+    const second = target.remember(moved, "落地后第二条");
+
+    expect(first).toBe("mem-1000000000000");
+    expect(second).toBe("mem-1000000000001");
+    expect(new Set([first, second]).size).toBe(2);
+    expect(target.memories(moved)).toHaveLength(3);
+    expect(target.memories(moved).find((entry) => entry.id === importedId)?.content).toBe(
+      "导入原件",
+    );
+    expect(target.memories(moved).find((entry) => entry.id === first)?.content).toBe(
+      "落地后第一条",
+    );
+    expect(target.memories(moved).find((entry) => entry.id === second)?.content).toBe(
+      "落地后第二条",
+    );
+  });
+
+  it("恶意超长序号显式失败，且不消耗目标 resident id", async () => {
+    const sourceId = "resident-source";
+    const pack = encodeResidentExportM0({
+      residentId: sourceId,
+      resident: { name: "恶意包", createdAt: "2026-08-14T06:00:00.000Z" },
+      commitments: [],
+      memories: [
+        {
+          id: `mem-${"z".repeat(65)}`,
+          residentId: sourceId,
+          content: "不应落地",
+          supersededBy: null,
+          createdAt: "2026-08-14T06:00:01.000Z",
+        },
+      ],
+      history: [],
+    });
+
+    const target = new ResidentStore();
+    await expect(createResidentMigrationService(target).importResident(pack)).rejects.toThrow(
+      /sequence suffix exceeds/,
+    );
+    expect(target.createResident("首个有效住户")).toBe("resident-000001");
   });
 
   it("坏包在 store 前失败，不建房也不消耗 resident id", async () => {

--- a/tests/resident-migration-store.test.ts
+++ b/tests/resident-migration-store.test.ts
@@ -1,0 +1,112 @@
+import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ResidentMigrationError } from "../src/migration/resident-migration.ts";
+import { createResidentMigrationService } from "../src/migration/resident-store-migration.ts";
+import { ResidentStore } from "../src/store/resident-store.ts";
+
+const temporaryDirectories: string[] = [];
+
+function freshDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "mist-p5-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("ResidentStore 迁移接缝", () => {
+  it("搬齐身份来源、承诺、勘误链和整棵树，副本生死不碰原件", async () => {
+    const source = new ResidentStore();
+    const sourceId = source.createResident("迁移住户");
+    source.commit(sourceId, `正文保留来源 id：${sourceId}`);
+    const wrong = source.remember(sourceId, "旧记忆");
+    const correction = source.errata(sourceId, wrong, `新记忆仍提到 ${sourceId}`);
+    const root = source.appendNode(sourceId, null, "user", "第一句");
+    source.appendNode(sourceId, root.id, "assistant", `回应 ${sourceId}`);
+    const sourceBefore = JSON.stringify(source.exportRoom(sourceId));
+
+    const exported = await createResidentMigrationService(source).exportResident(sourceId);
+    expect(JSON.stringify(source.exportRoom(sourceId))).toBe(sourceBefore);
+
+    const target = new ResidentStore();
+    const targetService = createResidentMigrationService(target);
+    const first = await targetService.importResident(exported);
+    const second = await targetService.importResident(exported);
+    expect(first).not.toBe(sourceId);
+    expect(second).not.toBe(first);
+
+    const imported = target.exportRoom(first);
+    expect(imported.name).toBe("迁移住户");
+    expect(imported.commitments).toEqual([`正文保留来源 id：${sourceId}`]);
+    expect(imported.memories.find((entry) => entry.id === wrong)?.supersededBy).toBe(correction);
+    expect(imported.memories.find((entry) => entry.id === correction)?.content).toContain(sourceId);
+    expect(imported.memories.every((entry) => entry.residentId === first)).toBe(true);
+    expect(imported.nodes).toEqual(source.exportRoom(sourceId).nodes);
+
+    target.remember(first, "导入件新增");
+    target.destroyResident(first);
+    expect(JSON.stringify(source.exportRoom(sourceId))).toBe(sourceBefore);
+    expect(target.has(second)).toBe(true);
+  });
+
+  it("fresh target 导入后继续写，不撞 id，时间戳不倒退", async () => {
+    const source = new ResidentStore();
+    const sourceId = source.createResident("高水位来源");
+    for (let index = 0; index < 30; index += 1) {
+      source.remember(sourceId, `记忆 ${index}`);
+      source.appendNode(sourceId, null, "system", `节点 ${index}`);
+    }
+    const exported = await createResidentMigrationService(source).exportResident(sourceId);
+
+    const target = new ResidentStore();
+    const moved = await createResidentMigrationService(target).importResident(exported);
+    const imported = target.exportRoom(moved);
+    const importedIds = new Set([
+      ...imported.memories.map((entry) => entry.id),
+      ...imported.nodes.map((node) => node.id),
+    ]);
+    const latestTimestamp = [...imported.memories, ...imported.nodes]
+      .map((record) => record.createdAt)
+      .sort()
+      .at(-1);
+
+    const memoryId = target.remember(moved, "落地后新记忆");
+    const node = target.appendNode(moved, null, "system", "落地后新节点");
+    expect(importedIds.has(memoryId)).toBe(false);
+    expect(importedIds.has(node.id)).toBe(false);
+    expect(latestTimestamp !== undefined && node.createdAt > latestTimestamp).toBe(true);
+  });
+
+  it("坏包在 store 前失败，不建房也不消耗 resident id", async () => {
+    const target = new ResidentStore();
+    await expect(
+      createResidentMigrationService(target).importResident(new TextEncoder().encode("bad-json")),
+    ).rejects.toThrow(ResidentMigrationError);
+    expect(target.createResident("第一个真人")).toBe("resident-000001");
+  });
+
+  it("落盘提交失败时不留下房间、最终文件或水位副作用", async () => {
+    const source = new ResidentStore();
+    const sourceId = source.createResident("来源");
+    source.remember(sourceId, "一条记忆");
+    const pack = await createResidentMigrationService(source).exportResident(sourceId);
+
+    const directory = freshDirectory();
+    // resident-000001 与来源 id 同名会被跳过，真正待提交的目标是 000002。
+    const collision = join(directory, "resident-000002.json.tmp");
+    mkdirSync(collision);
+    const target = new ResidentStore({ dataDir: directory });
+    await expect(createResidentMigrationService(target).importResident(pack)).rejects.toThrow();
+    expect(target.has("resident-000002")).toBe(false);
+    expect(readdirSync(directory)).toEqual(["resident-000002.json.tmp"]);
+
+    rmSync(collision, { recursive: true });
+    expect(target.createResident("重试成功")).toBe("resident-000001");
+  });
+});

--- a/tests/resident-migration.test.ts
+++ b/tests/resident-migration.test.ts
@@ -86,6 +86,31 @@ describe("M0 编解码", () => {
     expect(decoded.history.map((node) => node.id)).toEqual(["node-1", "node-2"]);
   });
 
+  it("非 ASCII id 使用与 locale 无关的固定 code-unit 顺序", () => {
+    const snapshot = fixture();
+    snapshot.memories = [
+      {
+        id: "ä",
+        residentId: sourceResidentId,
+        content: "非 ASCII",
+        supersededBy: null,
+        createdAt: "2026-08-14T06:00:01.000Z",
+      },
+      {
+        id: "z",
+        residentId: sourceResidentId,
+        content: "ASCII",
+        supersededBy: null,
+        createdAt: "2026-08-14T06:00:01.000Z",
+      },
+    ];
+
+    const first = encodeResidentExportM0(snapshot);
+    const second = encodeResidentExportM0(snapshot);
+    expect(first).toEqual(second);
+    expect(decodeResidentExportM0(first).memories.map((entry) => entry.id)).toEqual(["z", "ä"]);
+  });
+
   it("只重绑结构化 residentId，不改正文、承诺、id、时间和引用", () => {
     const decoded = decodeResidentExportM0(encodeResidentExportM0(fixture()));
     const rebound = rebindResidentId(decoded, "resident-target");

--- a/tests/resident-migration.test.ts
+++ b/tests/resident-migration.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  DurableResidentSnapshotM0,
+  ResidentMigrationPort,
+} from "../src/migration/resident-migration.ts";
+import {
+  MAX_RESIDENT_EXPORT_BYTES,
+  ResidentMigrationError,
+  ResidentMigrationService,
+  decodeResidentExportM0,
+  encodeResidentExportM0,
+  rebindResidentId,
+} from "../src/migration/resident-migration.ts";
+
+const sourceResidentId = "resident-source";
+
+function fixture(): DurableResidentSnapshotM0 {
+  return {
+    residentId: sourceResidentId,
+    resident: { name: "小粽子", createdAt: "2026-08-14T06:00:00.000Z" },
+    commitments: ["答应：正文里的 resident-source 不能被替换"],
+    memories: [
+      {
+        id: "mem-2",
+        residentId: sourceResidentId,
+        content: "修正后：中文\nemoji 🥟；resident-source 仍是正文",
+        supersededBy: null,
+        createdAt: "2026-08-14T06:00:02.000Z",
+      },
+      {
+        id: "mem-1",
+        residentId: sourceResidentId,
+        content: "原始记录",
+        supersededBy: "mem-2",
+        createdAt: "2026-08-14T06:00:01.000Z",
+      },
+    ],
+    history: [
+      {
+        id: "node-2",
+        parentId: "node-1",
+        role: "assistant",
+        content: "收到：resident-source",
+        createdAt: "2026-08-14T06:00:04.000Z",
+      },
+      {
+        id: "node-1",
+        parentId: null,
+        role: "user",
+        content: "第一句",
+        createdAt: "2026-08-14T06:00:03.000Z",
+      },
+    ],
+  };
+}
+
+function jsonPack(mutator: (value: Record<string, unknown>) => void): Uint8Array {
+  const value = JSON.parse(new TextDecoder().decode(encodeResidentExportM0(fixture()))) as Record<
+    string,
+    unknown
+  >;
+  mutator(value);
+  return new TextEncoder().encode(JSON.stringify(value));
+}
+
+function itemAt<T>(items: T[], index: number): T {
+  const item = items[index];
+  if (item === undefined) throw new Error(`fixture item ${index} is missing`);
+  return item;
+}
+
+describe("M0 编解码", () => {
+  it("同一状态重复导出逐字节相同，且不修改来源数组顺序", () => {
+    const snapshot = fixture();
+    const memoryOrder = snapshot.memories.map((entry) => entry.id);
+    const historyOrder = snapshot.history.map((node) => node.id);
+
+    const first = encodeResidentExportM0(snapshot);
+    const second = encodeResidentExportM0(snapshot);
+
+    expect(first).toEqual(second);
+    expect(snapshot.memories.map((entry) => entry.id)).toEqual(memoryOrder);
+    expect(snapshot.history.map((node) => node.id)).toEqual(historyOrder);
+    const decoded = decodeResidentExportM0(first);
+    expect(decoded.memories.map((entry) => entry.id)).toEqual(["mem-1", "mem-2"]);
+    expect(decoded.history.map((node) => node.id)).toEqual(["node-1", "node-2"]);
+  });
+
+  it("只重绑结构化 residentId，不改正文、承诺、id、时间和引用", () => {
+    const decoded = decodeResidentExportM0(encodeResidentExportM0(fixture()));
+    const rebound = rebindResidentId(decoded, "resident-target");
+
+    expect(rebound.residentId).toBe("resident-target");
+    expect(rebound.memories.every((entry) => entry.residentId === "resident-target")).toBe(true);
+    expect(rebound.memories[1]?.content).toContain(sourceResidentId);
+    expect(rebound.commitments[0]).toContain(sourceResidentId);
+    expect(rebound.history[1]?.content).toContain(sourceResidentId);
+    expect(
+      rebound.memories.map(({ id, createdAt, supersededBy }) => ({
+        id,
+        createdAt,
+        supersededBy,
+      })),
+    ).toEqual([
+      { id: "mem-1", createdAt: "2026-08-14T06:00:01.000Z", supersededBy: "mem-2" },
+      { id: "mem-2", createdAt: "2026-08-14T06:00:02.000Z", supersededBy: null },
+    ]);
+  });
+
+  it("拒绝非 UTF-8、未知版本和超限包", () => {
+    expect(() => decodeResidentExportM0(Uint8Array.from([0xc3, 0x28]))).toThrow(
+      ResidentMigrationError,
+    );
+    expect(() =>
+      decodeResidentExportM0(
+        jsonPack((value) => {
+          value.formatVersion = 1;
+        }),
+      ),
+    ).toThrow(/unsupported resident export version/);
+    expect(() => decodeResidentExportM0(new Uint8Array(MAX_RESIDENT_EXPORT_BYTES + 1))).toThrow(
+      /exceeds/,
+    );
+  });
+
+  it("拒绝跨房记录、重复 id、悬空引用和环", () => {
+    const cases: Uint8Array[] = [
+      jsonPack((value) => {
+        const raw = value.raw as { memories: Array<Record<string, unknown>> };
+        itemAt(raw.memories, 0).residentId = "resident-other";
+      }),
+      jsonPack((value) => {
+        const raw = value.raw as { memories: Array<Record<string, unknown>> };
+        itemAt(raw.memories, 1).id = itemAt(raw.memories, 0).id;
+      }),
+      jsonPack((value) => {
+        const raw = value.raw as { history: Array<Record<string, unknown>> };
+        itemAt(raw.history, 1).parentId = "node-missing";
+      }),
+      jsonPack((value) => {
+        const raw = value.raw as { history: Array<Record<string, unknown>> };
+        itemAt(raw.history, 0).parentId = "node-2";
+      }),
+    ];
+
+    for (const pack of cases)
+      expect(() => decodeResidentExportM0(pack)).toThrow(ResidentMigrationError);
+  });
+});
+
+describe("迁移服务接缝", () => {
+  it("坏包在调用原子提交口之前失败，零写入", async () => {
+    const port: ResidentMigrationPort = {
+      snapshotResident: vi.fn(async () => fixture()),
+      commitImportedResident: vi.fn(async () => "resident-target"),
+    };
+    const service = new ResidentMigrationService(port);
+
+    await expect(service.importResident(new TextEncoder().encode("not-json"))).rejects.toThrow(
+      ResidentMigrationError,
+    );
+    expect(port.commitImportedResident).not.toHaveBeenCalled();
+  });
+
+  it("同一个包可重复导入，每次都交给原子提交口生成新住户", async () => {
+    let sequence = 0;
+    const port: ResidentMigrationPort = {
+      snapshotResident: vi.fn(async () => fixture()),
+      commitImportedResident: vi.fn(async () => {
+        sequence += 1;
+        return `resident-target-${sequence}`;
+      }),
+    };
+    const service = new ResidentMigrationService(port);
+    const pack = await service.exportResident(sourceResidentId);
+
+    await expect(service.importResident(pack)).resolves.toBe("resident-target-1");
+    await expect(service.importResident(pack)).resolves.toBe("resident-target-2");
+    expect(port.commitImportedResident).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/resident-store.test.ts
+++ b/tests/resident-store.test.ts
@@ -162,6 +162,34 @@ describe("迁移", () => {
 });
 
 describe("id 与时间戳", () => {
+  it("末道碰撞闸拒绝覆盖已有记忆和历史节点", () => {
+    const store = new ResidentStore();
+    const residentId = store.createResident("r");
+    const room = store.room(residentId);
+    room.memories.set("mem-000002", {
+      id: "mem-000002",
+      residentId,
+      content: "不能被覆盖",
+      supersededBy: null,
+      createdAt: "2026-08-14T06:00:00.000Z",
+    });
+
+    expect(() => store.remember(residentId, "试图覆盖")).toThrow(/memory id collision/);
+    expect(room.memories.get("mem-000002")?.content).toBe("不能被覆盖");
+
+    room.nodes.set("node-000003", {
+      id: "node-000003",
+      parentId: null,
+      role: "system",
+      content: "历史不能被覆盖",
+      createdAt: "2026-08-14T06:00:01.000Z",
+    });
+    expect(() => store.appendNode(residentId, null, "system", "试图覆盖历史")).toThrow(
+      /history id collision/,
+    );
+    expect(room.nodes.get("node-000003")?.content).toBe("历史不能被覆盖");
+  });
+
   it("同一毫秒内连续写入的条目时间戳严格递增", () => {
     const store = new ResidentStore();
     const r = store.createResident("r");


### PR DESCRIPTION
## 做了什么

- 定义可丢弃的 M0 迁移信封：显式 format/version、来源住户、耐久住户记录和 raw records。
- 固定字段顺序；memories/history 按 locale-independent code-unit 顺序确定性编码为 UTF-8 紧凑 JSON，导出不修改来源快照。
- 导入前严格校验 UTF-8、大小、精确 schema、房间归属、唯一 id、勘误链和消息树引用/环。
- residentId 只做结构化重绑，正文里的来源 id 字面量不改。
- 接入真实 ResidentStore：detached room 先原子落盘，成功后才可见；失败回滚 id/时间水位。
- 导入件使用 fresh target id，同一个包可重复导入，导入件生死不碰原件。
- 发号水位改用 BigInt base36，拒绝恶意超长序号；remember/history 末道检测碰撞，绝不 Map.set 静默覆盖。

## 本轮 review 修复

- Elio Blocker：`mem-zzzzzzzzzzzz` 导入后连续两次 remember 现为 `mem-1000000000000` / `mem-1000000000001`，3 条记录全部保留。
- Elio Major：`z` / `ä` 在 `LANG=C` 与 `LANG=sv_SE.UTF-8` 下导出顺序均为 `z,ä`，sha256 同为 `39cd3577...`。
- 新增真实 import 后连续两写、非 ASCII 确定性排序、恶意超长 id 原子失败、末道碰撞拒绝回归。

## 边界与接缝

- 不包含 sessionHead、sessionAlive 或在途 context。
- 不实现 H2 的正式 schema、签名或插件契约。
- 不修改 `src/acceptance-driver.ts` / `acceptance/checks.ts`；判卷与 P4 总装边界不夹带。
- commitments 保留 P1 append-only 立约顺序，不另做排序。

## 验证

- `npm run lint`：通过（27 files）
- `npm run typecheck`：通过
- `npm test`：105 passed
- `npm run acceptance`：命令 exit 0；当前 1 真绿 / 4 桩灯 / C3 red。C3 与剩余桩灯属于既有 P4 总装接线，本 PR 不冒充六绿。
- 手工跨 locale 复现：两环境导出 bytes / sha256 完全相同。
- 手工精度复现：超大 id 导入后连续两写 id 唯一、memory count = 3。

Refs #17