### PR TITLE
E1: add driver opts for persistence and reply injection

### DIFF
--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -22,6 +22,7 @@
 import type { BootPack, HarnessDriver, HistoryNode, MemoryEntry } from "../acceptance/driver.ts";
 import { buildBootPack as assembleBootPack } from "./bootpack.ts";
 import {
+  type AssistantReply,
   MessageTreeService,
   MessageTreeStore,
   type SessionHeadPort,
@@ -30,18 +31,18 @@ import { createResidentMigrationService } from "./migration/resident-store-migra
 import { SessionRegistry } from "./session/session-registry.ts";
 import { ResidentStore } from "./store/resident-store.ts";
 
+export interface CreateDriverOptions {
+  dataDir?: string;
+  reply?: AssistantReply;
+}
+
 class MistDriver implements HarnessDriver {
-  readonly #store = new ResidentStore();
-  readonly #messageTreeStore = new MessageTreeStore();
-  readonly #messageTree = new MessageTreeService(
-    this.#messageTreeStore,
-    {
-      getHead: (residentId) => this.#session(residentId).headId,
-      setHead: (residentId, headId) => this.#sessions.setHead(residentId, headId),
-    } satisfies SessionHeadPort,
-    { assistantReply: (_residentId, message) => `收到：${message}` },
-  );
-  readonly #migration = createResidentMigrationService(this.#store, this.#messageTreeStore);
+  readonly #store: ResidentStore;
+  readonly #messageTreeStore: MessageTreeStore;
+  readonly #messageTree: MessageTreeService;
+  readonly #migration: ReturnType<typeof createResidentMigrationService>;
+  // 本集合只缓存本 driver 亲手建过的 P2 room；任何拆房入口必须同步清掉。
+  readonly #messageRooms = new Set<string>();
 
   /**
    * 会话态注册表 —— 跟住户存储分开的一张表（#16 问 2 裁定）。
@@ -53,15 +54,48 @@ class MistDriver implements HarnessDriver {
    */
   readonly #sessions = new SessionRegistry<null>();
 
+  constructor(options: CreateDriverOptions = {}) {
+    this.#store = new ResidentStore(
+      options.dataDir === undefined ? undefined : { dataDir: options.dataDir },
+    );
+    this.#messageTreeStore = new MessageTreeStore();
+    this.#messageTree = new MessageTreeService(
+      this.#messageTreeStore,
+      {
+        getHead: (residentId) => this.#session(residentId).headId,
+        setHead: (residentId, headId) => this.#sessions.setHead(residentId, headId),
+      } satisfies SessionHeadPort,
+      { assistantReply: options.reply ?? ((_residentId, message) => `收到：${message}`) },
+    );
+    this.#migration = createResidentMigrationService(this.#store, this.#messageTreeStore);
+  }
+
   #session(residentId: string) {
     return this.#sessions.get(residentId) ?? this.#sessions.open(residentId, null, null);
+  }
+
+  #createMessageRoom(residentId: string): void {
+    this.#messageTreeStore.createRoom(residentId);
+    this.#messageRooms.add(residentId);
+  }
+
+  #ensureMessageRoom(residentId: string, unknownResident: "resident" | "tree" = "resident"): void {
+    if (this.#messageRooms.has(residentId)) return;
+    if (!this.#store.has(residentId)) {
+      if (unknownResident === "tree") {
+        this.#messageTreeStore.history(residentId);
+      }
+      this.#store.room(residentId);
+    }
+    // 住户回来了，消息房间补一个空房间；对话树不伪装恢复。
+    this.#createMessageRoom(residentId);
   }
 
   // --- P1：记忆库存储（本 issue 的认领范围）---
 
   async createResident(name: string): Promise<string> {
     const residentId = this.#store.createResident(name);
-    this.#messageTreeStore.createRoom(residentId);
+    this.#createMessageRoom(residentId);
     return residentId;
   }
 
