### PR TITLE
demo: 修复实测四虫（B1 并发锁 / B2 快照 0600 / B3 未登录 503 / B4 控制路由 token）

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ kimi web
 几个动作不要混淆：
 
 - Kimi Web 的 `/clear`（也叫 `/new`）清掉聊天壳的当前上下文。
-- `POST /demo/clear` 杀掉 Mist 当前会话，但不删住户、记忆或承诺。
+- `POST /demo/clear` 杀掉 Mist 当前会话，但不删住户、记忆或承诺。这条和 `/demo/reset`
+  都要带启动行里打印的 `controlToken`（`Authorization: Bearer <controlToken>`），
+  每次启动都会换；裸打会收到 401，这不是坏了。
 - `Ctrl-C` 后重新运行 `npm run demo` 会重建服务；`residentId` 应保持相同，对话从新根开始。
 - `POST /demo/reset` 是重置整位演示住户，不属于连续性验收。
 

--- a/demo/CHECKLIST.md
+++ b/demo/CHECKLIST.md
@@ -20,6 +20,7 @@ Mist 的启动包里认得自己的长期状态。
 - Node.js：`________________`
 - Kimi Code：`________________`
 - Mist 启动行里的 `residentId`：`________________`
+- Mist 启动行里的 `controlToken`：`________________`（每次启动都会换，照抄本次的）
 
 确认下面三项后再继续：
 
@@ -50,13 +51,14 @@ Mist 的启动包里认得自己的长期状态。
 
 ## 3. 杀掉 Mist 会话
 
-在另一个终端运行：
+在另一个终端运行（把 `<controlToken>` 换成第 0 步记下的那串）：
 
 ```bash
-curl -i -X POST http://127.0.0.1:4317/demo/clear
+curl -i -X POST http://127.0.0.1:4317/demo/clear -H "Authorization: Bearer <controlToken>"
 ```
 
-应看到 `HTTP/1.1 204 No Content`。然后在 Kimi Web 再输入一次 `/clear`，依次发送三条探针。
+应看到 `HTTP/1.1 204 No Content`。如果看到 401，是 token 没带或带错，回第 0 步核对。
+然后在 Kimi Web 再输入一次 `/clear`，依次发送三条探针。
 
 - [ ] HTTP 返回 204。
 - [ ] P1 逐字命中。
@@ -68,7 +70,8 @@ curl -i -X POST http://127.0.0.1:4317/demo/clear
 ## 4. 杀进程再重开
 
 1. 先发送：`这句话只属于旧会话：蓝色纸船。请只回复收到。`
-2. 回到运行 Mist 的终端，按 `Ctrl-C`。
+2. 回到运行 Mist 的终端，按 `Ctrl-C`。**必须在跑 Mist 的那个终端里按**——从别的终端
+   kill 单个 pid 会留下孤儿子进程还持着锁，下次启动会被自己的陈尸挡在门外。
 3. 再运行 `npm run demo`，记下新的启动行。
 4. 确认新启动行里的 `residentId` 与第 0 步完全相同。
 5. 在 Kimi Web 输入 `/clear`，再问：`上一轮临时说的颜色是什么？如果启动包里没有相关记录，只回复两个汉字：未知。回复中不要包含标点。`

--- a/demo/brain-claude.ts
+++ b/demo/brain-claude.ts
@@ -21,6 +21,7 @@ export interface ClaudeQueryMessage {
   subtype?: string;
   result?: string;
   errors?: string[];
+  error?: string;
 }
 
 export type ClaudeQueryRunner = (request: ClaudeQueryRequest) => AsyncIterable<ClaudeQueryMessage>;
@@ -44,7 +45,22 @@ export class ClaudeBrainError extends Error {
   }
 }
 
+export class ClaudeAuthenticationError extends ClaudeBrainError {
+  constructor() {
+    super("Claude Agent SDK is not authenticated; run /login before using the demo");
+    this.name = "ClaudeAuthenticationError";
+  }
+}
+
 const defaultQueryRunner: ClaudeQueryRunner = (request) => query(request);
