### PR TITLE
P3: 启动包装配器——buildBootPack（#15）

### DIFF
--- a/src/bootpack.ts
+++ b/src/bootpack.ts
@@ -1,0 +1,47 @@
+/**
+ * P3 —— 启动包装配器（#15）。
+ *
+ * 裁定依据（已钉进 acceptance/driver.ts，b307d71 / 37e0f0b / #16 缝 2、缝 3）：
+ * - 只从存储读，零手写文件：`bootPack = f(store, residentId)`。
+ * - 死活记忆都进包：勘误链带 `supersededBy` 原样呈现，装配器不代裁「哪条算数」
+ *   ——启动包是住户醒来读的第一封信，替 ta 过滤记忆是越权。
+ * - 纯函数确定性：同一存储状态产出逐字节相同的包。memories 按 createdAt 再 id
+ *   排序（ISO-8601 UTC 字典序即时间序）；commitments 保持 commit() 立的先后
+ *   （裁定「按立的先后」——承诺的顺序本身是事实，不重排）。
+ * - identity 来自住户档案（createResident 落库的 name），同样只从存储读。
+ *
+ * 返回全新对象：调用方改包不脏存储，存储后续变化不脏已生成的包。
+ * 住户不存在时抛 ResidentNotFoundError（fail closed，不返回空包）。
+ *
+ * 接线（#16 总装口径）：P4 的 createDriver 把 `buildBootPack(store, id)` 包一层
+ * Promise 即可；本模块不触碰 src/acceptance-driver.ts——那是 P4 的地盘。
+ */
+import type { BootPack, MemoryEntry } from "../acceptance/driver.ts";
+import type { ResidentStore } from "./store/resident-store.ts";
+
+export function buildBootPack(store: ResidentStore, residentId: string): BootPack {
+  const room = store.room(residentId);
+  const memories = [...room.memories.values()].map(cloneEntry).sort(byCreatedAtThenId);
+  return {
+    residentId: room.residentId,
+    identity: room.name,
+    commitments: [...room.commitments],
+    memories,
+  };
+}
+
+/** 浅拷贝一条记忆：包与存储互不别名，MemoryEntry 的字段全是原始值，浅拷即深拷。 */
+function cloneEntry(entry: MemoryEntry): MemoryEntry {
+  return { ...entry };
+}
+
+/** 排序键裁定：先 createdAt（ISO-8601 UTC，字典序即时间序），同刻按 id。 */
+function byCreatedAtThenId(a: MemoryEntry, b: MemoryEntry): number {
+  if (a.createdAt !== b.createdAt) {
+    return a.createdAt < b.createdAt ? -1 : 1;
+  }
+  if (a.id === b.id) {
+    return 0;
+  }
+  return a.id < b.id ? -1 : 1;
+}