@@ -82,24 +116,34 @@ class MistDriver implements HarnessDriver {
   }
 
   async destroyResident(residentId: string): Promise<void> {
+    if (!this.#store.has(residentId)) {
+      this.#sessions.kill(residentId);
+      this.#messageRooms.delete(residentId);
+      this.#messageTreeStore.destroyRoom(residentId);
+      this.#store.destroyResident(residentId);
+      return;
+    }
     this.#sessions.kill(residentId);
-    this.#messageTreeStore.destroyRoom(residentId);
+    if (this.#messageRooms.delete(residentId)) {
+      this.#messageTreeStore.destroyRoom(residentId);
+    }
     this.#store.destroyResident(residentId);
   }
 
   // --- P2：消息树 ---
 
   async say(residentId: string, message: string): Promise<HistoryNode> {
-    this.#store.room(residentId);
+    this.#ensureMessageRoom(residentId);
     return this.#messageTree.say(residentId, message);
   }
 
   async history(residentId: string): Promise<HistoryNode[]> {
+    this.#ensureMessageRoom(residentId, "tree");
     return this.#messageTree.history(residentId);
   }
 
   async reviseNode(residentId: string, nodeId: string, newContent: string): Promise<HistoryNode> {
-    this.#store.room(residentId);
+    this.#ensureMessageRoom(residentId);
     return this.#messageTree.reviseNode(residentId, nodeId, newContent);
   }
 
@@ -123,16 +167,19 @@ class MistDriver implements HarnessDriver {
   // --- P5：迁移 ---
 
   async exportResident(residentId: string): Promise<Uint8Array> {
+    this.#ensureMessageRoom(residentId);
     return this.#migration.exportResident(residentId);
   }
 
   async importResident(pack: Uint8Array): Promise<string> {
-    return this.#migration.importResident(pack);
+    const residentId = await this.#migration.importResident(pack);
+    this.#messageRooms.add(residentId);
+    return residentId;
   }
 }
 