+
+function isAuthenticationFailureText(value: string): boolean {
+  const normalized = value.trim();
+  return (
+    normalized === "authentication_failed" ||
+    /(?:^|:\s*)Not logged in(?:\s*[·:—-]\s*Please run \/login)?$/i.test(normalized)
+  );
+}
 
 /**
  * 生成 E1 约定的 reply(residentId, message)。
@@ -58,21 +74,37 @@ export function createClaudeReply(options: CreateClaudeReplyOptions): AssistantR
     const bootPack = await options.buildBootPack(residentId);
     const queryOptions = buildClaudeQueryOptions(bootPack, options.model);
 
-    for await (const event of runQuery({ prompt: message, options: queryOptions })) {
-      if (event.type !== "result") continue;
+    try {
+      for await (const event of runQuery({ prompt: message, options: queryOptions })) {
+        if (event.type === "assistant" && event.error === "authentication_failed") {
+          throw new ClaudeAuthenticationError();
+        }
+        if (event.type !== "result") continue;
 
-      if (event.subtype === "success") {
-        const reply = event.result?.trim();
-        if (reply) return reply;
-        throw new ClaudeBrainError("Claude Agent SDK returned an empty reply");
+        if (event.subtype === "success") {
+          const reply = event.result?.trim();
+          if (reply !== undefined && isAuthenticationFailureText(reply)) {
+            throw new ClaudeAuthenticationError();
+          }
+          if (reply) return reply;
+          throw new ClaudeBrainError("Claude Agent SDK returned an empty reply");
+        }
+
+        const errors = event.errors?.filter(Boolean) ?? [];
+        if (errors.some(isAuthenticationFailureText)) throw new ClaudeAuthenticationError();
+        const detail = errors.join("; ");
+        throw new ClaudeBrainError(
+          detail
+            ? `Claude Agent SDK failed (${event.subtype ?? "unknown"}): ${detail}`
+            : `Claude Agent SDK failed (${event.subtype ?? "unknown"})`,
+        );
       }
-
-      const detail = event.errors?.filter(Boolean).join("; ");
-      throw new ClaudeBrainError(
-        detail
-          ? `Claude Agent SDK failed (${event.subtype ?? "unknown"}): ${detail}`
-          : `Claude Agent SDK failed (${event.subtype ?? "unknown"})`,
-      );
+    } catch (error) {
+      if (error instanceof ClaudeBrainError) throw error;
+      if (error instanceof Error && isAuthenticationFailureText(error.message)) {
+        throw new ClaudeAuthenticationError();
+      }
+      throw error;
     }
 
     throw new ClaudeBrainError("Claude Agent SDK ended without a result message");

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -84,18 +84,30 @@ async function main(): Promise<void> {
     runtime,
     adapters: [openAiChatCompletionsAdapter, anthropicMessagesAdapter],
   });
-  const address = await server.start(options.port);
-  const { residentId } = runtime.inspect();
-  process.stdout.write(
-    `${JSON.stringify({ ok: true, host: address.address, port: address.port, residentId })}\n`,
-  );
+  try {
+    const address = await server.start(options.port);
+    const { residentId } = runtime.inspect();
+    process.stdout.write(
+      `${JSON.stringify({
+        ok: true,
+        host: address.address,
+        port: address.port,
+        residentId,
+        controlToken: server.controlToken,
+      })}\n`,
+    );
 
-  const stop = async () => {
-    await server.stop();
-    process.exit(0);
-  };
-  process.once("SIGINT", () => void stop());
-  process.once("SIGTERM", () => void stop());
+    const stop = async () => {
+      await server.stop();
+      runtime.close();
+      process.exit(0);
+    };
+    process.once("SIGINT", () => void stop());
+    process.once("SIGTERM", () => void stop());
+  } catch (error) {
+    runtime.close();
+    throw error;
+  }
 }
 
 const invokedPath =

--- a/demo/runtime.ts
+++ b/demo/runtime.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "node:crypto";
 import {
   closeSync,
   existsSync,
+  fchmodSync,
   fsyncSync,
   mkdirSync,
   openSync,
@@ -10,6 +12,7 @@ import {
   rmSync,
   writeSync,
 } from "node:fs";
+import { hostname } from "node:os";
 import { join, resolve } from "node:path";
 import type { BootPack, HarnessDriver } from "../acceptance/driver.ts";
 import { type CreateDriverOptions, createDriver } from "../src/acceptance-driver.ts";
@@ -18,6 +21,7 @@ import type { DemoResident, DemoRuntime } from "./server.ts";
 
 const STATE_SCHEMA_VERSION = 2;
 const STATE_FILE = "demo-state.json";
+const LOCK_FILE = "demo.lock";
 const RESIDENTS_DIR = "residents";
 
 export interface PersistentDemoRuntimeOptions {
@@ -34,12 +38,164 @@ export interface PersistentDemoInspection extends DemoResident {
 export interface PersistentDemoRuntime extends DemoRuntime {
   inspect(): PersistentDemoInspection;
   bootPack(): Promise<BootPack>;
+  close(): void;
 }
 
 interface DemoState {
   schemaVersion: number;
   seedId: string;
   residentId: string;
+}
+
+interface DataDirLockRecord {
+  schemaVersion: 1;
+  token: string;
+  pid: number;
+  hostname: string;
+  startedAt: string;
+}
+
+interface DataDirLock {
+  assertHeld(): void;
+  release(): void;
+}
+
+export class DemoDataDirLockedError extends Error {
+  constructor(dataDir: string, owner: DataDirLockRecord | null) {
+    const description =
+      owner === null
+        ? `an unknown process (owner metadata in ${join(dataDir, LOCK_FILE)} is unreadable)`
+        : `pid ${owner.pid} on ${owner.hostname}, started ${owner.startedAt}`;
+    super(`demo data directory is locked by ${description}: ${dataDir}`);
+    this.name = "DemoDataDirLockedError";
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+function parseLockRecord(value: string): DataDirLockRecord | null {
+  try {
+    const record = JSON.parse(value) as Partial<DataDirLockRecord>;
+    if (
+      record.schemaVersion !== 1 ||
+      typeof record.token !== "string" ||
+      record.token.length === 0 ||
+      !Number.isSafeInteger(record.pid) ||
+      (record.pid ?? 0) <= 0 ||
+      typeof record.hostname !== "string" ||
+      record.hostname.length === 0 ||
+      typeof record.startedAt !== "string" ||
+      !Number.isFinite(Date.parse(record.startedAt))
+    ) {
+      return null;
+    }
+    return record as DataDirLockRecord;
+  } catch {
+    return null;
+  }
+}
+
+function lockOwnerIsGone(record: DataDirLockRecord): boolean {
+  if (record.hostname !== hostname()) return false;
+  try {
+    process.kill(record.pid, 0);
+    return false;
+  } catch (error) {
+    return hasErrorCode(error, "ESRCH");
+  }
+}
+
+function acquireDataDirLock(dataDir: string): DataDirLock {
+  const path = join(dataDir, LOCK_FILE);
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const record: DataDirLockRecord = {
+      schemaVersion: 1,
+      token: randomUUID(),
+      pid: process.pid,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+    };
+    let descriptor: number;
+    try {
+      descriptor = openSync(path, "wx", 0o600);
+    } catch (error) {
+      if (!hasErrorCode(error, "EEXIST")) throw error;
+
+      let owner: DataDirLockRecord | null;
+      try {
+        owner = parseLockRecord(readFileSync(path, "utf8"));
+      } catch (readError) {
+        if (hasErrorCode(readError, "ENOENT")) continue;
+        owner = null;
+      }
+      if (owner !== null && lockOwnerIsGone(owner)) {
+        try {
+          rmSync(path);
+        } catch (removeError) {
+          if (hasErrorCode(removeError, "ENOENT")) continue;
+          throw removeError;
+        }
+        continue;
+      }
+      throw new DemoDataDirLockedError(dataDir, owner);
+    }
+
+    try {
+      fchmodSync(descriptor, 0o600);
+      writeSync(descriptor, JSON.stringify(record));
+      fsyncSync(descriptor);
+    } catch (error) {
+      try {
+        closeSync(descriptor);
+      } finally {
+        rmSync(path, { force: true });
+      }
+      throw error;
+    }
+
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      process.off("exit", release);
+      try {
+        closeSync(descriptor);
+      } catch {
+        // The lock file identity check below still prevents deleting another owner's lock.
+      }
+      try {
+        const current = parseLockRecord(readFileSync(path, "utf8"));
+        if (current?.token === record.token) rmSync(path, { force: true });
+      } catch {
+        // Process shutdown and explicit close are both idempotent.
+      }
+    };
+    const lock: DataDirLock = {
+      assertHeld() {
+        if (released) throw new Error(`demo data directory lock has been released: ${dataDir}`);
+        let current: DataDirLockRecord | null = null;
+        try {
+          current = parseLockRecord(readFileSync(path, "utf8"));
+        } catch {
+          // Report the same explicit lost-lock error for deletion and unreadable metadata.
+        }
+        if (current?.token !== record.token) {
+          throw new Error(`demo data directory lock was lost: ${dataDir}`);
+        }
+      },
+      release,
+    };
+    process.once("exit", release);
+    return lock;
+  }
+  throw new DemoDataDirLockedError(dataDir, null);
 }
 
 function statePath(dataDir: string): string {
@@ -76,13 +232,20 @@ function parseState(path: string): DemoState {
   };
 }
 
-function persistState(dataDir: string, seedId: string, residentId: string): void {
+function persistState(
+  lock: DataDirLock,
+  dataDir: string,
+  seedId: string,
+  residentId: string,
+): void {
+  lock.assertHeld();
   const finalPath = statePath(dataDir);
   const temporaryPath = `${finalPath}.tmp`;
   const body = JSON.stringify({ schemaVersion: STATE_SCHEMA_VERSION, seedId, residentId });
   let descriptor: number | null = null;
   try {
     descriptor = openSync(temporaryPath, "w", 0o600);
+    fchmodSync(descriptor, 0o600);
     writeSync(descriptor, body);
     fsyncSync(descriptor);
     closeSync(descriptor);
@@ -107,7 +270,8 @@ function openDriver(dataDir: string, reply: CreateDriverOptions["reply"]): Harne
   return createDriver(options);
 }
 
-function removeOrphanSnapshots(dataDir: string, residentId: string): void {
+function removeOrphanSnapshots(lock: DataDirLock, dataDir: string, residentId: string): void {
+  lock.assertHeld();
   const residents = residentDataDir(dataDir);
   for (const file of readdirSync(residents)) {
     if (file.endsWith(".tmp")) {
@@ -128,53 +292,69 @@ export async function createPersistentDemoRuntime(
   const seed = options.seed ?? DEMO_SEED;
   assertDemoSeed(seed);
   mkdirSync(dataDir, { recursive: true });
-  mkdirSync(residentDataDir(dataDir), { recursive: true });
+  const lock = acquireDataDirLock(dataDir);
+  try {
+    mkdirSync(residentDataDir(dataDir), { recursive: true });
 
-  const savedState = existsSync(statePath(dataDir)) ? parseState(statePath(dataDir)) : null;
-  if (savedState !== null && savedState.seedId !== seed.id) {
-    throw new Error(
-      `demo state belongs to seed ${savedState.seedId}, but this run requested ${seed.id}`,
-    );
-  }
-  let driver = openDriver(dataDir, options.reply);
-  let residentId: string;
-  if (savedState === null) {
-    const existingSnapshots = readdirSync(residentDataDir(dataDir)).filter((file) =>
-      file.endsWith(".json"),
-    );
-    if (existingSnapshots.length > 0) {
-      throw new Error("demo resident snapshots exist without demo-state.json");
+    const savedState = existsSync(statePath(dataDir)) ? parseState(statePath(dataDir)) : null;
+    if (savedState !== null && savedState.seedId !== seed.id) {
+      throw new Error(
+        `demo state belongs to seed ${savedState.seedId}, but this run requested ${seed.id}`,
+      );
     }
-    residentId = await seedDemoResident(driver, seed);
-    persistState(dataDir, seed.id, residentId);
-  } else {
-    residentId = savedState.residentId;
-    await driver.buildBootPack(residentId);
-    // Only collect abandoned reset snapshots after the manifest target is
-    // proven readable. A bad pointer must fail closed without deleting data.
-    removeOrphanSnapshots(dataDir, residentId);
-  }
-
-  return {
-    current() {
-      return { driver, residentId };
-    },
-    inspect() {
-      return { driver, residentId };
-    },
-    bootPack() {
-      return driver.buildBootPack(residentId);
-    },
-    async reset() {
-      const previousDriver = driver;
-      const previousResidentId = residentId;
-      const nextResidentId = await seedDemoResident(previousDriver, seed);
-      persistState(dataDir, seed.id, nextResidentId);
-      residentId = nextResidentId;
-      await previousDriver.destroyResident(previousResidentId);
-      // Re-open from disk so reset exercises the same recovery path as a process restart.
-      driver = openDriver(dataDir, options.reply);
+    let driver = openDriver(dataDir, options.reply);
+    let residentId: string;
+    if (savedState === null) {
+      const existingSnapshots = readdirSync(residentDataDir(dataDir)).filter((file) =>
+        file.endsWith(".json"),
+      );
+      if (existingSnapshots.length > 0) {
+        throw new Error("demo resident snapshots exist without demo-state.json");
+      }
+      residentId = await seedDemoResident(driver, seed);
+      persistState(lock, dataDir, seed.id, residentId);
+    } else {
+      residentId = savedState.residentId;
       await driver.buildBootPack(residentId);
-    },
-  };
+      // Only collect abandoned reset snapshots after the manifest target is
+      // proven readable. A bad pointer must fail closed without deleting data.
+      removeOrphanSnapshots(lock, dataDir, residentId);
+    }
+
+    return {
+      current() {
+        lock.assertHeld();
+        return { driver, residentId };
+      },
+      inspect() {
+        lock.assertHeld();
+        return { driver, residentId };
+      },
+      bootPack() {
+        lock.assertHeld();
+        return driver.buildBootPack(residentId);
+      },
+      async reset() {
+        lock.assertHeld();
+        const previousDriver = driver;
+        const previousResidentId = residentId;
+        const nextResidentId = await seedDemoResident(previousDriver, seed);
+        lock.assertHeld();
+        persistState(lock, dataDir, seed.id, nextResidentId);
+        residentId = nextResidentId;
+        await previousDriver.destroyResident(previousResidentId);
+        lock.assertHeld();
+        // Re-open from disk so reset exercises the same recovery path as a process restart.
+        driver = openDriver(dataDir, options.reply);
+        await driver.buildBootPack(residentId);
+        lock.assertHeld();
+      },
+      close() {
+        lock.release();
+      },
+    };
+  } catch (error) {
+    lock.release();
+    throw error;
+  }
 }

--- a/demo/server.ts
+++ b/demo/server.ts
@@ -1,3 +1,4 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import {
   type IncomingHttpHeaders,
   type IncomingMessage,
@@ -5,6 +6,7 @@ import {
   createServer,
 } from "node:http";
 import type { AddressInfo } from "node:net";
+import { ClaudeAuthenticationError } from "./brain-claude.ts";
 
 const LOOPBACK_HOST = "127.0.0.1";
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
@@ -79,6 +81,8 @@ export interface DemoServerOptions {
 }
 
 export interface DemoServer {
+  /** Per-process secret required by destructive control routes. */
+  readonly controlToken: string;
   /** Starts on loopback only. No public-bind escape hatch is exposed. */
   start(port: number): Promise<AddressInfo>;
   stop(): Promise<void>;
