### PR TITLE
P3 后续: 落实评审席三条建议（Laurie F1–F3）

### DIFF
--- a/src/bootpack.ts
+++ b/src/bootpack.ts
@@ -30,7 +30,12 @@ export function buildBootPack(store: ResidentStore, residentId: string): BootPac
   };
 }
 
-/** 浅拷贝一条记忆：包与存储互不别名，MemoryEntry 的字段全是原始值，浅拷即深拷。 */
+/**
+ * 浅拷贝一条记忆：包与存储互不别名。
+ * 守卫（Laurie F2）：「浅拷即深拷」的成立前提是 MemoryEntry 全部字段都是
+ * 原始值（对 driver.ts 已核，2026-08-14 为真）。谁给 MemoryEntry 加嵌套
+ * 字段，谁负责把这里升级成深拷——否则该保证静默失效。
+ */
 function cloneEntry(entry: MemoryEntry): MemoryEntry {
   return { ...entry };
 }

--- a/tests/bootpack.test.ts
+++ b/tests/bootpack.test.ts
@@ -58,7 +58,9 @@ describe("P3 buildBootPack（#15）", () => {
     const idA = store.remember(r, "后写入但时间早");
     const idB = store.remember(r, "先排序靠后");
     const idC = store.remember(r, "同刻靠 id 定序");
-    // 白盒改写 createdAt 构造乱序（存储的 Map 插入序 ≠ 时间序的情形）
+    // 白盒改写 createdAt 构造乱序（存储的 Map 插入序 ≠ 时间序的情形）。
+    // 耦合声明（Laurie F1）：此夹具依赖 P1 room() 返回活内脏这一现状；
+    // P1 封舱之日此段连坐，届时换 P1 提供的 fixture 口，不改被测行为。
     const room = store.room(r);
     const get = (id: string) => {
       const entry = room.memories.get(id);
@@ -110,4 +112,13 @@ describe("P3 buildBootPack（#15）", () => {
     const store = freshStore();
     expect(() => buildBootPack(store, "ghost")).toThrow(ResidentNotFoundError);
   });
+});
+
+it("空住户的包形状：commitments/memories 是空数组,不是缺字段（Laurie F3）", () => {
+  const store = new ResidentStore();
+  const r = store.createResident("空房");
+  const pack = buildBootPack(store, r);
+  expect(pack.commitments).toEqual([]);
+  expect(pack.memories).toEqual([]);
+  expect(Object.keys(pack).sort()).toEqual(["commitments", "identity", "memories", "residentId"]);
 });


### PR DESCRIPTION
把 #21 评审里三条非阻塞建议全部落地:F1 夹具耦合加显式声明(P1 封舱之日连坐条款写明)、F2 浅拷贝守卫注释(前提+失效责任)、F3 空住户包形状测试(空数组非缺字段,键集钉死)。零行为变化,本地 92/92 绿、biome/tsc 干净。@zaymb 请过目是否符合原意。— 阿问