-export function createDriver(): HarnessDriver {
-  return new MistDriver();
+export function createDriver(options: CreateDriverOptions = {}): HarnessDriver {
+  return new MistDriver(options);
 }
 
 /**

--- a/tests/acceptance-driver-options.test.ts
+++ b/tests/acceptance-driver-options.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDriver } from "../src/acceptance-driver.ts";
+import { MessageTreeError } from "../src/message-tree/index.ts";
+import { decodeResidentExportM0 } from "../src/migration/resident-migration.ts";
+import { ResidentNotFoundError } from "../src/store/resident-store.ts";
+
+const dirs: string[] = [];
+
+function freshDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "mist-driver-"));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("acceptance driver opts", () => {
+  it("默认不传 opts 时保留原哑回应", async () => {
+    const driver = createDriver();
+    const residentId = await driver.createResident("default");
+
+    const reply = await driver.say(residentId, "你好");
+
+    expect(reply.content).toBe("收到：你好");
+  });
+
+  it("默认不传 opts 时 driver 全路径不在当前目录写文件", async () => {
+    const cwd = process.cwd();
+    const workDir = freshDir();
+    process.chdir(workDir);
+    try {
+      const driver = createDriver();
+      const residentId = await driver.createResident("memory-only");
+      await driver.remember(residentId, "只在内存");
+      await driver.commit(residentId, "答应过不落盘");
+      await driver.say(residentId, "默认路径");
+      await driver.history(residentId);
+      await driver.buildBootPack(residentId);
+      await driver.exportResident(residentId);
+      await driver.killSession(residentId);
+      await driver.destroyResident(residentId);
+
+      expect(readdirSync(workDir)).toEqual([]);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it("未知住户错误来源保持默认路径原语义", async () => {
+    const driver = createDriver();
+
+    await expect(driver.history("ghost")).rejects.toThrow(MessageTreeError);
+    await expect(driver.destroyResident("ghost")).rejects.toThrow(MessageTreeError);
+    await expect(driver.say("ghost", "hi")).rejects.toThrow(ResidentNotFoundError);
+    await expect(driver.reviseNode("ghost", "node", "hi")).rejects.toThrow(ResidentNotFoundError);
+    await expect(driver.exportResident("ghost")).rejects.toThrow(ResidentNotFoundError);
+  });
+
+  it("reply 注入支持 async 回应并写进消息树", async () => {
+    const driver = createDriver({
+      reply: async (residentId, message) => `脑子:${residentId}:${message}`,
+    });
+    const residentId = await driver.createResident("reply");
+
+    const reply = await driver.say(residentId, "开门");
+    const history = await driver.history(residentId);
+
+    expect(reply.content).toBe(`脑子:${residentId}:开门`);
+    expect(history.map((node) => node.content)).toContain(`脑子:${residentId}:开门`);
+    expect(history.map((node) => node.content)).not.toContain("[object Promise]");
+  });
+
+  it("dataDir 重启后读回住户态，但不伪装恢复消息树", async () => {
+    const dataDir = freshDir();
+    const first = createDriver({ dataDir });
+    const residentId = await first.createResident("persisted");
+    await first.remember(residentId, "记得我是谁");
+    await first.commit(residentId, "答应过开灯");
+    await first.say(residentId, "重启前的话");
+    expect(readdirSync(dataDir).length).toBeGreaterThan(0);
+
+    const second = createDriver({ dataDir });
+
+    expect((await second.recall(residentId, "记得")).map((entry) => entry.content)).toEqual([
+      "记得我是谁",
+    ]);
+    expect((await second.buildBootPack(residentId)).commitments).toEqual(["答应过开灯"]);
+    expect(await second.history(residentId)).toEqual([]);
+  });
+
+  it("dataDir 恢复出的住户第一句 say 从新根开始", async () => {
+    const dataDir = freshDir();
+    const first = createDriver({ dataDir });
+    const residentId = await first.createResident("restart");
+    await first.remember(residentId, "重启后还在");
+
+    const second = createDriver({ dataDir });
+    const reply = await second.say(residentId, "重启后第一句");
+    const history = await second.history(residentId);
+    const user = history.find((node) => node.role === "user" && node.content === "重启后第一句");
+
+    expect(reply.content).toBe("收到：重启后第一句");
+    expect(user?.parentId).toBeNull();
+  });
+
+  it("dataDir 恢复出的住户可导出空消息树并可销毁", async () => {
+    const dataDir = freshDir();
+    const first = createDriver({ dataDir });
+    const residentId = await first.createResident("quiet");
+    await first.remember(residentId, "只写住户态");
+    expect(readdirSync(dataDir).length).toBeGreaterThan(0);
+
+    const second = createDriver({ dataDir });
+    const pack = decodeResidentExportM0(await second.exportResident(residentId));
+    expect(pack.history).toEqual([]);
+
+    await expect(second.destroyResident(residentId)).resolves.toBeUndefined();
+    expect(readdirSync(dataDir)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #30.

- add `createDriver(opts?)` with `dataDir` and `reply` injection
- keep default `createDriver()` behavior on the acceptance path unchanged
- lazily create an empty message room for residents restored from `dataDir`, so rebooted residents can speak from a new root without pretending the old P2 tree survived
- add regression tests for async reply injection, `dataDir` disk-backed round-trip restore, restored empty history, restored first `say`, export, destroy, default-path zero file IO, and default unknown-resident error sources

## Boundary

This implements the A boundary from #30: reboot preserves resident state (memories / commitments / errata) through `ResidentStore`, but it does not persist P2 history or P4 session head. After restart, the resident is alive and the conversation starts from a new root.

## Validation

- `npm run lint` -> clean
- `npm run typecheck` -> clean
- `npm test` -> 136 passed
- `npm run acceptance` -> true green 6/6
- default acceptance output compared against `origin/main` -> empty diff

## Extra probes

- async `reply` is awaited and written into the assistant node, not `[object Promise]`
- `dataDir` writes a real snapshot before the second driver is created, and the second driver reads back memory + commitment
- restored resident `history()` is `[]` before new speech
- restored resident first `say()` succeeds and starts at `parentId: null`
- restored resident can be exported with empty history and destroyed from snapshot file to empty directory
- default `createDriver()` full driver path leaves a temp current directory empty
- unknown-resident error source stays aligned with the pre-E1 default path (`history` / `destroyResident` from message tree; `say` / `reviseNode` / `exportResident` from resident store)

## Probe notes for reviewers

Cat ran five probe rounds against this change. Four probe attempts were caught by the new tests: ignoring `dataDir`, ignoring injected `reply`, skipping restored-room creation, and faking restored history. The fifth probe found a test gap: the original round-trip test proved two drivers could see the same state, but did not prove that state was actually written to `dataDir`. This PR now asserts that a real snapshot exists before constructing the second driver.