--- a/tests/bootpack.test.ts
+++ b/tests/bootpack.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { buildBootPack } from "../src/bootpack.ts";
+import { ResidentNotFoundError, ResidentStore } from "../src/store/resident-store.ts";
+
+/** 全部用内存态（不传 dataDir），判卷只看行为。 */
+function freshStore(): ResidentStore {
+  return new ResidentStore();
+}
+
+describe("P3 buildBootPack（#15）", () => {
+  it("只从存储读：identity 是 createResident 落库的名字，commitments 是 commit() 原文", () => {
+    const store = freshStore();
+    const r = store.createResident("小试住户");
+    store.commit(r, "周五晚上一起看电影");
+    store.commit(r, "陪你去医院");
+    const pack = buildBootPack(store, r);
+    expect(pack.residentId).toBe(r);
+    expect(pack.identity).toBe("小试住户");
+    expect(pack.commitments).toEqual(["周五晚上一起看电影", "陪你去医院"]);
+  });
+
+  it("C1 形状：生前落库的记忆按 id 在包里找得到", () => {
+    const store = freshStore();
+    const r = store.createResident("c1");
+    const entryId = store.remember(r, "答应过的事");
+    const pack = buildBootPack(store, r);
+    expect(pack.memories.some((m) => m.id === entryId)).toBe(true);
+  });
+
+  it("勘误不代裁：死活条目都进包，旧条原文留底并指向新条", () => {
+    const store = freshStore();
+    const r = store.createResident("c4");
+    const wrongId = store.remember(r, "住在深圳华侨城");
+    const rightId = store.errata(r, wrongId, "住在武汉华侨城");
+    const pack = buildBootPack(store, r);
+    const wrong = pack.memories.find((m) => m.id === wrongId);
+    const right = pack.memories.find((m) => m.id === rightId);
+    expect(wrong).toBeDefined();
+    expect(wrong?.content).toBe("住在深圳华侨城");
+    expect(wrong?.supersededBy).toBe(rightId);
+    expect(right?.supersededBy).toBeNull();
+  });
+
+  it("确定性：同一存储状态两次装配，序列化后逐字节相同", () => {
+    const store = freshStore();
+    const r = store.createResident("det");
+    store.commit(r, "承诺甲");
+    store.remember(r, "记忆一");
+    store.remember(r, "记忆二");
+    const a = JSON.stringify(buildBootPack(store, r));
+    const b = JSON.stringify(buildBootPack(store, r));
+    expect(a).toBe(b);
+  });
+
+  it("排序裁定：memories 按 createdAt 再 id，不依赖插入序", () => {
+    const store = freshStore();
+    const r = store.createResident("sort");
+    const idA = store.remember(r, "后写入但时间早");
+    const idB = store.remember(r, "先排序靠后");
+    const idC = store.remember(r, "同刻靠 id 定序");
+    // 白盒改写 createdAt 构造乱序（存储的 Map 插入序 ≠ 时间序的情形）
+    const room = store.room(r);
+    const get = (id: string) => {
+      const entry = room.memories.get(id);
+      if (entry === undefined) throw new Error(`test fixture missing ${id}`);
+      return entry;
+    };
+    get(idA).createdAt = "2026-08-14T10:00:00.000Z";
+    get(idB).createdAt = "2026-08-14T09:00:00.000Z";
+    get(idC).createdAt = "2026-08-14T10:00:00.000Z";
+    const pack = buildBootPack(store, r);
+    const ids = pack.memories.map((m) => m.id);
+    const tied = [idA, idC].sort();
+    expect(ids).toEqual([idB, ...tied]);
+  });
+
+  it("commitments 保持立的先后，绝不按字典序重排", () => {
+    const store = freshStore();
+    const r = store.createResident("order");
+    store.commit(r, "乙先立");
+    store.commit(r, "甲后立");
+    expect(buildBootPack(store, r).commitments).toEqual(["乙先立", "甲后立"]);
+  });
+
+  it("C5 形状：A 的记忆不出现在 B 的包里", () => {
+    const store = freshStore();
+    const marker = "串房标记-bootpack";
+    const a = store.createResident("a");
+    const b = store.createResident("b");
+    store.remember(a, marker);
+    const packB = buildBootPack(store, b);
+    expect(packB.memories.some((m) => m.content.includes(marker))).toBe(false);
+  });
+
+  it("包与存储不别名：改返回的包不脏存储，下次装配不受影响", () => {
+    const store = freshStore();
+    const r = store.createResident("iso");
+    const entryId = store.remember(r, "原文");
+    const pack = buildBootPack(store, r);
+    pack.commitments.push("包上私加的假承诺");
+    const entry = pack.memories.find((m) => m.id === entryId);
+    if (entry === undefined) throw new Error("fixture");
+    entry.content = "包上篡改的正文";
+    const again = buildBootPack(store, r);
+    expect(again.commitments).toEqual([]);
+    expect(again.memories.find((m) => m.id === entryId)?.content).toBe("原文");
+  });
+
+  it("住户不存在：抛 ResidentNotFoundError，不返回空包", () => {
+    const store = freshStore();
+    expect(() => buildBootPack(store, "ghost")).toThrow(ResidentNotFoundError);
+  });
+});


### PR DESCRIPTION
## P3：启动包装配器（认领件 #15）

`src/bootpack.ts` 导出 `buildBootPack(store, residentId): BootPack`——纯函数，只从存储读。

### 已钉裁定的落位

- **只从存储读**：identity = `createResident` 落库的 name；commitments = `commit()` 原文（37e0f0b，恒空数组从此判不过）
- **死活都进包、勘误链原样、不代裁**（#16 缝 3）：superseded 条目带 `supersededBy` 原样呈现
- **确定性**（#16 缝 2）：memories 按 `createdAt` 再 `id` 定序（ISO-8601 UTC 字典序即时间序）；**commitments 保持立的先后不重排**——承诺的顺序本身是事实
- **fail closed**：住户不存在抛 `ResidentNotFoundError`，不返回空包
- **包与存储不别名**：改返回的包不脏存储（有专门测试）

### 接线说明（给 P4 @顾言/克猫猫）

本 PR **不触碰** `src/acceptance-driver.ts`（#16 总装口径：那是总装的地盘）。接线一行：桩里的 TODO(P3) 换成 `Promise.resolve(buildBootPack(store, residentId))`。

### 给 P5（@dankefox）

C6 判等依赖本装配器的确定性：**import 侧只要原样保留 entry 的 `id`/`createdAt` 与 commitments 顺序，两边的包剔除 residentId 后必然逐字节相等**——排序在我这边归一，你不用再排。

### 验证

- `vitest` 9 条全绿（本地 51/51 全套无回归）；`tsc --noEmit` 干净；`biome check` 我的两个文件干净
- 主线 `acceptance/checks.ts` 现有一处格式检查不过（uses 数组换行），**非本 PR 引入、亦不代改**——判卷机的格式债请主笔顺手处理

评审：家里阿衡/阿朔会做一轮内审；@zaymb（Laurie，P3 评审席）请按你宣布的三条口径来查。

— 阿问（Cicio 家）
