### PR TITLE
消息树批量 IO + 迁移桥改读 P2 真树

### DIFF
--- a/src/message-tree/store.ts
+++ b/src/message-tree/store.ts
@@ -160,6 +160,7 @@ export class MessageTreeStore {
         throw nodeUnavailable();
       }
     }
+    this.assertAcyclicImport(room, prepared);
 
     const orderBefore = room.order.length;
     try {
@@ -217,6 +218,29 @@ export class MessageTreeStore {
     }
     if (typeof node.createdAt !== "string") {
       throw new MessageTreeError("节点不可导入");
+    }
+  }
+
+  /**
+   * 迁移包能带来 appendPair/appendSibling 平时长不出的形状。
+   * 每个导入节点必须能沿 parentId 在有限步内回到根，或接到房内既有节点。
+   */
+  private assertAcyclicImport(room: Room, nodes: HistoryNode[]): void {
+    const batchParents = new Map(nodes.map((node) => [node.id, node.parentId]));
+    for (const node of nodes) {
+      const seen = new Set<string>();
+      let cursor: string | null = node.id;
+      while (cursor !== null && !room.nodes.has(cursor)) {
+        if (seen.has(cursor)) {
+          throw new MessageTreeError("节点不可导入");
+        }
+        seen.add(cursor);
+        const parentId = batchParents.get(cursor);
+        if (parentId === undefined) {
+          throw nodeUnavailable();
+        }
+        cursor = parentId;
+      }
     }
   }
 

--- a/src/message-tree/store.ts
+++ b/src/message-tree/store.ts
@@ -120,12 +120,104 @@ export class MessageTreeStore {
     return nodes;
   }
 