@@ -102,6 +106,16 @@ function pathnameOf(url: string): string {
   } catch {
     return url;
   }
+}
+
+function hasControlAuthorization(headers: IncomingHttpHeaders, token: string): boolean {
+  const authorization = headers.authorization;
+  if (typeof authorization !== "string") return false;
+  const match = /^Bearer ([A-Za-z0-9_-]+)$/i.exec(authorization);
+  if (match?.[1] === undefined) return false;
+  const actual = Buffer.from(match[1]);
+  const expected = Buffer.from(token);
+  return actual.byteLength === expected.byteLength && timingSafeEqual(actual, expected);
 }
 
 function latestUserMessage(messages: readonly DemoMessage[]): string | null {
@@ -174,6 +188,7 @@ function serialExecutor() {
 
 export function createDemoServer(options: DemoServerOptions): DemoServer {
   const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  const controlToken = randomBytes(32).toString("base64url");
   if (!Number.isSafeInteger(maxBodyBytes) || maxBodyBytes <= 0) {
     throw new RangeError("maxBodyBytes must be a positive safe integer");
   }
@@ -193,6 +208,11 @@ export function createDemoServer(options: DemoServerOptions): DemoServer {
           sendJson(response, 405, { error: "method_not_allowed" });
           return;
         }
+        if (!hasControlAuthorization(view.headers, controlToken)) {
+          response.setHeader("www-authenticate", 'Bearer realm="mist-demo-control"');
+          sendJson(response, 401, { error: "control_token_required" });
+          return;
+        }
         await runSerial(async () => {
           const { driver, residentId } = options.runtime.current();
           await driver.killSession(residentId);
@@ -206,6 +226,11 @@ export function createDemoServer(options: DemoServerOptions): DemoServer {
         if (view.method !== "POST") {
           response.setHeader("allow", "POST");
           sendJson(response, 405, { error: "method_not_allowed" });
+          return;
+        }
+        if (!hasControlAuthorization(view.headers, controlToken)) {
+          response.setHeader("www-authenticate", 'Bearer realm="mist-demo-control"');
+          sendJson(response, 401, { error: "control_token_required" });
           return;
         }
         await runSerial(() => options.runtime.reset());
@@ -250,12 +275,20 @@ export function createDemoServer(options: DemoServerOptions): DemoServer {
         sendJson(response, 400, { error: "bad_request" });
         return;
       }
+      if (error instanceof ClaudeAuthenticationError) {
+        sendJson(response, 503, {
+          error: "claude_authentication_required",
+          message: error.message,
+        });
+        return;
+      }
       options.onError?.(error);
       sendJson(response, 500, { error: "internal_error" });
     });
   });
 
   return {
+    controlToken,
     start(port) {
       if (!Number.isInteger(port) || port < 0 || port > 65_535) {
         return Promise.reject(new RangeError("port must be an integer from 0 through 65535"));

--- a/src/store/resident-store.ts
+++ b/src/store/resident-store.ts
@@ -15,6 +15,7 @@
 
 import {
   closeSync,
+  fchmodSync,
   fsyncSync,
   mkdirSync,
   openSync,
@@ -201,7 +202,8 @@ export class ResidentStore {
     const tmpPath = `${finalPath}.tmp`;
     let fd: number | null = null;
     try {
-      fd = openSync(tmpPath, "w");
+      fd = openSync(tmpPath, "w", 0o600);
+      fchmodSync(fd, 0o600);
       writeSync(fd, JSON.stringify(record));
       fsyncSync(fd);
       closeSync(fd);

--- a/tests/brain-claude.test.ts
+++ b/tests/brain-claude.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { BootPack } from "../acceptance/driver.ts";
 import {
+  ClaudeAuthenticationError,
   ClaudeBrainError,
   type ClaudeQueryMessage,
   type ClaudeQueryRequest,
@@ -114,5 +115,36 @@ describe("Claude Agent SDK brain", () => {
       "Claude Agent SDK ended without a result message",
     );
     await expect(failedDriver.say(failedResidentId, "hi")).rejects.toBeInstanceOf(ClaudeBrainError);
+  });
+
+  it("把未登录的 assistant error 和假 success 识别为认证失败", async () => {
+    const structured = createClaudeReply({
+      buildBootPack: async () => bootPack,
+      runQuery: () =>
+        messages(
+          { type: "assistant", error: "authentication_failed" },
+          {
+            type: "result",
+            subtype: "success",
+            result: "Not logged in · Please run /login",
+          },
+        ),
+    });
+    const resultOnly = createClaudeReply({
+      buildBootPack: async () => bootPack,
+      runQuery: () =>
+        messages({
+          type: "result",
+          subtype: "success",
+          result: "Not logged in",
+        }),
+    });
+
+    await expect(structured("resident-demo", "hi")).rejects.toBeInstanceOf(
+      ClaudeAuthenticationError,
+    );
+    await expect(resultOnly("resident-demo", "hi")).rejects.toBeInstanceOf(
+      ClaudeAuthenticationError,
+    );
   });
 });

--- a/tests/demo-runtime.test.ts
+++ b/tests/demo-runtime.test.ts
@@ -1,10 +1,47 @@
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import { createPersistentDemoRuntime } from "../demo/runtime.ts";
+import {
+  type PersistentDemoRuntime,
+  type PersistentDemoRuntimeOptions,
+  createPersistentDemoRuntime,
+} from "../demo/runtime.ts";
 
 const dirs: string[] = [];
+const runtimes: PersistentDemoRuntime[] = [];
+const children: ChildProcess[] = [];
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const runtimeModuleUrl = pathToFileURL(join(repoRoot, "demo/runtime.ts")).href;
+const lockHolderScript = `
+const { createPersistentDemoRuntime } = await import(process.env.MIST_RUNTIME_MODULE);
+try {
+  const runtime = await createPersistentDemoRuntime({ dataDir: process.env.MIST_TEST_DATA_DIR });
+  console.log(JSON.stringify({ residentId: runtime.inspect().residentId, pid: process.pid }));
+  let stopping = false;
+  const stop = () => {
+    if (stopping) return;
+    stopping = true;
+    clearTimeout(expiry);
+    runtime.close();
+    process.exit(0);
+  };
+  const expiry = setTimeout(stop, 5000);
+  process.on("message", async (command) => {
+    if (command === "reset") {
+      await runtime.reset();
+      process.send?.({ reset: true, residentId: runtime.inspect().residentId });
+    } else if (command === "stop") {
+      stop();
+    }
+  });
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}
+`;
 
 function freshDir(): string {
   const directory = mkdtempSync(join(tmpdir(), "mist-demo-runtime-"));
@@ -12,7 +49,128 @@ function freshDir(): string {
   return directory;
 }
 
-afterEach(() => {
+async function openRuntime(options: PersistentDemoRuntimeOptions): Promise<PersistentDemoRuntime> {
+  const runtime = await createPersistentDemoRuntime(options);
+  runtimes.push(runtime);
+  return runtime;
+}
+
+function startDemoProcess(dataDir: string): ChildProcess {
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "-e", lockHolderScript],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        MIST_RUNTIME_MODULE: runtimeModuleUrl,
+        MIST_TEST_DATA_DIR: dataDir,
+      },
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+    },
+  );
+  children.push(child);
+  return child;
+}
+
+function waitForStartup(child: ChildProcess): Promise<{
+  residentId: string;
+  pid: number;
+}> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => reject(new Error("demo process startup timed out")), 10_000);
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+      const newline = stdout.indexOf("\n");
+      if (newline < 0) return;
+      clearTimeout(timer);
+      cleanup();
+      try {
+        resolve(JSON.parse(stdout.slice(0, newline)));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("exit", onExit);
+
+    function cleanup() {
+      child.off("exit", onExit);
+    }
+    function onExit(code: number | null) {
+      clearTimeout(timer);
+      reject(new Error(`demo process exited ${String(code)} before startup: ${stderr}`));
+    }
+  });
+}
+
+function collectProcess(child: ChildProcess): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+function resetChild(child: ChildProcess): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("demo process reset timed out")), 5_000);
+    child.once("message", (message) => {
+      clearTimeout(timer);
+      const result = message as { reset?: unknown; residentId?: unknown };
+      if (result.reset === true && typeof result.residentId === "string") {
+        resolve(result.residentId);
+      } else {
+        reject(new Error(`unexpected reset response: ${JSON.stringify(message)}`));
+      }
+    });
+    child.send?.("reset", (error) => {
+      if (error !== null) {
+        clearTimeout(timer);
+        reject(error);
+      }
+    });
+  });
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, 6_000);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    try {
+      child.send?.("stop");
+    } catch {
+      // The holder also self-expires, so cleanup does not need broad process signals.
+    }
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(children.splice(0).map(stopChild));
+  for (const runtime of runtimes.splice(0)) runtime.close();
   for (const directory of dirs.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
@@ -27,11 +185,12 @@ describe("persistent demo runtime", () => {
   it("keeps identity and resident state across restart while opening a new message root", async () => {
     const dataDir = freshDir();
     const reply = async (_residentId: string, message: string) => `脑子:${message}`;
-    const first = await createPersistentDemoRuntime({ dataDir, reply, seed });
+    const first = await openRuntime({ dataDir, reply, seed });
     const firstResidentId = first.inspect().residentId;
     await first.inspect().driver.say(firstResidentId, "重启前一句");
+    first.close();
 
-    const second = await createPersistentDemoRuntime({ dataDir, reply, seed });
+    const second = await openRuntime({ dataDir, reply, seed });
     const secondResidentId = second.inspect().residentId;
     const bootPack = await second.bootPack();
     const answer = await second.inspect().driver.say(secondResidentId, "重启后第一句");
@@ -50,7 +209,7 @@ describe("persistent demo runtime", () => {
 
   it("reset reseeds a new resident and removes the old snapshot", async () => {
     const dataDir = freshDir();
-    const runtime = await createPersistentDemoRuntime({ dataDir, seed });
+    const runtime = await openRuntime({ dataDir, seed });
     const oldResidentId = runtime.inspect().residentId;
 
     await runtime.reset();
@@ -79,9 +238,11 @@ describe("persistent demo runtime", () => {
     );
 
     const orphaned = freshDir();
-    const first = await createPersistentDemoRuntime({ dataDir: orphaned, seed });
+    const first = await openRuntime({ dataDir: orphaned, seed });
+    const residentId = first.inspect().residentId;
+    first.close();
     rmSync(join(orphaned, "demo-state.json"));
-    expect(first.inspect().residentId).toMatch(/^resident-/);
+    expect(residentId).toMatch(/^resident-/);
     await expect(createPersistentDemoRuntime({ dataDir: orphaned, seed })).rejects.toThrow(
       /snapshots exist without demo-state/,
     );
@@ -89,8 +250,9 @@ describe("persistent demo runtime", () => {
 
   it("does not collect snapshots when the identity pointer cannot be opened", async () => {
     const dataDir = freshDir();
-    const first = await createPersistentDemoRuntime({ dataDir, seed });
+    const first = await openRuntime({ dataDir, seed });
     const existingSnapshot = `${first.inspect().residentId}.json`;
+    first.close();
     writeFileSync(
       join(dataDir, "demo-state.json"),
       JSON.stringify({ schemaVersion: 2, seedId: seed.id, residentId: "resident-missing" }),
@@ -98,5 +260,27 @@ describe("persistent demo runtime", () => {
 
     await expect(createPersistentDemoRuntime({ dataDir, seed })).rejects.toThrow();
     expect(readdirSync(join(dataDir, "residents"))).toContain(existingSnapshot);
+  });
+
+  it("starts two real demo processes and rejects the second with the lock owner's pid", async () => {
+    const dataDir = freshDir();
+    const first = startDemoProcess(dataDir);
+    const startup = await waitForStartup(first);
+    expect(first.pid).toBeTypeOf("number");
+    expect(startup.pid).toBe(first.pid);
+
+    const second = startDemoProcess(dataDir);
+    const collision = await collectProcess(second);
+
+    expect(collision.code).toBe(1);
+    expect(collision.stdout).toBe("");
+    expect(collision.stderr).toContain("demo data directory is locked");
+    expect(collision.stderr).toContain(`pid ${String(first.pid)}`);
+
+    const resetResidentId = await resetChild(first);
+    expect(resetResidentId).not.toBe(startup.residentId);
+    const state = JSON.parse(readFileSync(join(dataDir, "demo-state.json"), "utf8"));
+    expect(state.residentId).toBe(resetResidentId);
+    expect(existsSync(join(dataDir, "residents", `${resetResidentId}.json`))).toBe(true);
   });
 });

--- a/tests/demo-seed.test.ts
+++ b/tests/demo-seed.test.ts
@@ -3,11 +3,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { HarnessDriver } from "../acceptance/driver.ts";
-import { createPersistentDemoRuntime } from "../demo/runtime.ts";
+import {
+  type PersistentDemoRuntime,
+  type PersistentDemoRuntimeOptions,
+  createPersistentDemoRuntime,
+} from "../demo/runtime.ts";
 import { DEMO_SEED, DemoSeedError, assertDemoSeed, seedDemoResident } from "../demo/seed.ts";
 import { createDriver } from "../src/acceptance-driver.ts";
 
 const dirs: string[] = [];
+const runtimes: PersistentDemoRuntime[] = [];
 
 function freshDir(): string {
   const directory = mkdtempSync(join(tmpdir(), "mist-demo-seed-"));
@@ -15,7 +20,14 @@ function freshDir(): string {
   return directory;
 }
 
+async function openRuntime(options: PersistentDemoRuntimeOptions): Promise<PersistentDemoRuntime> {
+  const runtime = await createPersistentDemoRuntime(options);
+  runtimes.push(runtime);
+  return runtime;
+}
+
 afterEach(() => {
+  for (const runtime of runtimes.splice(0)) runtime.close();
   for (const directory of dirs.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
@@ -33,7 +45,7 @@ describe("demo seed", () => {
 
   it("runtime 首次启动播种，后续启动复用同一住户且零字节重复写入", async () => {
     const dataDir = freshDir();
-    const first = await createPersistentDemoRuntime({ dataDir });
+    const first = await openRuntime({ dataDir });
     const residentId = first.inspect().residentId;
     const residentPath = join(dataDir, "residents", `${residentId}.json`);
     const statePath = join(dataDir, "demo-state.json");
@@ -43,7 +55,8 @@ describe("demo seed", () => {
       files: readdirSync(join(dataDir, "residents")),
     };
 
-    const second = await createPersistentDemoRuntime({ dataDir });
+    first.close();
+    const second = await openRuntime({ dataDir });
 
     expect(second.inspect().residentId).toBe(residentId);
     expect(readFileSync(residentPath)).toEqual(before.resident);
@@ -58,7 +71,7 @@ describe("demo seed", () => {
 
   it("状态属于另一套 seed 时 fail closed，不换住户也不改字节", async () => {
     const dataDir = freshDir();
-    const first = await createPersistentDemoRuntime({ dataDir });
+    const first = await openRuntime({ dataDir });
     const residentId = first.inspect().residentId;
     const residentPath = join(dataDir, "residents", `${residentId}.json`);
     const statePath = join(dataDir, "demo-state.json");
@@ -67,6 +80,7 @@ describe("demo seed", () => {
       state: readFileSync(statePath),
     };
 
+    first.close();
     await expect(
       createPersistentDemoRuntime({
         dataDir,

--- a/tests/demo-server.test.ts
+++ b/tests/demo-server.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ClaudeAuthenticationError } from "../demo/brain-claude.ts";
 import {
   type DemoChatAdapter,
   type DemoDriver,
@@ -27,7 +28,10 @@ afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.stop()));
 });
 
-async function start(runtime: DemoRuntime, options: { maxBodyBytes?: number } = {}) {
+async function start(
+  runtime: DemoRuntime,
+  options: { maxBodyBytes?: number; onError?: (error: unknown) => void } = {},
+) {
   const server = createDemoServer({ runtime, adapters: [adapter], ...options });
   servers.push(server);
   const address = await server.start(0);
@@ -71,7 +75,7 @@ describe("demo server core", () => {
       current: () => ({ driver, residentId }),
       reset: vi.fn(async () => undefined),
     };
-    const { baseUrl } = await start(runtime);
+    const { server, baseUrl } = await start(runtime);
 
     for (const content of ["before clear one", "before clear two"]) {
       expect(
@@ -82,7 +86,10 @@ describe("demo server core", () => {
       ).toHaveProperty("status", 200);
     }
 
-    const clearResponse = await fetch(`${baseUrl}/demo/clear`, { method: "POST" });
+    const clearResponse = await fetch(`${baseUrl}/demo/clear`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${server.controlToken}` },
+    });
     expect(clearResponse.status).toBe(204);
     await fetch(`${baseUrl}/wire/chat`, {
       method: "POST",
@@ -111,9 +118,12 @@ describe("demo server core", () => {
         residentId = "resident-reseeded";
       }),
     };
-    const { baseUrl } = await start(runtime);
+    const { server, baseUrl } = await start(runtime);
 
-    const resetResponse = await fetch(`${baseUrl}/demo/reset`, { method: "POST" });
+    const resetResponse = await fetch(`${baseUrl}/demo/reset`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${server.controlToken}` },
+    });
     expect(resetResponse.status).toBe(204);
     await fetch(`${baseUrl}/wire/chat`, {
       method: "POST",
@@ -162,6 +172,78 @@ describe("demo server core", () => {
     expect(malformed.status).toBe(400);
     expect(oversized.status).toBe(413);
     expect(say).not.toHaveBeenCalled();
+  });
+
+  it("requires the per-run bearer token for cross-origin control posts but not chat", async () => {
+    const driver: DemoDriver = {
+      say: vi.fn(async () => ({ content: "ok" })),
+      killSession: vi.fn(async () => undefined),
+    };
+    const runtime: DemoRuntime = {
+      current: () => ({ driver, residentId: "resident-demo" }),
+      reset: vi.fn(async () => undefined),
+    };
+    const { server, baseUrl } = await start(runtime);
+
+    const clear = await fetch(`${baseUrl}/demo/clear`, {
+      method: "POST",
+      headers: { origin: "https://attacker.invalid" },
+    });
+    const reset = await fetch(`${baseUrl}/demo/reset`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer wrong-token",
+        origin: "https://attacker.invalid",
+      },
+    });
+    const chat = await fetch(`${baseUrl}/wire/chat`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://attacker.invalid",
+      },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    });
+
+    expect(clear.status).toBe(401);
+    expect(await clear.json()).toEqual({ error: "control_token_required" });
+    expect(reset.status).toBe(401);
+    expect(driver.killSession).not.toHaveBeenCalled();
+    expect(runtime.reset).not.toHaveBeenCalled();
+    expect(chat.status).toBe(200);
+    expect(server.controlToken).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(createDemoServer({ runtime, adapters: [adapter] }).controlToken).not.toBe(
+      server.controlToken,
+    );
+  });
+
+  it("returns an explicit 503 JSON error when the Claude SDK is not authenticated", async () => {
+    const onError = vi.fn();
+    const driver: DemoDriver = {
+      say: vi.fn(async () => {
+        throw new ClaudeAuthenticationError();
+      }),
+      killSession: vi.fn(async () => undefined),
+    };
+    const { baseUrl } = await start(
+      {
+        current: () => ({ driver, residentId: "resident-demo" }),
+        reset: vi.fn(async () => undefined),
+      },
+      { onError },
+    );
+
+    const response = await fetch(`${baseUrl}/wire/chat`, {
+      method: "POST",
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "claude_authentication_required",
+      message: "Claude Agent SDK is not authenticated; run /login before using the demo",
+    });
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("keeps management methods narrow and returns 404 for unknown routes", async () => {

--- a/tests/demo-wiring.test.ts
+++ b/tests/demo-wiring.test.ts
@@ -5,11 +5,13 @@ import { afterEach, describe, expect, it } from "vitest";
 import { openAiChatCompletionsAdapter } from "../demo/adapters/openai.ts";
 import type { ClaudeQueryRequest } from "../demo/brain-claude.ts";
 import { createClaudeDemoRuntime } from "../demo/main.ts";
+import type { PersistentDemoRuntime } from "../demo/runtime.ts";
 import { DEMO_SEED } from "../demo/seed.ts";
 import { type DemoServer, createDemoServer } from "../demo/server.ts";
 
 const dirs: string[] = [];
 const servers: DemoServer[] = [];
+const runtimes: PersistentDemoRuntime[] = [];
 
 function freshDir(): string {
   const directory = mkdtempSync(join(tmpdir(), "mist-demo-wiring-"));
@@ -19,6 +21,7 @@ function freshDir(): string {
 
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.stop()));
+  for (const runtime of runtimes.splice(0)) runtime.close();
   for (const directory of dirs.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
@@ -31,6 +34,7 @@ describe("E2 + E3 + E4 demo wiring", () => {
       yield { type: "result", subtype: "success", result: "小栖" };
     };
     const first = await createClaudeDemoRuntime({ dataDir, runQuery });
+    runtimes.push(first);
     const residentId = first.inspect().residentId;
     const server = createDemoServer({ runtime: first, adapters: [openAiChatCompletionsAdapter] });
     servers.push(server);
@@ -52,7 +56,10 @@ describe("E2 + E3 + E4 demo wiring", () => {
     expect(requests[0]?.options.systemPrompt).toContain(DEMO_SEED.memories[0]);
     expect(requests[0]?.options.systemPrompt).toContain(DEMO_SEED.commitments[0]);
 
-    await fetch(`${baseUrl}/demo/clear`, { method: "POST" });
+    await fetch(`${baseUrl}/demo/clear`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${server.controlToken}` },
+    });
     await fetch(`${baseUrl}/v1/chat/completions`, {
       method: "POST",
       body: JSON.stringify({
@@ -67,7 +74,9 @@ describe("E2 + E3 + E4 demo wiring", () => {
 
     await server.stop();
     servers.splice(servers.indexOf(server), 1);
+    first.close();
     const second = await createClaudeDemoRuntime({ dataDir, runQuery });
+    runtimes.push(second);
     expect(second.inspect().residentId).toBe(residentId);
     expect(await second.inspect().driver.history(residentId)).toEqual([]);
     expect((await second.bootPack()).memories.map((memory) => memory.content)).toEqual(

--- a/tests/resident-store.test.ts
+++ b/tests/resident-store.test.ts
@@ -6,8 +6,48 @@
  * 也不代表跨房访问会老实报错而不是返回空数组。
  */
 
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { ResidentNotFoundError, ResidentStore } from "../src/store/resident-store.ts";
+
+describe("持久化权限", () => {
+  it("在 umask 022 下新快照和覆盖旧临时文件都保持 0600", () => {
+    const moduleUrl = new URL("../src/store/resident-store.ts", import.meta.url).href;
+    const probe = `
+import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+const { ResidentStore } = await import(${JSON.stringify(moduleUrl)});
+const dataDir = mkdtempSync(join(tmpdir(), "mist-resident-permissions-"));
+process.umask(0o022);
+try {
+  const store = new ResidentStore({ dataDir });
+  const residentId = store.createResident("private");
+  const snapshotPath = join(dataDir, \`\${residentId}.json\`);
+  const initialMode = statSync(snapshotPath).mode & 0o777;
+  const staleTemporaryPath = \`\${snapshotPath}.tmp\`;
+  writeFileSync(staleTemporaryPath, "old exposed temporary file", { mode: 0o644 });
+  chmodSync(staleTemporaryPath, 0o644);
+  store.remember(residentId, "同机其他用户不可读");
+  const rewrittenMode = statSync(snapshotPath).mode & 0o777;
+  console.log(JSON.stringify({ initialMode, rewrittenMode }));
+} finally {
+  rmSync(dataDir, { recursive: true, force: true });
+}
+`;
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", probe],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      initialMode: 0o600,
+      rewrittenMode: 0o600,
+    });
+  });
+});
 
 describe("房间隔离", () => {
   it("跨房读抛错，而不是返回空数组", () => {


### PR DESCRIPTION
出处：#28 楼 Bijou-Jacque 的 macOS 实测报告（两高两中）。

- B1：demo.lock 排他锁（PID/主机/时间），撞锁拒启动并明说谁占着；锁覆盖 reset 全序列；两进程实测
- B2：住户快照强制 0600（写临时文件即 fchmod，rename 后保持），umask 022 子进程实测
- B3：识别 SDK 认证失败，chat 返回 503 claude_authentication_required，错误文本不再混进 assistant content
- B4：per-run control token，clear/reset 要 Bearer 头，主对话路由不受限

望舒验收（亲手重跑）：lint/typecheck/167 测试/判卷六真绿全过；活体四步——无 token 打 clear 401、带 token 204、未登录 chat 503、双进程撞锁被拒、杀进程锁自清、快照权限 -rw-------。