### PR TITLE
E3: add persistent Kimi Web demo server

### DIFF
--- a/demo/adapters/anthropic.ts
+++ b/demo/adapters/anthropic.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from "node:crypto";
+import type { DemoChatAdapter } from "../server.ts";
+import {
+  adapterContext,
+  jsonResponse,
+  parseContext,
+  parseMessages,
+  recordOf,
+  sseResponse,
+} from "./shared.ts";
+
+function event(name: string, data: Record<string, unknown>): string {
+  return `event: ${name}\ndata: ${JSON.stringify(data)}`;
+}
+
+export const anthropicMessagesAdapter: DemoChatAdapter = {
+  matches: ({ method, url }) =>
+    method === "POST" && new URL(url, "http://127.0.0.1").pathname === "/v1/messages",
+  parseRequest(body) {
+    const envelope = recordOf(body);
+    return {
+      messages: parseMessages(envelope.messages),
+      context: parseContext(envelope),
+    };
+  },
+  formatReply(assistantContent, parsed) {
+    const { model, stream } = adapterContext(parsed.context);
+    const id = `msg_${randomUUID()}`;
+    if (!stream) {
+      return jsonResponse({
+        id,
+        type: "message",
+        role: "assistant",
+        model,
+        content: [{ type: "text", text: assistantContent }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      });
+    }
+
+    return sseResponse([
+      event("message_start", {
+        type: "message_start",
+        message: {
+          id,
+          type: "message",
+          role: "assistant",
+          model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      }),
+      event("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      event("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: assistantContent },
+      }),
+      event("content_block_stop", { type: "content_block_stop", index: 0 }),
+      event("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 0 },
+      }),
+      event("message_stop", { type: "message_stop" }),
+    ]);
+  },
+};

--- a/demo/adapters/openai.ts
+++ b/demo/adapters/openai.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "node:crypto";
+import type { DemoChatAdapter } from "../server.ts";
+import {
+  adapterContext,
+  jsonResponse,
+  parseContext,
+  parseMessages,
+  recordOf,
+  sseResponse,
+} from "./shared.ts";
+
+function completionBase(model: string) {
+  return {
+    id: `chatcmpl-${randomUUID()}`,
+    created: Math.floor(Date.now() / 1000),
+    model,
+  };
+}
+
+export const openAiChatCompletionsAdapter: DemoChatAdapter = {
+  matches: ({ method, url }) =>
+    method === "POST" && new URL(url, "http://127.0.0.1").pathname === "/v1/chat/completions",
+  parseRequest(body) {
+    const envelope = recordOf(body);
+    return {
+      messages: parseMessages(envelope.messages),
+      context: parseContext(envelope),
+    };
+  },
+  formatReply(assistantContent, parsed) {
+    const { model, stream } = adapterContext(parsed.context);
+    const base = completionBase(model);
+    if (!stream) {
+      return jsonResponse({
+        ...base,
+        object: "chat.completion",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: assistantContent },
+            finish_reason: "stop",
+          },
+        ],
+      });
+    }
+
+    const content = JSON.stringify({
+      ...base,
+      object: "chat.completion.chunk",
+      choices: [
+        {
+          index: 0,
+          delta: { role: "assistant", content: assistantContent },
+          finish_reason: null,
+        },
+      ],
+    });
+    const finished = JSON.stringify({
+      ...base,
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    });
+    return sseResponse([`data: ${content}`, `data: ${finished}`, "data: [DONE]"]);
+  },
+};