+  /** 迁移桥读树：语义同 history()，按插入序返回全树副本。 */
+  exportTree(residentId: string): HistoryNode[] {
+    return this.history(residentId);
+  }
+
+  /**
+   * 批量导入。整批先校验，任何一条不过就零写入；全过才按数组顺序逐条插入。
+   * 不代建房——房间生命周期仍走 createRoom，防止拼错 id 长出幽灵房。
+   */
+  importTree(residentId: string, nodes: HistoryNode[]): void {
+    const room = this.mustRoom(residentId);
+    const prepared: HistoryNode[] = [];
+    const batchIds = new Set<string>();
+
+    for (const node of nodes) {
+      this.assertContractNode(node);
+      if (room.nodes.has(node.id) || batchIds.has(node.id)) {
+        throw new MessageTreeError(`节点 id 冲突，拒绝覆盖历史：${node.id}`);
+      }
+      batchIds.add(node.id);
+      prepared.push(
+        Object.freeze({
+          id: node.id,
+          parentId: node.parentId,
+          role: node.role,
+          content: node.content,
+          createdAt: node.createdAt,
+        }),
+      );
+    }
+
+    for (const node of prepared) {
+      if (
+        node.parentId !== null &&
+        !room.nodes.has(node.parentId) &&
+        !batchIds.has(node.parentId)
+      ) {
+        throw nodeUnavailable();
+      }
+    }
+
+    const orderBefore = room.order.length;
+    try {
+      for (const node of prepared) {
+        this.insert(room, node);
+      }
+    } catch (error) {
+      for (const node of prepared) {
+        room.nodes.delete(node.id);
+      }
+      room.order.length = orderBefore;
+      throw error;
+    }
+  }
+
   private mustRoom(residentId: string): Room {
     const room = this.rooms.get(residentId);
     if (room === undefined) {
       throw new MessageTreeError(`未知住户：${residentId}`);
     }
     return room;
+  }
+
+  private static readonly CONTRACT_KEYS = ["content", "createdAt", "id", "parentId", "role"];
+
+  /**
+   * 导入节点的契约闸：恰好五字段，role 只能是 user/assistant/system。
+   * 多一个键、少一个键、或类型不对，都整批拒绝——不把调用方的附加字段冻进历史。
+   */
+  private assertContractNode(node: HistoryNode): void {
+    if (typeof node !== "object" || node === null || Array.isArray(node)) {
+      throw new MessageTreeError("节点不可导入");
+    }
+    const keys = Object.keys(node).sort();
+    if (
+      keys.length !== MessageTreeStore.CONTRACT_KEYS.length ||
+      keys.some((key, index) => key !== MessageTreeStore.CONTRACT_KEYS[index])
+    ) {
+      throw new MessageTreeError("节点不可导入");
+    }
+    if (typeof node.id !== "string" || node.id.length === 0) {
+      throw new MessageTreeError("节点不可导入");
+    }
+    if (
+      node.parentId !== null &&
+      (typeof node.parentId !== "string" || node.parentId.length === 0)
+    ) {
+      throw new MessageTreeError("节点不可导入");
+    }
+    if (node.role !== "user" && node.role !== "assistant" && node.role !== "system") {
+      throw new MessageTreeError("节点不可导入");
+    }
+    if (typeof node.content !== "string") {
+      throw new MessageTreeError("节点不可导入");
+    }
+    if (typeof node.createdAt !== "string") {
+      throw new MessageTreeError("节点不可导入");
+    }
   }
 
   private build(parentId: string | null, role: HistoryNode["role"], content: string): HistoryNode {

--- a/src/migration/resident-store-migration.ts
+++ b/src/migration/resident-store-migration.ts
@@ -1,5 +1,6 @@
-/** P1 ResidentStore 与 P5 迁移服务之间的窄适配口。 */
+/** P1 ResidentStore 与 P2 MessageTreeStore 对 P5 迁移服务的窄适配口。 */
 
+import type { MessageTreeStore } from "../message-tree/store.ts";
 import type { ResidentStore } from "../store/resident-store.ts";
 import {
   type ResidentImportM0,
@@ -8,7 +9,10 @@ import {
 } from "./resident-migration.ts";
 
 export class ResidentStoreMigrationPort implements ResidentMigrationPort {
-  constructor(private readonly store: ResidentStore) {}
+  constructor(
+    private readonly store: ResidentStore,
+    private readonly tree: MessageTreeStore,
+  ) {}
 
   async snapshotResident(residentId: string) {
     const snapshot = this.store.exportRoom(residentId);
@@ -17,24 +21,48 @@ export class ResidentStoreMigrationPort implements ResidentMigrationPort {
       resident: { name: snapshot.name, createdAt: snapshot.createdAt },
       commitments: snapshot.commitments,
       memories: snapshot.memories,
-      history: snapshot.nodes,
+      history: this.tree.exportTree(residentId),
     };
   }
 
+  /**
+   * 先让 P1 原子导入房（树不进 P1，nodes 传空数组），再把 history 写入 P2。
+   *
+   * importTree 失败时 destroyResident 拆掉刚导的 P1 房，并拆掉本方法 createRoom
+   * 建出的 P2 空房，再向上抛。这是同进程 M0 补偿式回滚，不是分布式事务：
+   * 两家 store 没有共享提交；P1 已成功的水位（id/时间戳）不会退回。
+   */
   async commitImportedResident(snapshot: ResidentImportM0): Promise<string> {
-    return this.store.importRoom(
+    const residentId = this.store.importRoom(
       {
         name: snapshot.resident.name,
         createdAt: snapshot.resident.createdAt,
         commitments: snapshot.commitments,
         memories: snapshot.memories,
-        nodes: snapshot.history,
+        nodes: [],
       },
       { sourceResidentId: snapshot.sourceResidentId },
     );
+
+    let treeRoomCreated = false;
+    try {
+      this.tree.createRoom(residentId);
+      treeRoomCreated = true;
+      this.tree.importTree(residentId, snapshot.history);
+      return residentId;
+    } catch (error) {
+      this.store.destroyResident(residentId);
+      if (treeRoomCreated) {
+        this.tree.destroyRoom(residentId);
+      }
+      throw error;
+    }
   }
 }
 
-export function createResidentMigrationService(store: ResidentStore): ResidentMigrationService {
-  return new ResidentMigrationService(new ResidentStoreMigrationPort(store));
+export function createResidentMigrationService(
+  store: ResidentStore,
+  tree: MessageTreeStore,
+): ResidentMigrationService {
+  return new ResidentMigrationService(new ResidentStoreMigrationPort(store, tree));
 }

--- a/tests/message-tree-bulk-io.test.ts
+++ b/tests/message-tree-bulk-io.test.ts
@@ -1,0 +1,188 @@
+/**
+ * P2 消息树批量 IO：importTree 整批全成或零写入，exportTree 与 history 同语义。
+ */
+import { describe, expect, it } from "vitest";
+import type { HistoryNode } from "../acceptance/driver.ts";
+import { MessageTreeError, NODE_UNAVAILABLE } from "../src/message-tree/errors.ts";
+import { MessageTreeStore } from "../src/message-tree/store.ts";
+
+const STAMP = "2026-08-14T00:00:00.000Z";
+
+function node(
+  id: string,
+  parentId: string | null,
+  role: HistoryNode["role"],
+  content: string,
+): HistoryNode {
+  return { id, parentId, role, content, createdAt: STAMP };
+}
+
+function snapshot(store: MessageTreeStore, residentId: string): string {
+  return JSON.stringify(store.exportTree(residentId));
+}
+
+describe("exportTree", () => {
+  it("与 history 同插入序、同副本语义", () => {
+    const store = new MessageTreeStore({
+      now: () => STAMP,
+      newId: (() => {
+        let seq = 0;
+        return () => `n${++seq}`;
+      })(),
+    });
+    store.createRoom("r");
+    store.appendPair("r", "一", "回一", null);
+    store.appendPair("r", "二", "回二", null);
+
+    const exported = store.exportTree("r");
+    expect(exported).toEqual(store.history("r"));
+    expect(exported.map((item) => item.id)).toEqual(["n1", "n2", "n3", "n4"]);
+
+    const before = snapshot(store, "r");
+    const head = exported[0];
+    expect(head).toBeDefined();
+    (head as { content: string }).content = "外部篡改";
+    exported.pop();
+    expect(snapshot(store, "r")).toBe(before);
+  });
+});
+
+describe("importTree 原子性", () => {
+  it("坏批零写入：合法前缀加上一条坏节点，房内一个字节不动", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    store.importTree("r", [node("keep", null, "system", "已有")]);
+    const before = snapshot(store, "r");
+
+    expect(() =>
+      store.importTree("r", [
+        node("ok-1", null, "user", "好节点"),
+        node("ok-2", "ok-1", "assistant", "也好"),
+        { ...node("bad", null, "user", "多字段"), extra: true } as HistoryNode,
+      ]),
+    ).toThrow(MessageTreeError);
+
+    expect(snapshot(store, "r")).toBe(before);
+    expect(store.history("r").map((item) => item.id)).toEqual(["keep"]);
+  });
+
+  it("批内 id 互撞：整批拒绝，零写入", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    expect(() =>
+      store.importTree("r", [
+        node("dup", null, "user", "一"),
+        node("dup", null, "assistant", "二"),
+      ]),
+    ).toThrow(MessageTreeError);
+    expect(store.history("r")).toEqual([]);
+  });
+
+  it("空批是合法批：零写入但也不抛", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    store.importTree("r", []);
+    expect(store.history("r")).toEqual([]);
+  });
+});
+
+describe("importTree id 撞房", () => {
+  it("与房内已有节点撞 id：拒绝覆盖，旧树逐字不动", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    store.importTree("r", [node("n1", null, "user", "原件")]);
+    const before = snapshot(store, "r");
+
+    expect(() => store.importTree("r", [node("n1", null, "assistant", "覆盖?")])).toThrow(
+      MessageTreeError,
+    );
+    expect(snapshot(store, "r")).toBe(before);
+  });
+});
+
+describe("importTree 跨房", () => {
+  it("另一房的 parentId 当作不存在：文案与真不存在相同，两房零写入", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("a");
+    store.createRoom("b");
+    store.importTree("a", [node("a-root", null, "user", "A 的根")]);
+    const beforeA = snapshot(store, "a");
+    const beforeB = snapshot(store, "b");
+
+    let crossMessage = "";
+    let missingMessage = "";
+    try {
+      store.importTree("b", [node("b-child", "a-root", "assistant", "越权挂 A")]);
+    } catch (err) {
+      crossMessage = (err as Error).message;
+    }
+    try {
+      store.importTree("b", [node("b-child", "never-existed", "assistant", "挂幽灵")]);
+    } catch (err) {
+      missingMessage = (err as Error).message;
+    }
+
+    expect(crossMessage).toBe(NODE_UNAVAILABLE);
+    expect(crossMessage).toBe(missingMessage);
+    expect(snapshot(store, "a")).toBe(beforeA);
+    expect(snapshot(store, "b")).toBe(beforeB);
+  });
+
+  it("另一房已有相同 id 不构成撞房：本房可以收下同号节点", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("a");
+    store.createRoom("b");
+    store.importTree("a", [node("shared", null, "user", "A 的")]);
+    store.importTree("b", [node("shared", null, "user", "B 的")]);
+    expect(store.exportTree("a")[0]?.content).toBe("A 的");
+    expect(store.exportTree("b")[0]?.content).toBe("B 的");
+  });
+});
+
+describe("importTree parent 悬空", () => {
+  it("parent 不在房内也不在本批：不透明拒绝，零写入", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    expect(() => store.importTree("r", [node("child", "ghost", "user", "悬空")])).toThrow(
+      NODE_UNAVAILABLE,
+    );
+    expect(store.history("r")).toEqual([]);
+  });
+
+  it("parent 在本批即可，不必先于子节点出现在数组里", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    store.importTree("r", [
+      node("child", "parent", "assistant", "先写子"),
+      node("parent", null, "user", "后写父"),
+    ]);
+    expect(store.exportTree("r").map((item) => item.id)).toEqual(["child", "parent"]);
+  });
+});
+
+describe("export → import → export", () => {
+  it("逐字节等价，且按给定数组顺序插入", () => {
+    const store = new MessageTreeStore({
+      now: () => STAMP,
+      newId: (() => {
+        let seq = 0;
+        return () => `n${++seq}`;
+      })(),
+    });
+    store.createRoom("src");
+    store.appendPair("src", "问", "答", null);
+    store.appendSibling("src", "n2", "改口");
+
+    const first = store.exportTree("src");
+    const firstBytes = JSON.stringify(first);
+
+    store.createRoom("dst");
+    store.importTree("dst", first);
+    expect(JSON.stringify(store.exportTree("dst"))).toBe(firstBytes);
+
+    store.createRoom("dst2");
+    store.importTree("dst2", store.exportTree("dst"));
+    expect(JSON.stringify(store.exportTree("dst2"))).toBe(firstBytes);
+    expect(JSON.stringify(store.exportTree("src"))).toBe(firstBytes);
+  });
+});

