### PR TITLE
P4: 总装驱动接线与会话生命周期

### DIFF
--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -20,6 +20,7 @@
  */
 
 import type { BootPack, HarnessDriver, HistoryNode, MemoryEntry } from "../acceptance/driver.ts";
+import { buildBootPack as assembleBootPack } from "./bootpack.ts";
 import {
   MessageTreeService,
   MessageTreeStore,
@@ -100,21 +101,10 @@ class MistDriver implements HarnessDriver {
     return this.#messageTree.reviseNode(residentId, nodeId, newContent);
   }
 
-  // --- P3：启动包（TODO(P3) 认领者替换）---
+  // --- P3：启动包 ---
 
   async buildBootPack(residentId: string): Promise<BootPack> {
-    const room = this.#store.room(residentId);
-    const memories = this.#store.memories(residentId);
-    // TODO(P3)：identity 目前从存储机械推导，真实形态应由住户的身份锚生成。
-    // commitments 不再从记忆里按「答应」二字猜——那是把关键词匹配冒充承诺账本，
-    // 说过「答应」的记忆和真立过的承诺是两回事。改由 commit() 写入的原文供货
-    // （#16 问 4 裁定：存储归 P1、进包归 P3）。
-    return {
-      residentId,
-      identity: `住户 ${room.name}（建于 ${room.createdAt}）`,
-      commitments: this.#store.commitments(residentId),
-      memories,
-    };
+    return assembleBootPack(this.#store, residentId);
   }
 
   // --- P4：会话生杀（TODO(P4) 认领者替换）---
@@ -151,4 +141,4 @@ export function createDriver(): HarnessDriver {
  * 判卷桩申报（#16 裁定 1 的执行）：以下方法当前是 P1 代写的最小实现，
  * 各认领包交付时从名单里划掉自己那几个。隐瞒申报按伪证论。
  */
-export const STUBBED = ["buildBootPack", "exportResident", "importResident"];
+export const STUBBED = ["exportResident", "importResident"];

--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -20,11 +20,25 @@
  */
 
 import type { BootPack, HarnessDriver, HistoryNode, MemoryEntry } from "../acceptance/driver.ts";
+import {
+  MessageTreeService,
+  MessageTreeStore,
+  type SessionHeadPort,
+} from "./message-tree/index.ts";
 import { SessionRegistry } from "./session/session-registry.ts";
 import { type ResidentSnapshot, ResidentStore } from "./store/resident-store.ts";
 
 class MistDriver implements HarnessDriver {
   readonly #store = new ResidentStore();
+  readonly #messageTreeStore = new MessageTreeStore();
+  readonly #messageTree = new MessageTreeService(
+    this.#messageTreeStore,
+    {
+      getHead: (residentId) => this.#session(residentId).headId,
+      setHead: (residentId, headId) => this.#sessions.setHead(residentId, headId),
+    } satisfies SessionHeadPort,
+    { assistantReply: (_residentId, message) => `收到：${message}` },
+  );
 
   /**
    * 会话态注册表 —— 跟住户存储分开的一张表（#16 问 2 裁定）。
@@ -43,7 +57,9 @@ class MistDriver implements HarnessDriver {
   // --- P1：记忆库存储（本 issue 的认领范围）---
 
   async createResident(name: string): Promise<string> {
-    return this.#store.createResident(name);
+    const residentId = this.#store.createResident(name);
+    this.#messageTreeStore.createRoom(residentId);
+    return residentId;
   }
 
   async remember(residentId: string, content: string): Promise<string> {
@@ -63,45 +79,25 @@ class MistDriver implements HarnessDriver {
   }
 
   async destroyResident(residentId: string): Promise<void> {
+    this.#sessions.kill(residentId);
+    this.#messageTreeStore.destroyRoom(residentId);
     this.#store.destroyResident(residentId);
   }
 
-  // --- P2：消息树（TODO(P2) 认领者替换）---
+  // --- P2：消息树 ---
 
   async say(residentId: string, message: string): Promise<HistoryNode> {
-    // 先确认住户真的在（拿不到会抛）——会话态自己那张表没有隔离语义。
     this.#store.room(residentId);
-    const session = this.#session(residentId);
-    // 没有活会话时 #session 会开一个新 generation，headId 为 null。
-    // #16 问 3 裁定：kill 之后第一次说话的 user 节点必须是新根
-    // （parentId === null），会话边界才是可判的——否则「会话死了」
-    // 这件事在树上看不出来，killSession 写成空函数也能蒙混过关。
-    // 旧枝一个字节不动，人和历史都还在，只是这段对话从头起。
-    const userNode = this.#store.appendNode(residentId, session.headId, "user", message);
-    // TODO(P2)：M0 阶段回应是固定文本，判卷只看树结构不看措辞。
-    const replyNode = this.#store.appendNode(
-      residentId,
-      userNode.id,
-      "assistant",
-      `收到：${message}`,
-    );
-    this.#sessions.setHead(residentId, replyNode.id);
-    return replyNode;
+    return this.#messageTree.say(residentId, message);
   }
 
   async history(residentId: string): Promise<HistoryNode[]> {
-    return this.#store.nodes(residentId);
+    return this.#messageTree.history(residentId);
   }
 
   async reviseNode(residentId: string, nodeId: string, newContent: string): Promise<HistoryNode> {
-    const room = this.#store.room(residentId);
-    const target = room.nodes.get(nodeId);
-    if (target === undefined) {
-      throw new Error(`no such node in ${residentId}: ${nodeId}`);
-    }
-    // append-only：改口挂在旧节点的**父节点**下成为兄弟枝，旧枝一个字节不动。
-    // 挂在旧节点自己下面会把「改口」变成「追加」，语义就错了。
-    return this.#store.appendNode(residentId, target.parentId, target.role, newContent);
+    this.#store.room(residentId);
+    return this.#messageTree.reviseNode(residentId, nodeId, newContent);
   }
 
   // --- P3：启动包（TODO(P3) 认领者替换）---
@@ -141,7 +137,9 @@ class MistDriver implements HarnessDriver {
 
   async importResident(pack: Uint8Array): Promise<string> {
     const snapshot = JSON.parse(new TextDecoder().decode(pack)) as ResidentSnapshot;
-    return this.#store.importRoom(snapshot);
+    const residentId = this.#store.importRoom(snapshot);
+    this.#messageTreeStore.createRoom(residentId);
+    return residentId;
   }
 }
 
@@ -153,12 +151,4 @@ export function createDriver(): HarnessDriver {
  * 判卷桩申报（#16 裁定 1 的执行）：以下方法当前是 P1 代写的最小实现，
  * 各认领包交付时从名单里划掉自己那几个。隐瞒申报按伪证论。
  */
-export const STUBBED = [
-  "say",
-  "history",
-  "reviseNode",
-  "buildBootPack",
-  "killSession",
-  "exportResident",
-  "importResident",
-];
+export const STUBBED = ["buildBootPack", "exportResident", "importResident"];

--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -20,7 +20,8 @@
  */
 
 import type { BootPack, HarnessDriver, HistoryNode, MemoryEntry } from "../acceptance/driver.ts";
-import { type ResidentSnapshot, ResidentStore, type SessionState } from "./store/resident-store.ts";
+import { SessionRegistry } from "./session/session-registry.ts";
+import { type ResidentSnapshot, ResidentStore } from "./store/resident-store.ts";
 
 class MistDriver implements HarnessDriver {
   readonly #store = new ResidentStore();
@@ -33,15 +34,10 @@ class MistDriver implements HarnessDriver {
    * 分开放，是让「会话死人不死」这件事在数据结构上就成立，而不是靠约定。
    * 合龙时由 P4 的 SessionRegistry 接管这张表。
    */
-  readonly #sessions = new Map<string, SessionState>();
+  readonly #sessions = new SessionRegistry<null>();
 
-  #session(residentId: string): SessionState {
-    let s = this.#sessions.get(residentId);
-    if (s === undefined) {
-      s = { head: null, alive: false };
-      this.#sessions.set(residentId, s);
-    }
-    return s;
+  #session(residentId: string) {
+    return this.#sessions.get(residentId) ?? this.#sessions.open(residentId, null, null);
   }
 
   // --- P1：记忆库存储（本 issue 的认领范围）---
@@ -76,15 +72,12 @@ class MistDriver implements HarnessDriver {
     // 先确认住户真的在（拿不到会抛）——会话态自己那张表没有隔离语义。
     this.#store.room(residentId);
     const session = this.#session(residentId);
-    if (!session.alive) {
-      // 没有活会话就开一个：alive=true，head 保持 null。
-      // #16 问 3 裁定：kill 之后第一次说话的 user 节点必须是新根
-      // （parentId === null），会话边界才是可判的——否则「会话死了」
-      // 这件事在树上看不出来，killSession 写成空函数也能蒙混过关。
-      // 旧枝一个字节不动，人和历史都还在，只是这段对话从头起。
-      session.alive = true;
-    }
-    const userNode = this.#store.appendNode(residentId, session.head, "user", message);
+    // 没有活会话时 #session 会开一个新 generation，headId 为 null。
+    // #16 问 3 裁定：kill 之后第一次说话的 user 节点必须是新根
+    // （parentId === null），会话边界才是可判的——否则「会话死了」
+    // 这件事在树上看不出来，killSession 写成空函数也能蒙混过关。
+    // 旧枝一个字节不动，人和历史都还在，只是这段对话从头起。
+    const userNode = this.#store.appendNode(residentId, session.headId, "user", message);
     // TODO(P2)：M0 阶段回应是固定文本，判卷只看树结构不看措辞。
     const replyNode = this.#store.appendNode(
       residentId,
@@ -92,7 +85,7 @@ class MistDriver implements HarnessDriver {
       "assistant",
       `收到：${message}`,
     );
-    session.head = replyNode.id;
+    this.#sessions.setHead(residentId, replyNode.id);
     return replyNode;
   }
 
@@ -134,8 +127,9 @@ class MistDriver implements HarnessDriver {
     this.#store.room(residentId);
     // 只动会话态那张表，一个字节都不碰 nodes / memories / commitments：
     // 会话死，人不能死（C1 验 kill 前后整棵树的 hash 不变）。
-    // head 清空 —— 下一句 say 开新根，这就是会话边界在树上的形状。
-    this.#sessions.set(residentId, { head: null, alive: false });
+    // 删除活会话 —— 下一句 say 会开新 generation、新根；旧 generation 的迟到
+    // effect receipt 也不能再被视为当前会话，H1 的 Effect Journal 会接这条线。
+    this.#sessions.kill(residentId);
   }
 
   // --- P5：迁移（TODO(P5) 认领者替换）---

--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -26,8 +26,9 @@ import {
   MessageTreeStore,
   type SessionHeadPort,
 } from "./message-tree/index.ts";
+import { createResidentMigrationService } from "./migration/resident-store-migration.ts";
 import { SessionRegistry } from "./session/session-registry.ts";
-import { type ResidentSnapshot, ResidentStore } from "./store/resident-store.ts";
+import { ResidentStore } from "./store/resident-store.ts";
 
 class MistDriver implements HarnessDriver {
   readonly #store = new ResidentStore();
@@ -40,6 +41,7 @@ class MistDriver implements HarnessDriver {
     } satisfies SessionHeadPort,
     { assistantReply: (_residentId, message) => `收到：${message}` },
   );
+  readonly #migration = createResidentMigrationService(this.#store, this.#messageTreeStore);
 
   /**
    * 会话态注册表 —— 跟住户存储分开的一张表（#16 问 2 裁定）。
@@ -118,18 +120,14 @@ class MistDriver implements HarnessDriver {
     this.#sessions.kill(residentId);
   }
 
-  // --- P5：迁移（TODO(P5) 认领者替换）---
+  // --- P5：迁移 ---
 
   async exportResident(residentId: string): Promise<Uint8Array> {
-    const snapshot = this.#store.exportRoom(residentId);
-    return new TextEncoder().encode(JSON.stringify(snapshot));
+    return this.#migration.exportResident(residentId);
   }
 
   async importResident(pack: Uint8Array): Promise<string> {
-    const snapshot = JSON.parse(new TextDecoder().decode(pack)) as ResidentSnapshot;
-    const residentId = this.#store.importRoom(snapshot);
-    this.#messageTreeStore.createRoom(residentId);
-    return residentId;
+    return this.#migration.importResident(pack);
   }
 }
 
@@ -141,4 +139,4 @@ export function createDriver(): HarnessDriver {
  * 判卷桩申报（#16 裁定 1 的执行）：以下方法当前是 P1 代写的最小实现，
  * 各认领包交付时从名单里划掉自己那几个。隐瞒申报按伪证论。
  */
-export const STUBBED = ["exportResident", "importResident"];
+export const STUBBED: string[] = [];

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -6,17 +6,32 @@
  */
 export interface ActiveSession<TContext> {
   residentId: string;
+  /**
+   * 这次活会话的代际号。kill 后再 open 必须换代，旧代际的迟到结果不能
+   * 被当成当前会话的一部分。
+   */
+  generation: number;
   /** 当前活会话指向的消息节点；不是消息树本身。 */
   headId: string | null;
   /** 尚未落入持久存储的在途上下文。 */
   context: TContext;
 }
 
+export interface DispatchReceipt {
+  residentId: string;
+  generation: number;
+  dispatchId: string;
+}
+
 export class SessionRegistry<TContext> {
   readonly #active = new Map<string, ActiveSession<TContext>>();
+  readonly #lastGeneration = new Map<string, number>();
+  #dispatchSeq = 0;
 
   open(residentId: string, headId: string | null, context: TContext): ActiveSession<TContext> {
-    const session = { residentId, headId, context };
+    const generation = (this.#lastGeneration.get(residentId) ?? 0) + 1;
+    this.#lastGeneration.set(residentId, generation);
+    const session = { residentId, generation, headId, context };
     this.#active.set(residentId, session);
     return session;
   }
@@ -27,6 +42,32 @@ export class SessionRegistry<TContext> {
 
   isActive(residentId: string): boolean {
     return this.#active.has(residentId);
+  }
+
+  setHead(residentId: string, headId: string | null): void {
+    const session = this.#active.get(residentId);
+    if (session === undefined) {
+      throw new Error(`no active session for ${residentId}`);
+    }
+    session.headId = headId;
+  }
+
+  issueDispatch(residentId: string): DispatchReceipt {
+    const session = this.#active.get(residentId);
+    if (session === undefined) {
+      throw new Error(`no active session for ${residentId}`);
+    }
+    this.#dispatchSeq += 1;
+    return {
+      residentId,
+      generation: session.generation,
+      dispatchId: `dispatch-${this.#dispatchSeq.toString(36).padStart(6, "0")}`,
+    };
+  }
+
+  belongsToActiveSession(receipt: DispatchReceipt): boolean {
+    const session = this.#active.get(receipt.residentId);
+    return session !== undefined && session.generation === receipt.generation;
   }
 
   /** 幂等结束当前会话；住户不存在与否由总装侧的持久存储先行校验。 */

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -1,0 +1,36 @@
+/**
+ * 当前活会话的临时状态。
+ *
+ * 住户的记忆、消息树与关系记录不属于这里；它们必须由各自的持久存储保管。
+ * 删除这张表中的一格，只能让一次会话结束，不能删除住户留下的任何东西。
+ */
+export interface ActiveSession<TContext> {
+  residentId: string;
+  /** 当前活会话指向的消息节点；不是消息树本身。 */
+  headId: string | null;
+  /** 尚未落入持久存储的在途上下文。 */
+  context: TContext;
+}
+
+export class SessionRegistry<TContext> {
+  readonly #active = new Map<string, ActiveSession<TContext>>();
+
+  open(residentId: string, headId: string | null, context: TContext): ActiveSession<TContext> {
+    const session = { residentId, headId, context };
+    this.#active.set(residentId, session);
+    return session;
+  }
+
+  get(residentId: string): ActiveSession<TContext> | undefined {
+    return this.#active.get(residentId);
+  }
+
+  isActive(residentId: string): boolean {
+    return this.#active.has(residentId);
+  }
+
+  /** 幂等结束当前会话；住户不存在与否由总装侧的持久存储先行校验。 */
+  kill(residentId: string): void {
+    this.#active.delete(residentId);
+  }
+}

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -37,8 +37,46 @@ describe("SessionRegistry", () => {
     expect(sessions.isActive("resident-a")).toBe(false);
     expect(sessions.get("resident-b")).toEqual({
       residentId: "resident-b",
+      generation: 1,
       headId: "node-b",
       context: ["b"],
     });
+  });
+
+  it("advances the head inside one active generation", () => {
+    const sessions = new SessionRegistry<null>();
+    const session = sessions.open("resident-a", null, null);
+
+    sessions.setHead("resident-a", "reply-1");
+
+    expect(sessions.get("resident-a")).toEqual({
+      ...session,
+      headId: "reply-1",
+    });
+  });
+
+  it("rejects setting a head when no session is active", () => {
+    const sessions = new SessionRegistry<null>();
+
+    expect(() => sessions.setHead("resident-a", "reply-1")).toThrow(/no active session/);
+  });
+
+  it("marks stale dispatch receipts as not belonging to the active session after kill", () => {
+    const sessions = new SessionRegistry<null>();
+    sessions.open("resident-a", null, null);
+    const stale = sessions.issueDispatch("resident-a");
+
+    sessions.kill("resident-a");
+    sessions.open("resident-a", null, null);
+
+    expect(sessions.belongsToActiveSession(stale)).toBe(false);
+  });
+
+  it("keeps current-generation dispatch receipts valid while the session is still active", () => {
+    const sessions = new SessionRegistry<null>();
+    sessions.open("resident-a", null, null);
+    const receipt = sessions.issueDispatch("resident-a");
+
+    expect(sessions.belongsToActiveSession(receipt)).toBe(true);
   });
 });

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { SessionRegistry } from "../src/session/session-registry.ts";
+
+describe("SessionRegistry", () => {
+  it("kills the live pointer and in-flight context without touching resident state", () => {
+    const residentState = {
+      memories: ["答应过：周五晚上一起看电影"],
+      messages: ["记住这件事"],
+      relationships: ["一起看电影"],
+    };
+    const before = structuredClone(residentState);
+    const sessions = new SessionRegistry<{ pending: string[] }>();
+
+    sessions.open("resident-a", "node-2", { pending: ["还没落库的话"] });
+    sessions.kill("resident-a");
+
+    expect(sessions.get("resident-a")).toBeUndefined();
+    expect(residentState).toEqual(before);
+  });
+
+  it("is idempotent when the same session is killed twice", () => {
+    const sessions = new SessionRegistry<Record<string, never>>();
+    sessions.open("resident-a", null, {});
+
+    sessions.kill("resident-a");
+    expect(() => sessions.kill("resident-a")).not.toThrow();
+    expect(sessions.isActive("resident-a")).toBe(false);
+  });
+
+  it("does not kill another resident's live session", () => {
+    const sessions = new SessionRegistry<string[]>();
+    sessions.open("resident-a", "node-a", ["a"]);
+    sessions.open("resident-b", "node-b", ["b"]);
+
+    sessions.kill("resident-a");
+
+    expect(sessions.isActive("resident-a")).toBe(false);
+    expect(sessions.get("resident-b")).toEqual({
+      residentId: "resident-b",
+      headId: "node-b",
+      context: ["b"],
+    });
+  });
+});


### PR DESCRIPTION
## 范围

P4 总装线合龙：

- 新增并接入独立 `SessionRegistry`，`killSession` 只杀会话态，不碰住户持久态；
- `src/acceptance-driver.ts` 作为唯一 driver，接入已合入 main 的 P1/P2/P3/P5 真模块；
- `say/history/reviseNode` 走 P2 `MessageTreeService/MessageTreeStore`；
- `buildBootPack` 走 P3 `buildBootPack`；
- `exportResident/importResident` 走 P5 `createResidentMigrationService(store, tree)`，迁移读写 P2 真树；
- `STUBBED` 清零。

不包含：

- 不改 runner / acceptance 公共判卷规则；
- 不替其他包实现新功能；
- 不改 P1/P2/P3/P5 已合入模块边界。

## 验证

```text
npm test          -> 129 passed
npm run lint      -> clean
npm run typecheck -> clean
npm run acceptance -> 真绿 6/6；进入复验，不由判卷机宣布 H1 解锁
```

## 说明

P4 最后一刀等 #24 合入 main 后才接，避免把未合并接缝叠进总装。#24 的树批量 IO、迁移桥与拓扑闸均已在 main。