--- a/demo/adapters/shared.ts
+++ b/demo/adapters/shared.ts
@@ -1,0 +1,70 @@
+import type { DemoMessage } from "../server.ts";
+
+export interface AdapterContext {
+  model: string;
+  stream: boolean;
+}
+
+export function recordOf(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("expected an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function textContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+
+  return value
+    .map((part) => {
+      const block = recordOf(part);
+      if (block.type !== "text" || typeof block.text !== "string") return "";
+      return block.text;
+    })
+    .join("");
+}
+
+export function parseMessages(value: unknown): DemoMessage[] {
+  if (!Array.isArray(value)) throw new TypeError("messages must be an array");
+  return value.map((item) => {
+    const message = recordOf(item);
+    if (typeof message.role !== "string") throw new TypeError("message role is required");
+    return { role: message.role, content: textContent(message.content) };
+  });
+}
+
+export function parseContext(body: Record<string, unknown>): AdapterContext {
+  if (body.stream !== undefined && typeof body.stream !== "boolean") {
+    throw new TypeError("stream must be a boolean");
+  }
+  return {
+    model: typeof body.model === "string" && body.model.length > 0 ? body.model : "mist-demo",
+    stream: body.stream === true,
+  };
+}
+
+export function adapterContext(value: unknown): AdapterContext {
+  const context = recordOf(value);
+  if (typeof context.model !== "string" || typeof context.stream !== "boolean") {
+    throw new TypeError("invalid adapter context");
+  }
+  return { model: context.model, stream: context.stream };
+}
+
+export function jsonResponse(body: Record<string, unknown>) {
+  return {
+    headers: { "content-type": "application/json; charset=utf-8" },
+    body: JSON.stringify(body),
+  };
+}
+
+export function sseResponse(events: readonly string[]) {
+  return {
+    headers: {
+      "cache-control": "no-cache",
+      "content-type": "text/event-stream; charset=utf-8",
+    },
+    body: `${events.join("\n\n")}\n\n`,
+  };
+}

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,0 +1,75 @@
+import { anthropicMessagesAdapter } from "./adapters/anthropic.ts";
+import { openAiChatCompletionsAdapter } from "./adapters/openai.ts";
+import { createPersistentDemoRuntime } from "./runtime.ts";
+import { createDemoServer } from "./server.ts";
+
+interface CliOptions {
+  dataDir: string;
+  port: number;
+}
+
+function usage(): string {
+  return "Usage: npm run demo -- --data-dir <directory> [--port <0-65535>]";
+}
+
+function parsePort(value: string): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error("port must be an integer from 0 through 65535");
+  }
+  return port;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  let dataDir = process.env.MIST_DEMO_DATA_DIR ?? "";
+  let port = parsePort(process.env.MIST_DEMO_PORT ?? "4317");
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      process.stdout.write(`${usage()}\n`);
+      process.exit(0);
+    }
+    if (argument === "--data-dir") {
+      dataDir = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    if (argument === "--port") {
+      port = parsePort(argv[index + 1] ?? "");
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${argument}`);
+  }
+  if (dataDir.trim().length === 0) throw new Error("--data-dir is required");
+  return { dataDir, port };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const runtime = await createPersistentDemoRuntime({
+    dataDir: options.dataDir,
+    reply: async (_residentId, message) => `Mist 演示回应：${message}`,
+  });
+  const server = createDemoServer({
+    runtime,
+    adapters: [openAiChatCompletionsAdapter, anthropicMessagesAdapter],
+  });
+  const address = await server.start(options.port);
+  const { residentId } = runtime.inspect();
+  process.stdout.write(
+    `${JSON.stringify({ ok: true, host: address.address, port: address.port, residentId })}\n`,
+  );
+
+  const stop = async () => {
+    await server.stop();
+    process.exit(0);
+  };
+  process.once("SIGINT", () => void stop());
+  process.once("SIGTERM", () => void stop());
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/demo/runtime.ts
+++ b/demo/runtime.ts
@@ -1,0 +1,190 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import type { BootPack, HarnessDriver } from "../acceptance/driver.ts";
+import { type CreateDriverOptions, createDriver } from "../src/acceptance-driver.ts";
+import type { DemoResident, DemoRuntime } from "./server.ts";
+
+const STATE_SCHEMA_VERSION = 1;
+const STATE_FILE = "demo-state.json";
+const RESIDENTS_DIR = "residents";
+
+export interface DemoSeed {
+  name: string;
+  memories: readonly string[];
+  commitments: readonly string[];
+}
+
+export interface PersistentDemoRuntimeOptions {
+  /** Dedicated demo directory. It must not be shared with another Mist process. */
+  dataDir: string;
+  reply?: CreateDriverOptions["reply"];
+  seed?: DemoSeed;
+}
+
+export interface PersistentDemoInspection extends DemoResident {
+  driver: HarnessDriver;
+}
+
+export interface PersistentDemoRuntime extends DemoRuntime {
+  inspect(): PersistentDemoInspection;
+  bootPack(): Promise<BootPack>;
+}
+
+interface DemoState {
+  schemaVersion: number;
+  residentId: string;
+}
+
+const DEFAULT_SEED: DemoSeed = {
+  name: "Mist 演示住户",
+  memories: ["我住在一间编造的演示房间。"],
+  commitments: ["每次醒来先确认自己是谁。"],
+};
+
+function statePath(dataDir: string): string {
+  return join(dataDir, STATE_FILE);
+}
+
+function residentDataDir(dataDir: string): string {
+  return join(dataDir, RESIDENTS_DIR);
+}
+
+function parseState(path: string): DemoState {
+  const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("demo state must be an object");
+  }
+  const state = value as Record<string, unknown>;
+  const keys = Object.keys(state).sort();
+  if (keys.join(",") !== "residentId,schemaVersion") {
+    throw new Error("demo state has unknown or missing fields");
+  }
+  if (state.schemaVersion !== STATE_SCHEMA_VERSION) {
+    throw new Error(`unsupported demo state schema: ${String(state.schemaVersion)}`);
+  }
+  if (typeof state.residentId !== "string" || !/^resident-[a-z0-9]+$/.test(state.residentId)) {
+    throw new Error("demo state has an invalid residentId");
+  }
+  return { schemaVersion: STATE_SCHEMA_VERSION, residentId: state.residentId };
+}
+
+function persistState(dataDir: string, residentId: string): void {
+  const finalPath = statePath(dataDir);
+  const temporaryPath = `${finalPath}.tmp`;
+  const body = JSON.stringify({ schemaVersion: STATE_SCHEMA_VERSION, residentId });
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(temporaryPath, "w", 0o600);
+    writeSync(descriptor, body);
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = null;
+    renameSync(temporaryPath, finalPath);
+  } catch (error) {
+    if (descriptor !== null) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        // Preserve the original write/rename failure.
+      }
+    }
+    rmSync(temporaryPath, { force: true });
+    throw error;
+  }
+}
+
+function openDriver(dataDir: string, reply: CreateDriverOptions["reply"]): HarnessDriver {
+  const options: CreateDriverOptions = { dataDir: residentDataDir(dataDir) };
+  if (reply !== undefined) options.reply = reply;
+  return createDriver(options);
+}
+
+async function seedResident(driver: HarnessDriver, seed: DemoSeed): Promise<string> {
+  const residentId = await driver.createResident(seed.name);
+  try {
+    for (const memory of seed.memories) await driver.remember(residentId, memory);
+    for (const commitment of seed.commitments) await driver.commit(residentId, commitment);
+  } catch (error) {
+    await driver.destroyResident(residentId);
+    throw error;
+  }
+  return residentId;
+}
+
+function removeOrphanSnapshots(dataDir: string, residentId: string): void {
+  const residents = residentDataDir(dataDir);
+  for (const file of readdirSync(residents)) {
+    if (file.endsWith(".tmp")) {
+      rmSync(join(residents, file), { force: true });
+      continue;
+    }
+    if (file.endsWith(".json") && file !== `${residentId}.json`) {
+      rmSync(join(residents, file), { force: true });
+    }
+  }
+}
+
+export async function createPersistentDemoRuntime(
+  options: PersistentDemoRuntimeOptions,
+): Promise<PersistentDemoRuntime> {
+  if (options.dataDir.trim().length === 0) throw new Error("dataDir is required");
+  const dataDir = resolve(options.dataDir);
+  const seed = options.seed ?? DEFAULT_SEED;
+  if (seed.name.trim().length === 0) throw new Error("seed name is required");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(residentDataDir(dataDir), { recursive: true });
+
+  const savedState = existsSync(statePath(dataDir)) ? parseState(statePath(dataDir)) : null;
+  let driver = openDriver(dataDir, options.reply);
+  let residentId: string;
+  if (savedState === null) {
+    const existingSnapshots = readdirSync(residentDataDir(dataDir)).filter((file) =>
+      file.endsWith(".json"),
+    );
+    if (existingSnapshots.length > 0) {
+      throw new Error("demo resident snapshots exist without demo-state.json");
+    }
+    residentId = await seedResident(driver, seed);
+    persistState(dataDir, residentId);
+  } else {
+    residentId = savedState.residentId;
+    await driver.buildBootPack(residentId);
+    // Only collect abandoned reset snapshots after the manifest target is
+    // proven readable. A bad pointer must fail closed without deleting data.
+    removeOrphanSnapshots(dataDir, residentId);
+  }
+
+  return {
+    current() {
+      return { driver, residentId };
+    },
+    inspect() {
+      return { driver, residentId };
+    },
+    bootPack() {
+      return driver.buildBootPack(residentId);
+    },
+    async reset() {
+      const previousDriver = driver;
+      const previousResidentId = residentId;
+      const nextResidentId = await seedResident(previousDriver, seed);
+      persistState(dataDir, nextResidentId);
+      residentId = nextResidentId;
+      await previousDriver.destroyResident(previousResidentId);
+      // Re-open from disk so reset exercises the same recovery path as a process restart.
+      driver = openDriver(dataDir, options.reply);
+      await driver.buildBootPack(residentId);
+    },
+  };
+}

--- a/demo/server.ts
+++ b/demo/server.ts
@@ -1,0 +1,294 @@
+import {
+  type IncomingHttpHeaders,
+  type IncomingMessage,
+  type ServerResponse,
+  createServer,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+
+const LOOPBACK_HOST = "127.0.0.1";
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
+
+export interface DemoMessage {
+  role: string;
+  content: string;
+}
+
+export interface DemoDriver {
+  say(residentId: string, message: string): Promise<{ content: string }>;
+  killSession(residentId: string): Promise<void>;
+}
+
+export interface DemoResident {
+  driver: DemoDriver;
+  residentId: string;
+}
+
+/**
+ * Demo runtime ownership stays outside the HTTP shell.
+ *
+ * E4 can replace both the driver and resident during reset without teaching this
+ * server how seed data is stored. Every request takes one current snapshot after
+ * entering the serial queue, so reset cannot leave a request with a mixed pair.
+ */
+export interface DemoRuntime {
+  current(): DemoResident;
+  reset(): Promise<void>;
+}
+
+export interface DemoRequestView {
+  method: string;
+  url: string;
+  headers: IncomingHttpHeaders;
+}
+
+export interface DemoHttpResponse {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: string | Uint8Array;
+}
+
+export interface DemoChatRequest {
+  messages: DemoMessage[];
+  context: unknown;
+}
+
+/**
+ * Wire formats are adapters, not demo state.
+ *
+ * An OpenAI, Anthropic, or Kimi-specific adapter may decode its own envelope,
+ * but it must hand the complete normalized message list to the core. The core
+ * alone chooses the latest user message, so a shell replaying old history never
+ * writes that history into Mist's authoritative tree.
+ */
+export interface DemoChatAdapter {
+  matches(request: DemoRequestView): boolean;
+  parseRequest(body: unknown, request: DemoRequestView): DemoChatRequest;
+  formatReply(
+    assistantContent: string,
+    parsed: DemoChatRequest,
+    request: DemoRequestView,
+  ): DemoHttpResponse;
+}
+
+export interface DemoServerOptions {
+  runtime: DemoRuntime;
+  adapters: readonly DemoChatAdapter[];
+  maxBodyBytes?: number;
+  onError?: (error: unknown) => void;
+}
+
+export interface DemoServer {
+  /** Starts on loopback only. No public-bind escape hatch is exposed. */
+  start(port: number): Promise<AddressInfo>;
+  stop(): Promise<void>;
+  address(): AddressInfo | null;
+}
+
+class BadRequestError extends Error {}
+class PayloadTooLargeError extends Error {}
+
+function requestView(request: IncomingMessage): DemoRequestView {
+  return {
+    method: request.method ?? "GET",
+    url: request.url ?? "/",
+    headers: request.headers,
+  };
+}
+
+function pathnameOf(url: string): string {
+  try {
+    return new URL(url, "http://127.0.0.1").pathname;
+  } catch {
+    return url;
+  }
+}
+
+function latestUserMessage(messages: readonly DemoMessage[]): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === "user" && typeof message.content === "string") {
+      const content = withoutKimiSystemReminders(message.content);
+      if (content.trim().length > 0) return content;
+    }
+  }
+  return null;
+}
+
+function withoutKimiSystemReminders(content: string): string {
+  return content.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "");
+}
+
+function send(response: ServerResponse, value: DemoHttpResponse): void {
+  response.statusCode = value.status ?? 200;
+  for (const [name, headerValue] of Object.entries(value.headers ?? {})) {
+    response.setHeader(name, headerValue);
+  }
+  response.end(value.body);
+}
+
+function sendJson(response: ServerResponse, status: number, value: Record<string, unknown>): void {
+  send(response, {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+    body: JSON.stringify(value),
+  });
+}
+
+async function readJson(request: IncomingMessage, maxBodyBytes: number): Promise<unknown> {
+  const declaredLength = request.headers["content-length"];
+  if (declaredLength !== undefined) {
+    const parsed = Number(declaredLength);
+    if (!Number.isSafeInteger(parsed) || parsed < 0) throw new BadRequestError();
+    if (parsed > maxBodyBytes) throw new PayloadTooLargeError();
+  }
+
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.byteLength;
+    if (total > maxBodyBytes) throw new PayloadTooLargeError();
+    chunks.push(buffer);
+  }
+
+  if (total === 0) throw new BadRequestError();
+  try {
+    return JSON.parse(Buffer.concat(chunks, total).toString("utf8"));
+  } catch {
+    throw new BadRequestError();
+  }
+}
+
+function serialExecutor() {
+  let tail = Promise.resolve();
+  return async <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = tail.then(operation, operation);
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}
+
+export function createDemoServer(options: DemoServerOptions): DemoServer {
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  if (!Number.isSafeInteger(maxBodyBytes) || maxBodyBytes <= 0) {
+    throw new RangeError("maxBodyBytes must be a positive safe integer");
+  }
+  if (options.adapters.length === 0) {
+    throw new RangeError("at least one demo chat adapter is required");
+  }
+
+  const runSerial = serialExecutor();
+  const server = createServer((request, response) => {
+    void (async () => {
+      const view = requestView(request);
+      const pathname = pathnameOf(view.url);
+
+      if (pathname === "/demo/clear") {
+        if (view.method !== "POST") {
+          response.setHeader("allow", "POST");
+          sendJson(response, 405, { error: "method_not_allowed" });
+          return;
+        }
+        await runSerial(async () => {
+          const { driver, residentId } = options.runtime.current();
+          await driver.killSession(residentId);
+        });
+        response.statusCode = 204;
+        response.end();
+        return;
+      }
+
+      if (pathname === "/demo/reset") {
+        if (view.method !== "POST") {
+          response.setHeader("allow", "POST");
+          sendJson(response, 405, { error: "method_not_allowed" });
+          return;
+        }
+        await runSerial(() => options.runtime.reset());
+        response.statusCode = 204;
+        response.end();
+        return;
+      }
+
+      const adapter = options.adapters.find((candidate) => candidate.matches(view));
+      if (adapter === undefined) {
+        sendJson(response, 404, { error: "not_found" });
+        return;
+      }
+
+      const body = await readJson(request, maxBodyBytes);
+      let parsed: DemoChatRequest;
+      try {
+        parsed = adapter.parseRequest(body, view);
+      } catch {
+        throw new BadRequestError();
+      }
+      if (!Array.isArray(parsed.messages)) throw new BadRequestError();
+      const latest = latestUserMessage(parsed.messages);
+      if (latest === null) throw new BadRequestError();
+
+      const assistantContent = await runSerial(async () => {
+        const { driver, residentId } = options.runtime.current();
+        const reply = await driver.say(residentId, latest);
+        return reply.content;
+      });
+      send(response, adapter.formatReply(assistantContent, parsed, view));
+    })().catch((error: unknown) => {
+      if (response.headersSent) {
+        response.destroy();
+        return;
+      }
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: "payload_too_large" });
+        return;
+      }
+      if (error instanceof BadRequestError) {
+        sendJson(response, 400, { error: "bad_request" });
+        return;
+      }
+      options.onError?.(error);
+      sendJson(response, 500, { error: "internal_error" });
+    });
+  });
+
+  return {
+    start(port) {
+      if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+        return Promise.reject(new RangeError("port must be an integer from 0 through 65535"));
+      }
+      if (server.listening) return Promise.reject(new Error("demo server is already listening"));
+      return new Promise<AddressInfo>((resolve, reject) => {
+        const onError = (error: Error) => {
+          server.off("listening", onListening);
+          reject(error);
+        };
+        const onListening = () => {
+          server.off("error", onError);
+          const address = server.address();
+          if (address === null || typeof address === "string") {
+            reject(new Error("demo server did not expose a TCP address"));
+            return;
+          }
+          resolve(address);
+        };
+        server.once("error", onError);
+        server.once("listening", onListening);
+        server.listen({ host: LOOPBACK_HOST, port });
+      });
+    },
+    stop() {
+      if (!server.listening) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        server.close((error) => (error === undefined ? resolve() : reject(error)));
+      });
+    },
+    address() {
+      const address = server.address();
+      return address !== null && typeof address !== "string" ? address : null;
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=22"
   },
   "scripts": {
+    "demo": "tsx demo/main.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/tests/demo-adapters.test.ts
+++ b/tests/demo-adapters.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { anthropicMessagesAdapter } from "../demo/adapters/anthropic.ts";
+import { openAiChatCompletionsAdapter } from "../demo/adapters/openai.ts";
+import {
+  type DemoDriver,
+  type DemoRuntime,
+  type DemoServer,
+  createDemoServer,
+} from "../demo/server.ts";
+
+const servers: DemoServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.stop()));
+});
+
+async function start(reply = "Mist says hello") {
+  const say = vi.fn(async (_residentId: string, message: string) => ({
+    content: `${reply}:${message}`,
+  }));
+  const driver: DemoDriver = { say, killSession: vi.fn(async () => undefined) };
+  const runtime: DemoRuntime = {
+    current: () => ({ driver, residentId: "resident-demo" }),
+    reset: vi.fn(async () => undefined),
+  };
+  const server = createDemoServer({
+    runtime,
+    adapters: [openAiChatCompletionsAdapter, anthropicMessagesAdapter],
+  });
+  servers.push(server);
+  const address = await server.start(0);
+  return { say, baseUrl: `http://${address.address}:${address.port}` };
+}
+
+function eventNames(body: string): string[] {
+  return body
+    .split("\n")
+    .filter((line) => line.startsWith("event: "))
+    .map((line) => line.slice("event: ".length));
+}
+
+describe("demo provider adapters", () => {
+  it("serves OpenAI Chat Completions SSE and sends only the latest user text to Mist", async () => {
+    const { say, baseUrl } = await start();
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mist-openai-canary",
+        stream: true,
+        messages: [
+          { role: "user", content: "old shell history" },
+          { role: "assistant", content: null, tool_calls: [{ id: "old-tool" }] },
+          { role: "tool", content: { ignored: true } },
+          {
+            role: "user",
+            content: [{ type: "text", text: "latest OpenAI turn  " }],
+          },
+          {
+            role: "user",
+            content: "<system-reminder>\nKimi internal instruction\n</system-reminder>",
+          },
+        ],
+      }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+    expect(body).toContain('"model":"mist-openai-canary"');
+    expect(body).toContain('"content":"Mist says hello:latest OpenAI turn  "');
+    expect(body).toContain('"finish_reason":"stop"');
+    expect(body).toMatch(/data: \[DONE\]\n\n$/);
+    expect(say).toHaveBeenCalledOnce();
+    expect(say).toHaveBeenCalledWith("resident-demo", "latest OpenAI turn  ");
+  });
+
+  it("serves Anthropic Messages SSE through message_stop without an OpenAI sentinel", async () => {
+    const { say, baseUrl } = await start();
+    const response = await fetch(`${baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+        "x-api-key": "local-demo-placeholder",
+      },
+      body: JSON.stringify({
+        model: "mist-anthropic-canary",
+        stream: true,
+        max_tokens: 256,
+        messages: [
+          { role: "user", content: "old shell history" },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "latest Anthropic turn" },
+              {
+                type: "text",
+                text: "<system-reminder>internal Anthropic instruction</system-reminder>",
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(eventNames(body)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+    expect(body).toContain('"model":"mist-anthropic-canary"');
+    expect(body).toContain('"text":"Mist says hello:latest Anthropic turn"');
+    expect(body).not.toContain("[DONE]");
+    expect(body).toMatch(/event: message_stop\ndata: \{"type":"message_stop"\}\n\n$/);
+    expect(say).toHaveBeenCalledOnce();
+    expect(say).toHaveBeenCalledWith("resident-demo", "latest Anthropic turn");
+  });
+
+  it("returns provider-native JSON when streaming is disabled", async () => {
+    const { baseUrl } = await start("reply");
+    const openAi = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify({
+        model: "openai-json",
+        messages: [{ role: "user", content: "one" }],
+      }),
+    });
+    const anthropic = await fetch(`${baseUrl}/v1/messages`, {
+      method: "POST",
+      body: JSON.stringify({
+        model: "anthropic-json",
+        stream: false,
+        messages: [{ role: "user", content: "two" }],
+      }),
+    });
+
+    expect(await openAi.json()).toMatchObject({
+      object: "chat.completion",
+      model: "openai-json",
+      choices: [{ message: { role: "assistant", content: "reply:one" } }],
+    });
+    expect(await anthropic.json()).toMatchObject({
+      type: "message",
+      model: "anthropic-json",
+      content: [{ type: "text", text: "reply:two" }],
+      stop_reason: "end_turn",
+    });
+  });
+
+  it("rejects malformed provider envelopes before calling Mist", async () => {
+    const { say, baseUrl } = await start();
+    const badStream = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify({
+        stream: "yes",
+        messages: [{ role: "user", content: "must not run" }],
+      }),
+    });
+    const badMessages = await fetch(`${baseUrl}/v1/messages`, {
+      method: "POST",
+      body: JSON.stringify({ messages: "not-an-array" }),
+    });
+    const reminderOnly = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      body: JSON.stringify({
+        messages: [
+          {
+            role: "user",
+            content: "<system-reminder>internal only</system-reminder>",
+          },
+        ],
+      }),
+    });
+
+    expect(badStream.status).toBe(400);
+    expect(badMessages.status).toBe(400);
+    expect(reminderOnly.status).toBe(400);
+    expect(say).not.toHaveBeenCalled();
+  });
+});

--- a/tests/demo-runtime.test.ts
+++ b/tests/demo-runtime.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createPersistentDemoRuntime } from "../demo/runtime.ts";
+
+const dirs: string[] = [];
+
+function freshDir(): string {
+  const directory = mkdtempSync(join(tmpdir(), "mist-demo-runtime-"));
+  dirs.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of dirs.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+const seed = {
+  name: "编造的住户",
+  memories: ["记得纸船是蓝色的。"],
+  commitments: ["答应重启后仍认得纸船。"],
+};
+
+describe("persistent demo runtime", () => {
+  it("keeps identity and resident state across restart while opening a new message root", async () => {
+    const dataDir = freshDir();
+    const reply = async (_residentId: string, message: string) => `脑子:${message}`;
+    const first = await createPersistentDemoRuntime({ dataDir, reply, seed });
+    const firstResidentId = first.inspect().residentId;
+    await first.inspect().driver.say(firstResidentId, "重启前一句");
+
+    const second = await createPersistentDemoRuntime({ dataDir, reply, seed });
+    const secondResidentId = second.inspect().residentId;
+    const bootPack = await second.bootPack();
+    const answer = await second.inspect().driver.say(secondResidentId, "重启后第一句");
+    const history = await second.inspect().driver.history(secondResidentId);
+    const user = history.find((node) => node.role === "user");
+
+    expect(secondResidentId).toBe(firstResidentId);
+    expect(bootPack.identity).toBe(seed.name);
+    expect(bootPack.memories.map((memory) => memory.content)).toEqual(seed.memories);
+    expect(bootPack.commitments).toEqual(seed.commitments);
+    expect(answer.content).toBe("脑子:重启后第一句");
+    expect(user?.content).toBe("重启后第一句");
+    expect(user?.parentId).toBeNull();
+    expect(history.some((node) => node.content === "重启前一句")).toBe(false);
+  });
+
+  it("reset reseeds a new resident and removes the old snapshot", async () => {
+    const dataDir = freshDir();
+    const runtime = await createPersistentDemoRuntime({ dataDir, seed });
+    const oldResidentId = runtime.inspect().residentId;
+
+    await runtime.reset();
+
+    const newResidentId = runtime.inspect().residentId;
+    const snapshots = readdirSync(join(dataDir, "residents"));
+    expect(newResidentId).not.toBe(oldResidentId);
+    expect(snapshots).toEqual([`${newResidentId}.json`]);
+    expect((await runtime.bootPack()).memories.map((memory) => memory.content)).toEqual(
+      seed.memories,
+    );
+    const state = JSON.parse(readFileSync(join(dataDir, "demo-state.json"), "utf8"));
+    expect(state.residentId).toBe(newResidentId);
+  });
+
+  it("fails closed for corrupt state and for snapshots without an identity pointer", async () => {
+    const corrupt = freshDir();
+    writeFileSync(join(corrupt, "demo-state.json"), JSON.stringify({ schemaVersion: 99 }));
+    await expect(createPersistentDemoRuntime({ dataDir: corrupt, seed })).rejects.toThrow(
+      /unknown or missing fields/,
+    );
+
+    const orphaned = freshDir();
+    const first = await createPersistentDemoRuntime({ dataDir: orphaned, seed });
+    rmSync(join(orphaned, "demo-state.json"));
+    expect(first.inspect().residentId).toMatch(/^resident-/);
+    await expect(createPersistentDemoRuntime({ dataDir: orphaned, seed })).rejects.toThrow(
+      /snapshots exist without demo-state/,
+    );
+  });
+
+  it("does not collect snapshots when the identity pointer cannot be opened", async () => {
+    const dataDir = freshDir();
+    const first = await createPersistentDemoRuntime({ dataDir, seed });
+    const existingSnapshot = `${first.inspect().residentId}.json`;
+    writeFileSync(
+      join(dataDir, "demo-state.json"),
+      JSON.stringify({ schemaVersion: 1, residentId: "resident-missing" }),
+    );
+
+    await expect(createPersistentDemoRuntime({ dataDir, seed })).rejects.toThrow();
+    expect(readdirSync(join(dataDir, "residents"))).toContain(existingSnapshot);
+  });
+});

--- a/tests/demo-server.test.ts
+++ b/tests/demo-server.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type DemoChatAdapter,
+  type DemoDriver,
+  type DemoMessage,
+  type DemoRuntime,
+  type DemoServer,
+  createDemoServer,
+} from "../demo/server.ts";
+import { createDriver } from "../src/acceptance-driver.ts";
+
+const adapter: DemoChatAdapter = {
+  matches: ({ method, url }) => method === "POST" && url === "/wire/chat",
+  parseRequest: (body) => ({
+    messages: (body as { messages: DemoMessage[] }).messages,
+    context: null,
+  }),
+  formatReply: (content) => ({
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ content }),
+  }),
+};
+
+const servers: DemoServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.stop()));
+});
+
+async function start(runtime: DemoRuntime, options: { maxBodyBytes?: number } = {}) {
+  const server = createDemoServer({ runtime, adapters: [adapter], ...options });
+  servers.push(server);
+  const address = await server.start(0);
+  return { server, baseUrl: `http://${address.address}:${address.port}` };
+}
+
+describe("demo server core", () => {
+  it("only passes the latest user message to Mist", async () => {
+    const say = vi.fn(async (_residentId: string, message: string) => ({
+      content: `reply:${message}`,
+    }));
+    const driver: DemoDriver = { say, killSession: vi.fn(async () => undefined) };
+    const runtime: DemoRuntime = {
+      current: () => ({ driver, residentId: "resident-demo" }),
+      reset: vi.fn(async () => undefined),
+    };
+    const { baseUrl } = await start(runtime);
+
+    const response = await fetch(`${baseUrl}/wire/chat`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          { role: "user", content: "shell replay must be ignored" },
+          { role: "assistant", content: "old reply" },
+          { role: "user", content: "latest stays byte-for-byte  " },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ content: "reply:latest stays byte-for-byte  " });
+    expect(say).toHaveBeenCalledOnce();
+    expect(say).toHaveBeenCalledWith("resident-demo", "latest stays byte-for-byte  ");
+  });
+
+  it("clear uses the real driver's killSession and the next turn starts a new root", async () => {
+    const driver = createDriver();
+    const residentId = await driver.createResident("demo resident");
+    const runtime: DemoRuntime = {
+      current: () => ({ driver, residentId }),
+      reset: vi.fn(async () => undefined),
+    };
+    const { baseUrl } = await start(runtime);
+
+    for (const content of ["before clear one", "before clear two"]) {
+      expect(
+        await fetch(`${baseUrl}/wire/chat`, {
+          method: "POST",
+          body: JSON.stringify({ messages: [{ role: "user", content }] }),
+        }),
+      ).toHaveProperty("status", 200);
+    }
+
+    const clearResponse = await fetch(`${baseUrl}/demo/clear`, { method: "POST" });
+    expect(clearResponse.status).toBe(204);
+    await fetch(`${baseUrl}/wire/chat`, {
+      method: "POST",
+      body: JSON.stringify({ messages: [{ role: "user", content: "after clear" }] }),
+    });
+
+    const afterClear = (await driver.history(residentId)).find(
+      (node) => node.role === "user" && node.content === "after clear",
+    );
+    expect(afterClear?.parentId).toBeNull();
+  });
+
+  it("reset is serialized and subsequent chat uses the reseeded resident", async () => {
+    const calls: string[] = [];
+    const driver: DemoDriver = {
+      say: vi.fn(async (residentId, message) => {
+        calls.push(`${residentId}:${message}`);
+        return { content: "ok" };
+      }),
+      killSession: vi.fn(async () => undefined),
+    };
+    let residentId = "resident-old";
+    const runtime: DemoRuntime = {
+      current: () => ({ driver, residentId }),
+      reset: vi.fn(async () => {
+        residentId = "resident-reseeded";
+      }),
+    };
+    const { baseUrl } = await start(runtime);
+
+    const resetResponse = await fetch(`${baseUrl}/demo/reset`, { method: "POST" });
+    expect(resetResponse.status).toBe(204);
+    await fetch(`${baseUrl}/wire/chat`, {
+      method: "POST",
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    });
+
+    expect(runtime.reset).toHaveBeenCalledOnce();
+    expect(calls).toEqual(["resident-reseeded:hello"]);
+  });
+
+  it("binds only to IPv4 loopback", async () => {
+    const driver: DemoDriver = {
+      say: vi.fn(async () => ({ content: "ok" })),
+      killSession: vi.fn(async () => undefined),
+    };
+    const { server } = await start({
+      current: () => ({ driver, residentId: "resident-demo" }),
+      reset: vi.fn(async () => undefined),
+    });
+
+    expect(server.address()?.address).toBe("127.0.0.1");
+  });
+
+  it("rejects missing user content, malformed JSON, and oversized bodies before say", async () => {
+    const say = vi.fn(async () => ({ content: "must not run" }));
+    const driver: DemoDriver = { say, killSession: vi.fn(async () => undefined) };
+    const { baseUrl } = await start(
+      {
+        current: () => ({ driver, residentId: "resident-demo" }),
+        reset: vi.fn(async () => undefined),
+      },
+      { maxBodyBytes: 128 },
+    );
+
+    const noUser = await fetch(`${baseUrl}/wire/chat`, {
+      method: "POST",
+      body: JSON.stringify({ messages: [{ role: "assistant", content: "only assistant" }] }),
+    });
+    const malformed = await fetch(`${baseUrl}/wire/chat`, { method: "POST", body: "{" });
+    const oversized = await fetch(`${baseUrl}/wire/chat`, {
+      method: "POST",
+      body: JSON.stringify({ messages: [{ role: "user", content: "x".repeat(256) }] }),
+    });
+
+    expect(noUser.status).toBe(400);
+    expect(malformed.status).toBe(400);
+    expect(oversized.status).toBe(413);
+    expect(say).not.toHaveBeenCalled();
+  });
+
+  it("keeps management methods narrow and returns 404 for unknown routes", async () => {
+    const driver: DemoDriver = {
+      say: vi.fn(async () => ({ content: "ok" })),
+      killSession: vi.fn(async () => undefined),
+    };
+    const { baseUrl } = await start({
+      current: () => ({ driver, residentId: "resident-demo" }),
+      reset: vi.fn(async () => undefined),
+    });
+
+    const clearGet = await fetch(`${baseUrl}/demo/clear`);
+    const resetGet = await fetch(`${baseUrl}/demo/reset`);
+    const unknown = await fetch(`${baseUrl}/unknown`);
+
+    expect(clearGet.status).toBe(405);
+    expect(clearGet.headers.get("allow")).toBe("POST");
+    expect(resetGet.status).toBe(405);
+    expect(unknown.status).toBe(404);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.ts", "acceptance/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts", "acceptance/**/*.ts", "demo/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
Closes #32

## What

- add a loopback-only demo HTTP server with OpenAI Chat Completions and Anthropic Messages adapters
- pass only the latest real user message into Mist; Kimi shell history and injected system reminders do not enter the resident tree
- wire `/demo/clear` to `killSession` and `/demo/reset` to a persistent, atomically pointed demo resident
- preserve resident identity, memories, and commitments across process restart while starting a fresh message root
- reject malformed/oversized requests and expose no public-bind escape hatch

## Evidence

- `npm run lint`
- `npm run typecheck`
- `npm test`: 150/150
- `npm run acceptance`: 6/6 true green
- real Kimi Web `sessions -> prompts -> messages` canary completed through both provider shapes with exact fabricated reply readback
- process restart canary kept the same resident/boot pack and opened the next message at a new root

No new dependency, no acceptance-file change, and no private resident/chat data. Local internal review passed before this branch was pushed.
## Full terminal evidence

All text below is fabricated demo content. UUIDs, timestamps, and the temporary path are redacted only for readability.

### Start, talk twice, clear, then talk on the new root

```text
$ npm run demo -- --data-dir <temp-demo-dir> --port 19032
> mist-agent@0.0.0 demo
> tsx demo/main.ts --data-dir <temp-demo-dir> --port 19032
{"ok":true,"host":"127.0.0.1","port":19032,"residentId":"resident-000001"}

$ curl -sS http://127.0.0.1:19032/v1/chat/completions \
    -H 'content-type: application/json' \
    -d '{"model":"mist-demo","stream":false,"messages":[{"role":"user","content":"编造的壳历史，不应进 Mist"},{"role":"assistant","content":"编造的旧回答"},{"role":"user","content":"第一句：纸船是蓝色"}]}'
{"id":"chatcmpl-<uuid>","created":<unix-seconds>,"model":"mist-demo","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Mist 演示回应：第一句：纸船是蓝色"},"finish_reason":"stop"}]}

$ curl -sS http://127.0.0.1:19032/v1/messages \
    -H 'content-type: application/json' \
    -H 'x-api-key: local-demo-placeholder' \
    -d '{"model":"mist-demo","stream":false,"max_tokens":128,"messages":[{"role":"user","content":"第二句：答应记住纸船"}]}'
{"id":"msg_<uuid>","type":"message","role":"assistant","model":"mist-demo","content":[{"type":"text","text":"Mist 演示回应：第二句：答应记住纸船"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}

$ curl -sS -o /dev/null -w 'clear_http=%{http_code}\n' \
    -X POST http://127.0.0.1:19032/demo/clear
clear_http=204

$ curl -sS http://127.0.0.1:19032/v1/chat/completions \
    -H 'content-type: application/json' \
    -d '{"model":"mist-demo","stream":false,"messages":[{"role":"user","content":"清空后的新根"}]}'
{"id":"chatcmpl-<uuid>","created":<unix-seconds>,"model":"mist-demo","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Mist 演示回应：清空后的新根"},"finish_reason":"stop"}]}

$ # Ctrl-C: stop the demo process
^C
```

The focused real-driver test asserts that the user node created by the last request has `parentId === null`.

### Reopen the persisted resident, inspect the boot pack, and talk again

```text
$ npx tsx -e '<open createPersistentDemoRuntime on the same temp dir; print boot pack and history count>'
{"residentId":"resident-000001","identity":"Mist 演示住户","memories":["我住在一间编造的演示房间。"],"commitments":["每次醒来先确认自己是谁。"],"historyNodes":0}

$ npm run demo -- --data-dir <same-temp-demo-dir> --port 19032
> mist-agent@0.0.0 demo
> tsx demo/main.ts --data-dir <same-temp-demo-dir> --port 19032
{"ok":true,"host":"127.0.0.1","port":19032,"residentId":"resident-000001"}

$ curl -sS http://127.0.0.1:19032/v1/chat/completions \
    -H 'content-type: application/json' \
    -d '{"model":"mist-demo","stream":false,"messages":[{"role":"user","content":"重启后的第一句"}]}'
{"id":"chatcmpl-<uuid>","created":<unix-seconds>,"model":"mist-demo","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Mist 演示回应：重启后的第一句"},"finish_reason":"stop"}]}

$ # Ctrl-C, then verify no canary listener remains
^C
```

This is the requested start → two chats → clear → new-root chat → process death → reopen → same resident/boot-pack → chat sequence. The separate real Kimi Web provider canary in the Evidence summary exercised both SSE envelopes through `sessions -> prompts -> messages`.