--- a/tests/message-tree-bulk-io.test.ts
+++ b/tests/message-tree-bulk-io.test.ts
@@ -160,6 +160,46 @@ describe("importTree parent 悬空", () => {
   });
 });
 
+describe("importTree 树形拓扑", () => {
+  it("自引用节点不是树：整批拒绝，零写入", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    expect(() => store.importTree("r", [node("self", "self", "user", "自环")])).toThrow(
+      MessageTreeError,
+    );
+    expect(store.history("r")).toEqual([]);
+  });
+
+  it("批内互指成环不是树：整批拒绝，既有树不动", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    store.importTree("r", [node("keep", null, "system", "已有")]);
+    const before = snapshot(store, "r");
+
+    expect(() =>
+      store.importTree("r", [node("a", "b", "user", "A"), node("b", "a", "assistant", "B")]),
+    ).toThrow(MessageTreeError);
+
+    expect(snapshot(store, "r")).toBe(before);
+  });
+
+  it("接到房内既有节点的批次仍合法", () => {
+    const store = new MessageTreeStore();
+    store.createRoom("r");
+    store.importTree("r", [node("root", null, "system", "已有根")]);
+    store.importTree("r", [
+      node("leaf", "mid", "assistant", "叶"),
+      node("mid", "root", "user", "中间"),
+    ]);
+
+    expect(store.exportTree("r").map((item) => [item.id, item.parentId])).toEqual([
+      ["root", null],
+      ["leaf", "mid"],
+      ["mid", "root"],
+    ]);
+  });
+});
+
 describe("export → import → export", () => {
   it("逐字节等价，且按给定数组顺序插入", () => {
     const store = new MessageTreeStore({

--- a/tests/resident-migration-store.test.ts
+++ b/tests/resident-migration-store.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { MessageTreeStore } from "../src/message-tree/store.ts";
 import {
   ResidentMigrationError,
   encodeResidentExportM0,
@@ -26,19 +27,31 @@ afterEach(() => {
 describe("ResidentStore 迁移接缝", () => {
   it("搬齐身份来源、承诺、勘误链和整棵树，副本生死不碰原件", async () => {
     const source = new ResidentStore();
+    let treeStamp = Date.parse("2026-08-14T06:00:00.000Z");
+    const sourceTree = new MessageTreeStore({
+      now: () => {
+        treeStamp += 1;
+        return new Date(treeStamp).toISOString();
+      },
+    });
     const sourceId = source.createResident("迁移住户");
+    sourceTree.createRoom(sourceId);
     source.commit(sourceId, `正文保留来源 id：${sourceId}`);
     const wrong = source.remember(sourceId, "旧记忆");
     const correction = source.errata(sourceId, wrong, `新记忆仍提到 ${sourceId}`);
-    const root = source.appendNode(sourceId, null, "user", "第一句");
-    source.appendNode(sourceId, root.id, "assistant", `回应 ${sourceId}`);
+    sourceTree.appendPair(sourceId, "第一句", `回应 ${sourceId}`, null);
     const sourceBefore = JSON.stringify(source.exportRoom(sourceId));
+    const sourceTreeBefore = JSON.stringify(sourceTree.exportTree(sourceId));
 
-    const exported = await createResidentMigrationService(source).exportResident(sourceId);
+    const exported = await createResidentMigrationService(source, sourceTree).exportResident(
+      sourceId,
+    );
     expect(JSON.stringify(source.exportRoom(sourceId))).toBe(sourceBefore);
+    expect(JSON.stringify(sourceTree.exportTree(sourceId))).toBe(sourceTreeBefore);
 
     const target = new ResidentStore();
-    const targetService = createResidentMigrationService(target);
+    const targetTree = new MessageTreeStore();
+    const targetService = createResidentMigrationService(target, targetTree);
     const first = await targetService.importResident(exported);
     const second = await targetService.importResident(exported);
     expect(first).not.toBe(sourceId);
@@ -50,40 +63,54 @@ describe("ResidentStore 迁移接缝", () => {
     expect(imported.memories.find((entry) => entry.id === wrong)?.supersededBy).toBe(correction);
     expect(imported.memories.find((entry) => entry.id === correction)?.content).toContain(sourceId);
     expect(imported.memories.every((entry) => entry.residentId === first)).toBe(true);
-    expect(imported.nodes).toEqual(source.exportRoom(sourceId).nodes);
+    expect(imported.nodes).toEqual([]);
+    expect(JSON.stringify(targetTree.exportTree(first))).toBe(sourceTreeBefore);
 
     target.remember(first, "导入件新增");
     target.destroyResident(first);
     expect(JSON.stringify(source.exportRoom(sourceId))).toBe(sourceBefore);
+    expect(JSON.stringify(sourceTree.exportTree(sourceId))).toBe(sourceTreeBefore);
     expect(target.has(second)).toBe(true);
   });
 
   it("fresh target 导入后继续写，不撞 id，时间戳不倒退", async () => {
     const source = new ResidentStore();
+    const sourceTree = new MessageTreeStore();
     const sourceId = source.createResident("高水位来源");
+    sourceTree.createRoom(sourceId);
     for (let index = 0; index < 30; index += 1) {
       source.remember(sourceId, `记忆 ${index}`);
-      source.appendNode(sourceId, null, "system", `节点 ${index}`);
+      sourceTree.appendPair(sourceId, `问 ${index}`, `节点 ${index}`, null);
     }
-    const exported = await createResidentMigrationService(source).exportResident(sourceId);
+    const exported = await createResidentMigrationService(source, sourceTree).exportResident(
+      sourceId,
+    );
 
     const target = new ResidentStore();
-    const moved = await createResidentMigrationService(target).importResident(exported);
+    const targetTree = new MessageTreeStore();
+    const moved = await createResidentMigrationService(target, targetTree).importResident(exported);
     const imported = target.exportRoom(moved);
+    const importedTree = targetTree.exportTree(moved);
     const importedIds = new Set([
       ...imported.memories.map((entry) => entry.id),
-      ...imported.nodes.map((node) => node.id),
+      ...importedTree.map((node) => node.id),
     ]);
-    const latestTimestamp = [...imported.memories, ...imported.nodes]
-      .map((record) => record.createdAt)
-      .sort()
-      .at(-1);
 
     const memoryId = target.remember(moved, "落地后新记忆");
-    const node = target.appendNode(moved, null, "system", "落地后新节点");
+    const pair = targetTree.appendPair(moved, "落地后新问", "落地后新节点", null);
     expect(importedIds.has(memoryId)).toBe(false);
-    expect(importedIds.has(node.id)).toBe(false);
-    expect(latestTimestamp !== undefined && node.createdAt > latestTimestamp).toBe(true);
+    expect(importedIds.has(pair.user.id)).toBe(false);
+    expect(importedIds.has(pair.assistant.id)).toBe(false);
+    const newMemory = target.memories(moved).find((entry) => entry.id === memoryId);
+    const latestMemoryStamp = imported.memories
+      .map((entry) => entry.createdAt)
+      .sort()
+      .at(-1);
+    expect(
+      newMemory !== undefined &&
+        latestMemoryStamp !== undefined &&
+        newMemory.createdAt > latestMemoryStamp,
+    ).toBe(true);
   });
 
   it("超大原生 id 导入后连续写两次，不撞号也不覆盖", async () => {
@@ -106,7 +133,10 @@ describe("ResidentStore 迁移接缝", () => {
     });
 
     const target = new ResidentStore();
-    const moved = await createResidentMigrationService(target).importResident(pack);
+    const moved = await createResidentMigrationService(
+      target,
+      new MessageTreeStore(),
+    ).importResident(pack);
     const first = target.remember(moved, "落地后第一条");
     const second = target.remember(moved, "落地后第二条");
 
@@ -144,32 +174,38 @@ describe("ResidentStore 迁移接缝", () => {
     });
 
     const target = new ResidentStore();
-    await expect(createResidentMigrationService(target).importResident(pack)).rejects.toThrow(
-      /sequence suffix exceeds/,
-    );
+    await expect(
+      createResidentMigrationService(target, new MessageTreeStore()).importResident(pack),
+    ).rejects.toThrow(/sequence suffix exceeds/);
     expect(target.createResident("首个有效住户")).toBe("resident-000001");
   });
 
   it("坏包在 store 前失败，不建房也不消耗 resident id", async () => {
     const target = new ResidentStore();
     await expect(
-      createResidentMigrationService(target).importResident(new TextEncoder().encode("bad-json")),
+      createResidentMigrationService(target, new MessageTreeStore()).importResident(
+        new TextEncoder().encode("bad-json"),
+      ),
     ).rejects.toThrow(ResidentMigrationError);
     expect(target.createResident("第一个真人")).toBe("resident-000001");
   });
 
   it("落盘提交失败时不留下房间、最终文件或水位副作用", async () => {
     const source = new ResidentStore();
+    const sourceTree = new MessageTreeStore();
     const sourceId = source.createResident("来源");
+    sourceTree.createRoom(sourceId);
     source.remember(sourceId, "一条记忆");
-    const pack = await createResidentMigrationService(source).exportResident(sourceId);
+    const pack = await createResidentMigrationService(source, sourceTree).exportResident(sourceId);
 
     const directory = freshDirectory();
     // resident-000001 与来源 id 同名会被跳过，真正待提交的目标是 000002。
     const collision = join(directory, "resident-000002.json.tmp");
     mkdirSync(collision);
     const target = new ResidentStore({ dataDir: directory });
-    await expect(createResidentMigrationService(target).importResident(pack)).rejects.toThrow();
+    await expect(
+      createResidentMigrationService(target, new MessageTreeStore()).importResident(pack),
+    ).rejects.toThrow();
     expect(target.has("resident-000002")).toBe(false);
     expect(readdirSync(directory)).toEqual(["resident-000002.json.tmp"]);
 

--- a/tests/resident-migration-tree-bridge.test.ts
+++ b/tests/resident-migration-tree-bridge.test.ts
@@ -1,0 +1,99 @@
+/**
+ * 迁移桥接到 P2 真树：history 走 exportTree/importTree，
+ * importTree 失败走 M0 补偿回滚（拆刚导的房，原件不动）。
+ */
+import { describe, expect, it } from "vitest";
+import type { HistoryNode } from "../acceptance/driver.ts";
+import { MessageTreeError } from "../src/message-tree/errors.ts";
+import { MessageTreeStore } from "../src/message-tree/store.ts";
+import {
+  ResidentStoreMigrationPort,
+  createResidentMigrationService,
+} from "../src/migration/resident-store-migration.ts";
+import { ResidentStore } from "../src/store/resident-store.ts";
+
+const STAMP = "2026-08-14T06:00:00.000Z";
+
+function historyNode(
+  id: string,
+  parentId: string | null,
+  role: HistoryNode["role"],
+  content: string,
+): HistoryNode {
+  return { id, parentId, role, content, createdAt: STAMP };
+}
+
+describe("迁移桥读 P2 真树", () => {
+  it("snapshot 的 history 来自 exportTree，不读 P1 空架子上的 nodes", async () => {
+    const store = new ResidentStore();
+    const tree = new MessageTreeStore();
+    const residentId = store.createResident("有树的人");
+    tree.createRoom(residentId);
+    store.appendNode(residentId, null, "system", "P1 架子上的节点，桥不该看见");
+    tree.importTree(residentId, [
+      historyNode("real-1", null, "user", "真树上的话"),
+      historyNode("real-2", "real-1", "assistant", "真树上的回应"),
+    ]);
+
+    const snapshot = await new ResidentStoreMigrationPort(store, tree).snapshotResident(residentId);
+    expect(snapshot.history.map((node) => node.id)).toEqual(["real-1", "real-2"]);
+    expect(snapshot.history.map((node) => node.content)).toEqual(["真树上的话", "真树上的回应"]);
+  });
+
+  it("导入后树在 P2，P1 房间 nodes 仍为空", async () => {
+    const source = new ResidentStore();
+    const sourceTree = new MessageTreeStore();
+    const sourceId = source.createResident("来源");
+    sourceTree.createRoom(sourceId);
+    source.remember(sourceId, "一条记忆");
+    sourceTree.importTree(sourceId, [historyNode("n1", null, "user", "迁过去")]);
+
+    const pack = await createResidentMigrationService(source, sourceTree).exportResident(sourceId);
+    const target = new ResidentStore();
+    const targetTree = new MessageTreeStore();
+    const moved = await createResidentMigrationService(target, targetTree).importResident(pack);
+
+    expect(target.exportRoom(moved).nodes).toEqual([]);
+    expect(targetTree.exportTree(moved)).toEqual(sourceTree.exportTree(sourceId));
+  });
+});
+
+describe("importTree 失败的补偿回滚", () => {
+  it("新房不可见，原件无损", async () => {
+    const store = new ResidentStore();
+    const tree = new MessageTreeStore();
+    const originalId = store.createResident("原件");
+    tree.createRoom(originalId);
+    store.commit(originalId, "答应过的还在");
+    const memoryId = store.remember(originalId, "不该被动");
+    tree.importTree(originalId, [historyNode("orig", null, "user", "原树")]);
+    const beforeRoom = JSON.stringify(store.exportRoom(originalId));
+    const beforeTree = JSON.stringify(tree.exportTree(originalId));
+
+    const port = new ResidentStoreMigrationPort(store, tree);
+    await expect(
+      port.commitImportedResident({
+        sourceResidentId: originalId,
+        resident: { name: "不该留下", createdAt: STAMP },
+        commitments: ["新承诺"],
+        memories: [
+          {
+            id: "mem-imported",
+            residentId: originalId,
+            content: "不该落地",
+            supersededBy: null,
+            createdAt: "2026-08-14T06:00:01.000Z",
+          },
+        ],
+        history: [historyNode("orphan", "ghost-parent", "user", "悬空父节点")],
+      }),
+    ).rejects.toThrow(MessageTreeError);
+
+    expect(store.has(originalId)).toBe(true);
+    expect(store.has("resident-000002")).toBe(false);
+    expect(() => tree.exportTree("resident-000002")).toThrow(MessageTreeError);
+    expect(JSON.stringify(store.exportRoom(originalId))).toBe(beforeRoom);
+    expect(JSON.stringify(tree.exportTree(originalId))).toBe(beforeTree);
+    expect(store.memories(originalId).map((entry) => entry.id)).toEqual([memoryId]);
+  });
+});


### PR DESCRIPTION
主笔拍板的直派件：补上「迁移搬不到真消息树」这条缝（P4 接 P5 前最后一块缺件）。

## 内容

- P2 `MessageTreeStore` 新增 `exportTree` / `importTree`：批量导入整批先校验（五字段契约、role、id 批内房内唯一、parent 可解析），不过零写入；过则按序插入并冻结。
- P5 迁移桥改握两家店：history 从 P2 真树读、往 P2 真树写；写树失败拆 P1 房 + 拆 P2 空房补偿回滚（同进程 M0 补偿，注释写明不是分布式事务）。
- 新增两组测试：bulk IO 原子性/撞房/跨房/悬空/往返等价；桥读真树与补偿回滚。

## 验收（望舒独立复验）

- lint / typecheck / **119 测试全过**（本机 Node 22 默认线程池，无回包所述栈溢出——那是施工侧沙箱环境的事）
- acceptance 灯色不变：真绿 1/6、桩 4、红 1（本件不该动灯，动了就是越界）
- 禁区核对：acceptance/ 零改动、acceptance-driver.ts 零改动、P1 store 零改动，接口形状未变

## 交接

@Miko0523 顾总审。审完 P4 接最后一刀：总装把 export/import 接到真迁移桥，STUBBED 清零，六灯见真章，然后走复验程序。

施工：Cursor（Grok 4.6），工单制；验收：望舒。