### PR TITLE
feat: add transactional TUI installer

### DIFF
--- a/docs/design/2026-08-17-installer-tui-walkthrough.md
+++ b/docs/design/2026-08-17-installer-tui-walkthrough.md
@@ -33,7 +33,7 @@
 ## 3. 第 1 步 · credentials（钥匙）
 
 流程（对应 `collectCredentials`）：
-1. `Choose a credential provider` —— 列表来自 `PROVIDERS`（获取入口表，不是愿望表）：`Claude`、`Codex`、`Grok / xAI` 都有 Pi OAuth / API key。Grok 入口依据 Pi provider 表的 `/login xai` subscription 路径。
+1. `Choose a credential provider` —— 列表来自 `PROVIDERS`（获取入口表，不是愿望表）：`Claude`、`Codex` 提供 Pi OAuth / API key；`Grok / xAI` 在 v0 只提供 API key。Pi 已支持 `/login xai`，但 #50 明确把 Grok OAuth 留给后续插件，不在本单接入。
 2. `How should <provider> authenticate?` —— `Sign in through Pi` / `Enter an API key`。
 3. `Credential name` —— 默认 `<provider>-login` / `<provider>-key`，slug 化后成为 `id`，也是后面绑定时的引用名。
 4. OAuth 路径：屏幕先出 `Pi will open now. Run /login, choose <provider>, finish authorization, then quit Pi.`，然后把终端交给 pi；pi 退出后安装器只检查 `~/.pi/agent/auth.json` 里有没有该 provider 的 key，有 → 记 `pi-auth://<key>`；没有 → 报 `Pi exited without a <provider> credential in its auth store; the installer draft was kept`。

--- a/docs/design/2026-08-17-installer-tui-walkthrough.md
+++ b/docs/design/2026-08-17-installer-tui-walkthrough.md
@@ -33,13 +33,13 @@
 ## 3. 第 1 步 · credentials（钥匙）
 
 流程（对应 `collectCredentials`）：
-1. `Choose a credential provider` —— 列表来自 `PROVIDERS`（能力表，不是愿望表）：`Claude`（OAuth / API key）、`Codex`（OAuth / API key）、`Grok / xAI`（只 API key；pi 没有 Grok OAuth，界面上就不给）。
+1. `Choose a credential provider` —— 列表来自 `PROVIDERS`（获取入口表，不是愿望表）：`Claude`、`Codex`、`Grok / xAI` 都有 Pi OAuth / API key。Grok 入口依据 Pi provider 表的 `/login xai` subscription 路径。
 2. `How should <provider> authenticate?` —— `Sign in through Pi` / `Enter an API key`。
 3. `Credential name` —— 默认 `<provider>-login` / `<provider>-key`，slug 化后成为 `id`，也是后面绑定时的引用名。
 4. OAuth 路径：屏幕先出 `Pi will open now. Run /login, choose <provider>, finish authorization, then quit Pi.`，然后把终端交给 pi；pi 退出后安装器只检查 `~/.pi/agent/auth.json` 里有没有该 provider 的 key，有 → 记 `pi-auth://<key>`；没有 → 报 `Pi exited without a <provider> credential in its auth store; the installer draft was kept`。
 5. API key 路径：`<provider> API key`（掩码输入），落进 `draft-secrets/<id>.credential`。
 6. `Add another credential?` —— 默认否。至少一把才能进第 2 步（validate 兜底）。
-7. `CredentialRef { id, type }` 与 PR #52 一致；Claude OAuth 的约束由 `type: "claude_oauth"` 表达，不另造 `adapterConstraint` 字段。它只在 Claude Agent SDK 下出现，收完时界面也会明说。
+7. `CredentialRef { id, type, issuerId }` 与 PR #52 一致；Pi OAuth 记 `issuerId: "pi"`，手填 API key 记 `issuerId: "mist-installer-api-key"`。Claude OAuth 的约束由 `type: "claude_oauth"` 表达，不另造 `adapterConstraint` 字段；它只在 Claude Agent SDK 下出现，收完时界面也会明说。
 
 ## 4. 第 2 步 · bindings（车道）
 

--- a/docs/design/2026-08-17-installer-tui-walkthrough.md
+++ b/docs/design/2026-08-17-installer-tui-walkthrough.md
@@ -1,13 +1,13 @@
 # 安装引导 TUI · 用户路径走查（#50）
 
-状态：v0.2，对照 `feat/installer-tui` 1fcdb9d 写成。命令与字段名一律用实现里的真名。
+状态：v0.3，已对齐 `feat/installer-tui` 当前实现与 PR #52 的插件协议词表。命令与字段名一律用实现里的真名。
 分工：Elio 主状态机 / 配置事务 / 测试；本稿主用户路径 / 提示文案 / 中断恢复体验。同一 PR 交付。
 
 ## 0. 五条硬约束（贯穿全稿，也是判卷时先看的五条）
 
 1. **四步到底**：`credentials → bindings → frontend → memory → review`。任何一步 Ctrl-C 都只是暂停，不是失败。
 2. **draft → validate → commit**：草稿只存引用，密文进 `draft-secrets/`（0600）；`commit` 先写不可变快照再原子切 `current.json`。任一步取消或失败，`current.json` 不动。
-3. **凭证正文永不上屏、不进日志、不进错误、不进诊断导出、不进测试夹具**。屏幕上只有凭证的名字（`id`）和来源（`providerId` / `method`）。OAuth 由 pi 持有，安装器只拿到 `pi-auth://<key>` 这种定位符。
+3. **凭证正文永不上屏、不进日志、不进错误、不进诊断导出、不进测试夹具**。屏幕上只有凭证的名字（`id`）、来源（`providerId`）与公开类型（`CredentialType`）。OAuth 由 pi 持有，安装器只拿到 `pi-auth://<key>` 这种定位符。
 4. **留桩必须可见**：`frontend.kind = "official-skin"` 在 #49/#51 落地前只能是 `installation: "pending"`；界面明说"记录了意图，还没装"，不能显示成装好。
 5. **每屏能回答三件事**：我在第几步、还剩几步、现在退出会怎样。
 
@@ -28,7 +28,7 @@
 
 - B 选 discard：若草稿里 `memory.kind === "create"`，先删掉那时建的空库，再清草稿；这一步在界面上要说出来（"上次建的空记忆库 <path> 会一并删除"）。
 - C 选 reconfigure：旧 current 在新草稿 commit 之前一直有效，界面要说这句，用户才敢中途走。
-- **接线差异 D1**：A 态目前没有欢迎屏，直接落到 `Choose a credential provider`。建议加一段 `info`（见 §8 文案）。
+- A 态欢迎屏已接入；C 态重配期间旧 `current.json` 保持生效。
 
 ## 3. 第 1 步 · credentials（钥匙）
 
@@ -39,19 +39,16 @@
 4. OAuth 路径：屏幕先出 `Pi will open now. Run /login, choose <provider>, finish authorization, then quit Pi.`，然后把终端交给 pi；pi 退出后安装器只检查 `~/.pi/agent/auth.json` 里有没有该 provider 的 key，有 → 记 `pi-auth://<key>`；没有 → 报 `Pi exited without a <provider> credential in its auth store; the installer draft was kept`。
 5. API key 路径：`<provider> API key`（掩码输入），落进 `draft-secrets/<id>.credential`。
 6. `Add another credential?` —— 默认否。至少一把才能进第 2 步（validate 兜底）。
-7. Claude OAuth 的钥匙自动带 `adapterConstraint: "claude-agent-sdk"`；第 2 步选适配器时它只在 Claude Agent SDK 下出现。
-
-**接线差异 D2**：Claude OAuth 钥匙的"只能绑 Claude Agent SDK"这层约束目前只在第 2 步的过滤里体现，第 1 步收完没有告知。建议收完就 `info` 一句（§8）。
+7. `CredentialRef { id, type }` 与 PR #52 一致；Claude OAuth 的约束由 `type: "claude_oauth"` 表达，不另造 `adapterConstraint` 字段。它只在 Claude Agent SDK 下出现，收完时界面也会明说。
 
 ## 4. 第 2 步 · bindings（车道）
 
-对应 `collectBindings` / `chooseBinding`：
-- 主车道 `purpose: "main"`：`Daily channel adapter` → `Pi`（默认）/ `Claude Agent SDK`；然后 `Credential` 只列与该适配器兼容的钥匙。
-- `Configure a separate coding channel?`（默认是）→ `purpose: "coding"`：`Coding channel adapter`（默认 Claude Agent SDK）+ 兼容钥匙。
-- 落库形状：`ChannelBinding { residentId, purpose: "main" | "coding", adapterId, credentialId }`；`residentId × purpose` 唯一；`main` 必有。
-- 术语对齐：#52 RFC 里车道名是 `primary` / `coding`，这里的 `purpose: "main"` 是安装器本地契约（contracts.ts 头注写明），commit 边界翻译一次即可，本稿不再重复。
-
-**接线差异 D3（用户路径上最疼的一处）**：`chooseBinding` 在没有兼容钥匙时 `throw`，整个安装器以 `Setup failed: no credential can be used with adapter …` 退出。这是可恢复情境（用户只是少加了一把钥匙），不该是失败。建议：`info` 一句"没有能用在 <adapter> 上的钥匙"，然后回到第 1 步追加，草稿保留。
+对应 `collectBindings` / `chooseCredential`：
+- `primary` 主车道首版固定走 Pi，然后只列 Pi 能用的钥匙；Claude OAuth 不会混进来。
+- `Configure a separate coding channel?`（默认是）→ `coding` 车道首版固定走 Claude Agent SDK，然后列 Claude OAuth / API key。
+- coding 可选自定义 Claude-compatible gateway：`baseUrl + tokenCredentialRef`，token 必须引用一把 API key；这是 PR #52 PV0-D06 的首版能力，不是留桩。
+- 落库直接使用 RFC 形状：`LaneBinding { residentId, lane: "primary" | "coding", adapterId, credentialRef, adapterConfig? }`；`residentId × lane` 唯一；`primary` 必有。`main` 是角色，不是车道。
+- 若当前没有兼容钥匙，界面提示后回第 1 步追加；已有钥匙和草稿全部保留，不再把可恢复情境报成安装失败。
 
 ## 5. 第 3 步 · frontend（前端）
 
@@ -60,19 +57,19 @@
 - official-skin：`info` "The official skin install seam is reserved. It will activate when issues #49 and #51 land."，落 `{ kind: "official-skin", pluginId: "mist-official-skin", installation: "pending" }`。
 - external：`info` "Use the Mist session API contract to connect your existing frontend."，落 `{ kind: "external", integration: "mist-session-api" }`。
 
-**接线差异 D4（需要拍板，不是文案）**：目前 review 阶段只要 `installation === "pending"` 就直接返回 `dependency-pending`，**整份配置都不 commit**——钥匙、车道、记忆库全停在草稿里，`current.json` 不产生。也就是说四种验收组合里"无前端"的两种，现在的终点是"Setup is not active"。这确实是 fail-closed，但把"皮还没装"扩大成了"住户不能开工"。另一条路是：允许 commit，`current.json` 里如实写 `installation: "pending"`，住户先能用会话 API 干活，`npm run setup` 再跑一次或后续 `frontend install` 只补皮那一段。两条路都守住了"不把 TODO 显示成安装成功"，差别在住户能不能先住进去。**本稿倾向后者**（住户是主体，皮是外设），但这是产品口径，请 Elio 与维护者定；定了本稿 §8 的文案跟着改。
+产品口径已定为 fail-closed：只要 `installation === "pending"`，整份配置保留在草稿，`current.json` 不变。原因不是把皮当主体，而是 #50 的默认分支明确承诺“安装官方皮”；依赖没落地时不能把另一条 external 路径悄悄当成完成。pending 屏提供“保留草稿退出 / 改选前端”，后者只退回第 3 步，已完成的记忆库不重做。
 
 ## 6. 第 4 步 · memory（记忆库）
 
 对应 `collectMemory`：
 - `Memory library` → `Use an existing memory library` / `Create an empty memory library`（默认建）。
-- 路径默认 `<data-dir>/memory`。existing → `assertExisting`；create → 立刻建空库，`saveMemory` 失败则 `discardEmpty` 回滚。
+- 路径默认 `<data-dir>/memory`，输入 `~` / `~/…` 会展开。existing → `assertExisting`；create → 先把路径和 `memory_dir_created` 副作用写进草稿，再原子建空库。若进程刚好死在两者之间，重进 review 会幂等补建；discard 仍知道该清理什么。
 - 中断后 discard 草稿会一并删除这时建的空库（§2）。
 
 ## 7. review（汇总确认）与 commit
 
 对应 `runInstaller` 的 `review` 分支：
-- 目前只有一句 `Save this setup?`。**接线差异 D5**：确认前必须把草稿念一遍——钥匙（`id · provider · method · status`）、主车道 / coding 车道（adapter · credential id）、前端（external / official-skin pending）、记忆库（existing / create · path）。用户在这里看不见凭证正文，也不该看见；但看不见自己选了什么就点保存，是另一种盲签。文案见 §8。
+- `Save this setup?` 前会先念一遍草稿：钥匙（`id · provider · type · status`）、primary / coding 车道（adapter · credential id · 可选 gateway）、前端、记忆库。用户看得见自己的选择，看不见凭证正文。
 - 确认 → `commit()`：validate → 写快照 → 切 `current.json` → 删草稿与草稿密文。成功屏目前是 `Setup saved as <snapshotId>.`；建议补一句配置在哪、下一步是什么（§8）。
 - 不确认 → `paused`，草稿保留，`Setup paused. Run the same command to continue.`
 
@@ -81,15 +78,15 @@
 - A 态欢迎（D1）：
   `Welcome to Mist setup. Four steps: credentials → channels → frontend → memory. You can quit any time; only a draft is kept until you confirm.`
 - 每步开头一行（可选，实现里加一个 `info` 即可）：`Step 1/4 · Credentials` … `Step 4/4 · Memory`，review 用 `Review`。
-- Claude OAuth 收完（D2）：
-  `Saved as <id>. Note: a Claude subscription login can only run through the Claude Agent SDK adapter (using it via Pi would draw extra credit).`
-- 缺兼容钥匙（D3）：
+- Claude OAuth 收完：
+  `Saved as <id>. A Claude subscription login can only run through the Claude Agent SDK adapter.`
+- 缺兼容钥匙：
   `No saved credential can be used with <adapter>. Add one now — your draft is kept.` → 回到第 1 步。
-- review 汇总（D5）：
+- review 汇总：
   ```
   Review your setup (nothing is written yet):
     Credentials  codex-login (Codex, Pi sign-in, ready)
-    Daily        pi · codex-login
+    Primary      pi · codex-login
     Coding       claude-agent-sdk · claude-login   (or: not configured)
     Frontend     official skin — pending #49/#51   (or: external, session API)
     Memory       create · ~/.mist/memory           (or: existing · <path>)
@@ -105,25 +102,25 @@
 |---|---|---|
 | 1 | external × existing | 四步走完，成功屏给"connect via session API" |
 | 2 | external × create | 成功屏显示新建库路径 |
-| 3 | official-skin × existing | 见 D4 拍板：`dependency-pending`（现状）或 commit 且 frontend 显示 pending |
+| 3 | official-skin × existing | `dependency-pending`；草稿保留，旧 current 不变 |
 | 4 | official-skin × create | 同上 + 新建库路径 |
-| 5 | main pi + coding Claude SDK | review 屏两行车道；`current.json` 两条 binding |
+| 5 | primary Pi + coding Claude SDK | review 屏两行车道；`current.json` 两条 binding |
 | 6 | 每一步 Ctrl-C 一次 | 重进均为 B 态；resume 回到中断步；discard 后无残留（含空库） |
 | 7 | 脱敏 | 全流程终端输出、`installer-draft.json`、`current.json`、`snapshots/*`、测试夹具 grep 不到任何 key/token；`draft-secrets/` 0600 且 commit 后清空 |
-| 8 | Claude OAuth 钥匙 + 主车道选 Pi | 钥匙不在候选里；改选 Claude Agent SDK 后出现 |
-| 9 | 只加了 Claude OAuth 钥匙、主车道选 Pi | 现状：Setup failed；目标（D3）：提示后回第 1 步 |
+| 8 | Claude OAuth 钥匙 + primary Pi | 钥匙不在候选里；coding Claude Agent SDK 下出现 |
+| 9 | 只加了 Claude OAuth 钥匙 | 提示后回第 1 步追加兼容钥匙；Claude 钥匙保留 |
 | 10 | C 态 reconfigure 后中途 Ctrl-C | 旧 `current.json` 仍生效 |
 
 实测凭证：按维护者 02:34 UTC 提醒，用 Codex 登录或 Anthropic 通道的 API key，不用 Claude 订阅登录。
 
-## 10. 接线差异汇总（给 Elio 的清单）
+## 10. 接线差异汇总（已合入）
 
 | # | 类型 | 内容 | 谁改 |
 |---|---|---|---|
-| D1 | 文案 | A 态加欢迎与四步预告 | Laurie 可直接改 `run.ts` 字符串 |
-| D2 | 文案 | Claude OAuth 收完告知适配器约束 | 同上 |
-| D3 | 用户路径 | 无兼容钥匙时回第 1 步而不是 throw | Elio（动控制流） |
-| D4 | 产品口径 | pending 皮是否阻塞整份 commit | Elio + 维护者拍板 |
-| D5 | 文案+用户路径 | review 前念一遍草稿 | Laurie 写文案，Elio 接数据 |
+| D1 | 文案 | A 态加欢迎与四步预告 | 已接入 |
+| D2 | 文案 | Claude OAuth 收完告知适配器约束 | 已接入 |
+| D3 | 用户路径 | 无兼容钥匙时回第 1 步而不是 throw | 已接入并有回归测试 |
+| D4 | 产品口径 | pending 皮是否阻塞整份 commit | fail-closed，旧 current 不变 |
+| D5 | 文案+用户路径 | review 前念一遍草稿 | 已接入，敏感正文不出现 |
 
 — Laurie

--- a/docs/design/2026-08-17-installer-tui-walkthrough.md
+++ b/docs/design/2026-08-17-installer-tui-walkthrough.md
@@ -1,0 +1,129 @@
+# 安装引导 TUI · 用户路径走查（#50）
+
+状态：v0.2，对照 `feat/installer-tui` 1fcdb9d 写成。命令与字段名一律用实现里的真名。
+分工：Elio 主状态机 / 配置事务 / 测试；本稿主用户路径 / 提示文案 / 中断恢复体验。同一 PR 交付。
+
+## 0. 五条硬约束（贯穿全稿，也是判卷时先看的五条）
+
+1. **四步到底**：`credentials → bindings → frontend → memory → review`。任何一步 Ctrl-C 都只是暂停，不是失败。
+2. **draft → validate → commit**：草稿只存引用，密文进 `draft-secrets/`（0600）；`commit` 先写不可变快照再原子切 `current.json`。任一步取消或失败，`current.json` 不动。
+3. **凭证正文永不上屏、不进日志、不进错误、不进诊断导出、不进测试夹具**。屏幕上只有凭证的名字（`id`）和来源（`providerId` / `method`）。OAuth 由 pi 持有，安装器只拿到 `pi-auth://<key>` 这种定位符。
+4. **留桩必须可见**：`frontend.kind = "official-skin"` 在 #49/#51 落地前只能是 `installation: "pending"`；界面明说"记录了意图，还没装"，不能显示成装好。
+5. **每屏能回答三件事**：我在第几步、还剩几步、现在退出会怎样。
+
+## 1. 入口
+
+- 命令：`npm run setup`（`tsx src/installer/cli.ts`）。参数：`--resident <id>`（不给就问，默认 `resident-1`）、`--data-dir <dir>`（默认 `$MIST_DATA_DIR` 或 `~/.mist`）、`--pi-command <cmd>`（默认 `pi`）。
+- 落盘位置（都在 data-dir 下）：`installer-draft.json`（草稿，只有引用）、`draft-secrets/`（草稿期密文）、`snapshots/`（不可变配置快照）、`current.json`（指向当前生效快照）。
+
+## 2. 首屏三态
+
+安装器先读 `installer-draft.json` 和 `current.json`，分三态：
+
+| 态 | 条件 | 用户看到 | 选项 |
+|---|---|---|---|
+| A 全新 | 无草稿、无 current | 一句欢迎 + 四步预告 + "中途退出只会留下草稿，不会留下半套配置" | 直接进第 1 步 |
+| B 有草稿 | 有草稿 | `An unfinished setup was found` | `Continue where I stopped` / `Discard it and start over` |
+| C 已配置 | 无草稿、有 current | `Mist is already configured` | `Keep the current setup` / `Start a replacement draft` |
+
+- B 选 discard：若草稿里 `memory.kind === "create"`，先删掉那时建的空库，再清草稿；这一步在界面上要说出来（"上次建的空记忆库 <path> 会一并删除"）。
+- C 选 reconfigure：旧 current 在新草稿 commit 之前一直有效，界面要说这句，用户才敢中途走。
+- **接线差异 D1**：A 态目前没有欢迎屏，直接落到 `Choose a credential provider`。建议加一段 `info`（见 §8 文案）。
+
+## 3. 第 1 步 · credentials（钥匙）
+
+流程（对应 `collectCredentials`）：
+1. `Choose a credential provider` —— 列表来自 `PROVIDERS`（能力表，不是愿望表）：`Claude`（OAuth / API key）、`Codex`（OAuth / API key）、`Grok / xAI`（只 API key；pi 没有 Grok OAuth，界面上就不给）。
+2. `How should <provider> authenticate?` —— `Sign in through Pi` / `Enter an API key`。
+3. `Credential name` —— 默认 `<provider>-login` / `<provider>-key`，slug 化后成为 `id`，也是后面绑定时的引用名。
+4. OAuth 路径：屏幕先出 `Pi will open now. Run /login, choose <provider>, finish authorization, then quit Pi.`，然后把终端交给 pi；pi 退出后安装器只检查 `~/.pi/agent/auth.json` 里有没有该 provider 的 key，有 → 记 `pi-auth://<key>`；没有 → 报 `Pi exited without a <provider> credential in its auth store; the installer draft was kept`。
+5. API key 路径：`<provider> API key`（掩码输入），落进 `draft-secrets/<id>.credential`。
+6. `Add another credential?` —— 默认否。至少一把才能进第 2 步（validate 兜底）。
+7. Claude OAuth 的钥匙自动带 `adapterConstraint: "claude-agent-sdk"`；第 2 步选适配器时它只在 Claude Agent SDK 下出现。
+
+**接线差异 D2**：Claude OAuth 钥匙的"只能绑 Claude Agent SDK"这层约束目前只在第 2 步的过滤里体现，第 1 步收完没有告知。建议收完就 `info` 一句（§8）。
+
+## 4. 第 2 步 · bindings（车道）
+
+对应 `collectBindings` / `chooseBinding`：
+- 主车道 `purpose: "main"`：`Daily channel adapter` → `Pi`（默认）/ `Claude Agent SDK`；然后 `Credential` 只列与该适配器兼容的钥匙。
+- `Configure a separate coding channel?`（默认是）→ `purpose: "coding"`：`Coding channel adapter`（默认 Claude Agent SDK）+ 兼容钥匙。
+- 落库形状：`ChannelBinding { residentId, purpose: "main" | "coding", adapterId, credentialId }`；`residentId × purpose` 唯一；`main` 必有。
+- 术语对齐：#52 RFC 里车道名是 `primary` / `coding`，这里的 `purpose: "main"` 是安装器本地契约（contracts.ts 头注写明），commit 边界翻译一次即可，本稿不再重复。
+
+**接线差异 D3（用户路径上最疼的一处）**：`chooseBinding` 在没有兼容钥匙时 `throw`，整个安装器以 `Setup failed: no credential can be used with adapter …` 退出。这是可恢复情境（用户只是少加了一把钥匙），不该是失败。建议：`info` 一句"没有能用在 <adapter> 上的钥匙"，然后回到第 1 步追加，草稿保留。
+
+## 5. 第 3 步 · frontend（前端）
+
+对应 `collectFrontend`：
+- `Frontend` → `Install the official Mist skin`（默认）/ `Connect my own frontend`。
+- official-skin：`info` "The official skin install seam is reserved. It will activate when issues #49 and #51 land."，落 `{ kind: "official-skin", pluginId: "mist-official-skin", installation: "pending" }`。
+- external：`info` "Use the Mist session API contract to connect your existing frontend."，落 `{ kind: "external", integration: "mist-session-api" }`。
+
+**接线差异 D4（需要拍板，不是文案）**：目前 review 阶段只要 `installation === "pending"` 就直接返回 `dependency-pending`，**整份配置都不 commit**——钥匙、车道、记忆库全停在草稿里，`current.json` 不产生。也就是说四种验收组合里"无前端"的两种，现在的终点是"Setup is not active"。这确实是 fail-closed，但把"皮还没装"扩大成了"住户不能开工"。另一条路是：允许 commit，`current.json` 里如实写 `installation: "pending"`，住户先能用会话 API 干活，`npm run setup` 再跑一次或后续 `frontend install` 只补皮那一段。两条路都守住了"不把 TODO 显示成安装成功"，差别在住户能不能先住进去。**本稿倾向后者**（住户是主体，皮是外设），但这是产品口径，请 Elio 与维护者定；定了本稿 §8 的文案跟着改。
+
+## 6. 第 4 步 · memory（记忆库）
+
+对应 `collectMemory`：
+- `Memory library` → `Use an existing memory library` / `Create an empty memory library`（默认建）。
+- 路径默认 `<data-dir>/memory`。existing → `assertExisting`；create → 立刻建空库，`saveMemory` 失败则 `discardEmpty` 回滚。
+- 中断后 discard 草稿会一并删除这时建的空库（§2）。
+
+## 7. review（汇总确认）与 commit
+
+对应 `runInstaller` 的 `review` 分支：
+- 目前只有一句 `Save this setup?`。**接线差异 D5**：确认前必须把草稿念一遍——钥匙（`id · provider · method · status`）、主车道 / coding 车道（adapter · credential id）、前端（external / official-skin pending）、记忆库（existing / create · path）。用户在这里看不见凭证正文，也不该看见；但看不见自己选了什么就点保存，是另一种盲签。文案见 §8。
+- 确认 → `commit()`：validate → 写快照 → 切 `current.json` → 删草稿与草稿密文。成功屏目前是 `Setup saved as <snapshotId>.`；建议补一句配置在哪、下一步是什么（§8）。
+- 不确认 → `paused`，草稿保留，`Setup paused. Run the same command to continue.`
+
+## 8. 文案（英文，跟实现一致；括号里是给谁看的说明）
+
+- A 态欢迎（D1）：
+  `Welcome to Mist setup. Four steps: credentials → channels → frontend → memory. You can quit any time; only a draft is kept until you confirm.`
+- 每步开头一行（可选，实现里加一个 `info` 即可）：`Step 1/4 · Credentials` … `Step 4/4 · Memory`，review 用 `Review`。
+- Claude OAuth 收完（D2）：
+  `Saved as <id>. Note: a Claude subscription login can only run through the Claude Agent SDK adapter (using it via Pi would draw extra credit).`
+- 缺兼容钥匙（D3）：
+  `No saved credential can be used with <adapter>. Add one now — your draft is kept.` → 回到第 1 步。
+- review 汇总（D5）：
+  ```
+  Review your setup (nothing is written yet):
+    Credentials  codex-login (Codex, Pi sign-in, ready)
+    Daily        pi · codex-login
+    Coding       claude-agent-sdk · claude-login   (or: not configured)
+    Frontend     official skin — pending #49/#51   (or: external, session API)
+    Memory       create · ~/.mist/memory           (or: existing · <path>)
+  Save this setup?
+  ```
+- 成功：`Setup saved as <snapshotId>. Config: <data-dir>/current.json. Next: <按分支一句：connect your frontend to the session API / rerun setup after #49/#51 to install the skin>.`
+- 退出提示（Ctrl-C）：保持现有 `Setup paused. Run the same command to continue.`；若草稿里已建空库，加一句 `An empty memory library was created at <path>; discarding the draft later will remove it.`
+- 报错三段式：发生了什么 · 现在能做什么 · （可选）去哪看。不出现内部字段名与堆栈；凭证相关错误只提 `id`。
+
+## 9. 验收对照（用户可观察项；与 Elio 的测试和 dankefox 的审点对齐）
+
+| # | 场景 | 用户看到什么 |
+|---|---|---|
+| 1 | external × existing | 四步走完，成功屏给"connect via session API" |
+| 2 | external × create | 成功屏显示新建库路径 |
+| 3 | official-skin × existing | 见 D4 拍板：`dependency-pending`（现状）或 commit 且 frontend 显示 pending |
+| 4 | official-skin × create | 同上 + 新建库路径 |
+| 5 | main pi + coding Claude SDK | review 屏两行车道；`current.json` 两条 binding |
+| 6 | 每一步 Ctrl-C 一次 | 重进均为 B 态；resume 回到中断步；discard 后无残留（含空库） |
+| 7 | 脱敏 | 全流程终端输出、`installer-draft.json`、`current.json`、`snapshots/*`、测试夹具 grep 不到任何 key/token；`draft-secrets/` 0600 且 commit 后清空 |
+| 8 | Claude OAuth 钥匙 + 主车道选 Pi | 钥匙不在候选里；改选 Claude Agent SDK 后出现 |
+| 9 | 只加了 Claude OAuth 钥匙、主车道选 Pi | 现状：Setup failed；目标（D3）：提示后回第 1 步 |
+| 10 | C 态 reconfigure 后中途 Ctrl-C | 旧 `current.json` 仍生效 |
+
+实测凭证：按维护者 02:34 UTC 提醒，用 Codex 登录或 Anthropic 通道的 API key，不用 Claude 订阅登录。
+
+## 10. 接线差异汇总（给 Elio 的清单）
+
+| # | 类型 | 内容 | 谁改 |
+|---|---|---|---|
+| D1 | 文案 | A 态加欢迎与四步预告 | Laurie 可直接改 `run.ts` 字符串 |
+| D2 | 文案 | Claude OAuth 收完告知适配器约束 | 同上 |
+| D3 | 用户路径 | 无兼容钥匙时回第 1 步而不是 throw | Elio（动控制流） |
+| D4 | 产品口径 | pending 皮是否阻塞整份 commit | Elio + 维护者拍板 |
+| D5 | 文案+用户路径 | review 前念一遍草稿 | Laurie 写文案，Elio 接数据 |
+
+— Laurie

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "mist-agent",
       "version": "0.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.220"
+        "@anthropic-ai/claude-agent-sdk": "0.3.220",
+        "@inquirer/prompts": "^8.5.2"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -800,6 +801,334 @@
         "hono": "^4"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1233,7 +1562,7 @@
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1518,6 +1847,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "license": "MIT"
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1526,6 +1861,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/content-disposition": {
@@ -1894,6 +2238,21 @@
       "license": "Unlicense",
       "peer": true
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -1910,6 +2269,15 @@
       ],
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -2092,7 +2460,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2269,6 +2636,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -2577,8 +2953,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -2739,6 +3114,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2916,7 +3303,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "demo": "tsx demo/main.ts",
+    "setup": "tsx src/installer/cli.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -24,6 +25,7 @@
     "vitest": "^2.1.8"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.220"
+    "@anthropic-ai/claude-agent-sdk": "0.3.220",
+    "@inquirer/prompts": "^8.5.2"
   }
 }

--- a/src/installer/cli.ts
+++ b/src/installer/cli.ts
@@ -1,0 +1,98 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { InstallerController } from "./controller.ts";
+import { FileMemoryLibrary } from "./memory-library.ts";
+import { PiInteractiveLogin } from "./pi-login.ts";
+import { InquirerPromptPort } from "./prompt-port.ts";
+import { runInstaller } from "./run.ts";
+import { InstallerStateStore } from "./state-store.ts";
+
+interface CliArguments {
+  residentId?: string;
+  dataDir: string;
+  piCommand: string;
+}
+
+function valueAfter(args: readonly string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+export function parseInstallerArguments(args: readonly string[]): CliArguments {
+  const parsed: CliArguments = {
+    dataDir: process.env.MIST_DATA_DIR ?? join(homedir(), ".mist"),
+    piCommand: "pi",
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    switch (argument) {
+      case "--resident":
+        parsed.residentId = valueAfter(args, index, argument);
+        index += 1;
+        break;
+      case "--data-dir":
+        parsed.dataDir = valueAfter(args, index, argument);
+        index += 1;
+        break;
+      case "--pi-command":
+        parsed.piCommand = valueAfter(args, index, argument);
+        index += 1;
+        break;
+      default:
+        throw new Error(`unknown installer argument: ${argument ?? ""}`);
+    }
+  }
+  return parsed;
+}
+
+export async function main(args = process.argv.slice(2)): Promise<void> {
+  const cli = parseInstallerArguments(args);
+  const prompt = new InquirerPromptPort();
+  const residentId =
+    cli.residentId ??
+    (await prompt.input({
+      message: "Resident ID",
+      default: "resident-1",
+    }));
+  const dataDir = resolve(cli.dataDir);
+  const store = new InstallerStateStore(dataDir);
+  const controller = new InstallerController(store);
+  const result = await runInstaller({
+    residentId,
+    dataDir,
+    store,
+    controller,
+    prompt,
+    oauth: new PiInteractiveLogin({ command: cli.piCommand }),
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+  if (result.status === "committed") {
+    prompt.info(`Setup saved as ${result.receipt.snapshotId}.`);
+  } else if (result.status === "paused") {
+    prompt.info("Setup paused. Run the same command to continue.");
+  } else if (result.status === "dependency-pending") {
+    prompt.info(
+      `Setup is not active. The draft is waiting for ${result.dependencies.join(" and ")}.`,
+    );
+  } else {
+    prompt.info("Current setup kept unchanged.");
+  }
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined && import.meta.url === pathToFileURL(resolve(invokedPath)).href) {
+  main().catch((error: unknown) => {
+    if (error instanceof Error && error.name === "ExitPromptError") {
+      process.stdout.write("\nSetup paused. Run the same command to continue.\n");
+      process.exitCode = 130;
+      return;
+    }
+    const message = error instanceof Error ? error.message : "unknown installer failure";
+    process.stderr.write(`Setup failed: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/installer/contracts.ts
+++ b/src/installer/contracts.ts
@@ -277,6 +277,37 @@ function validateBindingCredential(
   }
 }
 
+function toCredentialRef(ref: CredentialRef): CredentialRef {
+  return {
+    id: ref.id,
+    type: ref.type,
+    issuerId: ref.issuerId,
+  };
+}
+
+function toLaneBinding(binding: LaneBinding): LaneBinding {
+  return {
+    residentId: binding.residentId,
+    lane: binding.lane,
+    adapterId: binding.adapterId,
+    credentialRef: toCredentialRef(binding.credentialRef),
+    ...(binding.adapterConfig === undefined
+      ? {}
+      : {
+          adapterConfig: {
+            ...(binding.adapterConfig.baseUrl === undefined
+              ? {}
+              : { baseUrl: binding.adapterConfig.baseUrl }),
+            ...(binding.adapterConfig.tokenCredentialRef === undefined
+              ? {}
+              : {
+                  tokenCredentialRef: toCredentialRef(binding.adapterConfig.tokenCredentialRef),
+                }),
+          },
+        }),
+  };
+}
+
 export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
   if (draft.schemaVersion !== INSTALLER_DRAFT_SCHEMA_VERSION) {
     throw new InstallerValidationError(
@@ -367,8 +398,8 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
   return {
     schemaVersion: INSTALL_CONFIG_SCHEMA_VERSION,
     residentId: draft.residentId,
-    credentialRefs: draft.credentials.map((credential) => ({ ...credential.ref })),
-    bindings: draft.bindings.map((binding) => structuredClone(binding)),
+    credentialRefs: draft.credentials.map((credential) => toCredentialRef(credential.ref)),
+    bindings: draft.bindings.map(toLaneBinding),
     frontend,
     memory,
   };

--- a/src/installer/contracts.ts
+++ b/src/installer/contracts.ts
@@ -1,4 +1,6 @@
-export const INSTALLER_DRAFT_SCHEMA_VERSION = 1;
+import { randomUUID } from "node:crypto";
+
+export const INSTALLER_DRAFT_SCHEMA_VERSION = 2;
 export const INSTALL_CONFIG_SCHEMA_VERSION = 1;
 
 export type InstallerStep = "credentials" | "bindings" | "frontend" | "memory" | "review";
@@ -65,6 +67,7 @@ export interface InstallerProgress {
 export type InstallerSideEffect = {
   kind: "memory_dir_created";
   path: string;
+  ownerDraftId: string;
 };
 
 /**
@@ -76,6 +79,7 @@ export type InstallerSideEffect = {
  */
 export interface InstallerDraft {
   schemaVersion: typeof INSTALLER_DRAFT_SCHEMA_VERSION;
+  draftId: string;
   residentId: string;
   credentials: InstallerCredential[];
   bindings: LaneBinding[];
@@ -127,6 +131,7 @@ export function createInstallerDraft(residentId: string): InstallerDraft {
   }
   return {
     schemaVersion: INSTALLER_DRAFT_SCHEMA_VERSION,
+    draftId: randomUUID(),
     residentId,
     credentials: [],
     bindings: [],
@@ -156,6 +161,32 @@ function validateCredentialIssuer(credential: InstallerCredential): void {
   }
 }
 
+const CREDENTIAL_TYPES = new Set<CredentialType>([
+  "claude_oauth",
+  "codex_oauth",
+  "grok_oauth",
+  "api_key",
+]);
+const CREDENTIAL_STATUSES = new Set<CredentialStatus>(["ready", "incomplete"]);
+const LANES = new Set<Lane>(["primary", "coding"]);
+const ADAPTER_CREDENTIAL_TYPES = {
+  pi: new Set<CredentialType>(["codex_oauth", "grok_oauth", "api_key"]),
+  "claude-agent-sdk": new Set<CredentialType>(["claude_oauth", "api_key"]),
+} as const;
+
+function validateCredentialEnums(credential: InstallerCredential): void {
+  if (!CREDENTIAL_TYPES.has(credential.ref.type)) {
+    throw new InstallerValidationError(
+      `credential ${credential.ref.id} has unsupported type: ${String(credential.ref.type)}`,
+    );
+  }
+  if (!CREDENTIAL_STATUSES.has(credential.status)) {
+    throw new InstallerValidationError(
+      `credential ${credential.ref.id} has unsupported status: ${String(credential.status)}`,
+    );
+  }
+}
+
 function validateBindingCredential(
   binding: LaneBinding,
   credentials: ReadonlyMap<string, InstallerCredential>,
@@ -174,9 +205,14 @@ function validateBindingCredential(
       `binding credential type or issuer does not match stored ref: ${binding.credentialRef.id}`,
     );
   }
-  if (credential.ref.type === "claude_oauth" && binding.adapterId !== "claude-agent-sdk") {
+  const acceptedTypes =
+    ADAPTER_CREDENTIAL_TYPES[binding.adapterId as keyof typeof ADAPTER_CREDENTIAL_TYPES];
+  if (acceptedTypes === undefined) {
+    throw new InstallerValidationError(`unsupported binding adapter: ${binding.adapterId}`);
+  }
+  if (!acceptedTypes.has(credential.ref.type)) {
     throw new InstallerValidationError(
-      `credential ${credential.ref.id} requires adapter claude-agent-sdk`,
+      `adapter ${binding.adapterId} does not accept credential type ${credential.ref.type}`,
     );
   }
 }
@@ -187,6 +223,7 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
       `unsupported installer draft schemaVersion: ${draft.schemaVersion}`,
     );
   }
+  assertSafeInstallerId(draft.draftId, "draft id");
   requireNonEmpty(draft.residentId, "residentId");
   if (draft.credentials.length === 0) {
     throw new InstallerValidationError("at least one credential is required");
@@ -198,6 +235,7 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
     requireNonEmpty(credential.label, `credential ${credential.ref.id} label`);
     requireNonEmpty(credential.providerId, `credential ${credential.ref.id} providerId`);
     requireNonEmpty(credential.ref.issuerId, `credential ${credential.ref.id} issuerId`);
+    validateCredentialEnums(credential);
     validateCredentialIssuer(credential);
     if (credential.status !== "ready") {
       throw new InstallerValidationError(`credential ${credential.ref.id} is incomplete`);
@@ -211,6 +249,14 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
   const bindings = new Set<string>();
   for (const binding of draft.bindings) {
     requireNonEmpty(binding.residentId, "binding residentId");
+    if (binding.residentId !== draft.residentId) {
+      throw new InstallerValidationError(
+        `binding resident ${binding.residentId} does not match draft resident ${draft.residentId}`,
+      );
+    }
+    if (!LANES.has(binding.lane)) {
+      throw new InstallerValidationError(`unsupported binding lane: ${String(binding.lane)}`);
+    }
     requireNonEmpty(binding.adapterId, "binding adapterId");
     const bindingKey = `${binding.residentId}\u0000${binding.lane}`;
     if (bindings.has(bindingKey)) {

--- a/src/installer/contracts.ts
+++ b/src/installer/contracts.ts
@@ -221,21 +221,27 @@ function validateCredentialIssuer(credential: InstallerCredential): void {
   }
 }
 
-const CREDENTIAL_TYPES = new Set<CredentialType>([
+const INSTALLER_CREDENTIAL_TYPES = new Set<CredentialType>([
   "claude_oauth",
   "codex_oauth",
-  "grok_oauth",
   "api_key",
 ]);
 const CREDENTIAL_STATUSES = new Set<CredentialStatus>(["ready", "incomplete"]);
 const LANES = new Set<Lane>(["primary", "coding"]);
 const ADAPTER_CREDENTIAL_TYPES = {
-  pi: new Set<CredentialType>(["codex_oauth", "grok_oauth", "api_key"]),
+  pi: new Set<CredentialType>(["codex_oauth", "api_key"]),
   "claude-agent-sdk": new Set<CredentialType>(["claude_oauth", "api_key"]),
 } as const;
 
+export function installerAdapterAcceptsCredentialType(
+  adapterId: keyof typeof ADAPTER_CREDENTIAL_TYPES,
+  type: CredentialType,
+): boolean {
+  return ADAPTER_CREDENTIAL_TYPES[adapterId].has(type);
+}
+
 function validateCredentialEnums(credential: InstallerCredential): void {
-  if (!CREDENTIAL_TYPES.has(credential.ref.type)) {
+  if (!INSTALLER_CREDENTIAL_TYPES.has(credential.ref.type)) {
     throw new InstallerValidationError(
       `credential ${credential.ref.id} has unsupported type: ${String(credential.ref.type)}`,
     );
@@ -385,7 +391,7 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
     throw new InstallerValidationError("frontend choice is required");
   }
   const frontend = validateFrontendChoice(draft.frontend);
-  if (frontend.kind === "official-skin" && frontend.installation !== "installed") {
+  if (frontend.kind === "official-skin") {
     throw new InstallerValidationError(
       "official skin is pending issues #49 and #51 and cannot be activated yet",
     );

--- a/src/installer/contracts.ts
+++ b/src/installer/contracts.ts
@@ -12,6 +12,7 @@ export type Lane = "primary" | "coding";
 export interface CredentialRef {
   id: string;
   type: CredentialType;
+  issuerId: string;
 }
 
 /** Installer-only metadata. This is never embedded in a lane binding or active config. */
@@ -115,7 +116,7 @@ export function assertSafeInstallerId(value: string, field: string): void {
   }
 }
 
-export function credentialSecretRef(credential: CredentialRef): string {
+export function credentialSecretRef(credential: Pick<CredentialRef, "id">): string {
   assertSafeInstallerId(credential.id, "credential id");
   return `${credential.id}.credential`;
 }
@@ -146,6 +147,15 @@ function requireNonEmpty(value: string, field: string): void {
   }
 }
 
+function validateCredentialIssuer(credential: InstallerCredential): void {
+  const expectedIssuer = credential.ref.type === "api_key" ? "mist-installer-api-key" : "pi";
+  if (credential.ref.issuerId !== expectedIssuer) {
+    throw new InstallerValidationError(
+      `credential ${credential.ref.id} issuer is unavailable for type ${credential.ref.type}`,
+    );
+  }
+}
+
 function validateBindingCredential(
   binding: LaneBinding,
   credentials: ReadonlyMap<string, InstallerCredential>,
@@ -156,9 +166,12 @@ function validateBindingCredential(
       `binding references unknown credential: ${binding.credentialRef.id}`,
     );
   }
-  if (credential.ref.type !== binding.credentialRef.type) {
+  if (
+    credential.ref.type !== binding.credentialRef.type ||
+    credential.ref.issuerId !== binding.credentialRef.issuerId
+  ) {
     throw new InstallerValidationError(
-      `binding credential type does not match stored ref: ${binding.credentialRef.id}`,
+      `binding credential type or issuer does not match stored ref: ${binding.credentialRef.id}`,
     );
   }
   if (credential.ref.type === "claude_oauth" && binding.adapterId !== "claude-agent-sdk") {
@@ -184,6 +197,8 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
     assertSafeInstallerId(credential.ref.id, "credential id");
     requireNonEmpty(credential.label, `credential ${credential.ref.id} label`);
     requireNonEmpty(credential.providerId, `credential ${credential.ref.id} providerId`);
+    requireNonEmpty(credential.ref.issuerId, `credential ${credential.ref.id} issuerId`);
+    validateCredentialIssuer(credential);
     if (credential.status !== "ready") {
       throw new InstallerValidationError(`credential ${credential.ref.id} is incomplete`);
     }
@@ -217,7 +232,8 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
       if (
         tokenCredential === undefined ||
         tokenCredential.ref.type !== "api_key" ||
-        adapterConfig.tokenCredentialRef.type !== "api_key"
+        adapterConfig.tokenCredentialRef.type !== "api_key" ||
+        tokenCredential.ref.issuerId !== adapterConfig.tokenCredentialRef.issuerId
       ) {
         throw new InstallerValidationError(
           `binding ${binding.lane} tokenCredentialRef must reference an api_key`,

--- a/src/installer/contracts.ts
+++ b/src/installer/contracts.ts
@@ -1,0 +1,210 @@
+export const INSTALLER_DRAFT_SCHEMA_VERSION = 1;
+export const INSTALL_CONFIG_SCHEMA_VERSION = 1;
+
+export type InstallerStep = "credentials" | "bindings" | "frontend" | "memory" | "review";
+
+export type CredentialMethod = "oauth" | "api-key";
+export type CredentialStatus = "ready" | "incomplete";
+export type BindingPurpose = "main" | "coding";
+
+export interface CredentialRef {
+  id: string;
+  label: string;
+  providerId: string;
+  method: CredentialMethod;
+  secretRef: string;
+  status: CredentialStatus;
+  /** Claude OAuth may only execute through the Claude Agent SDK adapter. */
+  adapterConstraint?: "claude-agent-sdk";
+}
+
+export interface ChannelBinding {
+  residentId: string;
+  purpose: BindingPurpose;
+  adapterId: string;
+  credentialId: string;
+}
+
+export type FrontendChoice =
+  | {
+      kind: "external";
+      integration: "mist-session-api";
+    }
+  | {
+      kind: "official-skin";
+      pluginId: "mist-official-skin";
+      /** Issue #50 deliberately leaves this branch pending until issues #49 and #51 land. */
+      installation: "pending" | "installed";
+    };
+
+export type MemoryChoice =
+  | {
+      kind: "existing";
+      path: string;
+    }
+  | {
+      kind: "create";
+      path: string;
+    };
+
+export interface InstallerProgress {
+  currentStep: InstallerStep;
+  completedSteps: InstallerStep[];
+  status: "in-progress" | "ready-to-commit";
+}
+
+/**
+ * Resumable installer state. It contains references only: secret material lives in the
+ * draft credential store and never enters this JSON document.
+ *
+ * This is an installer-local contract, not the final plugin RFC from issue #51. The commit
+ * boundary is the only place that will need to translate when that RFC freezes.
+ */
+export interface InstallerDraft {
+  schemaVersion: typeof INSTALLER_DRAFT_SCHEMA_VERSION;
+  residentId: string;
+  credentialRefs: CredentialRef[];
+  bindings: ChannelBinding[];
+  frontend: FrontendChoice | null;
+  memory: MemoryChoice | null;
+  progress: InstallerProgress;
+}
+
+export interface MistInstallConfigV0 {
+  schemaVersion: typeof INSTALL_CONFIG_SCHEMA_VERSION;
+  residentId: string;
+  credentialRefs: CredentialRef[];
+  bindings: ChannelBinding[];
+  frontend: FrontendChoice;
+  memory: MemoryChoice;
+}
+
+export interface InstallCommitReceipt {
+  snapshotId: string;
+  config: MistInstallConfigV0;
+}
+
+export class InstallerValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InstallerValidationError";
+  }
+}
+
+const SAFE_ID = /^[a-z0-9][a-z0-9._-]*$/;
+
+export function assertSafeInstallerId(value: string, field: string): void {
+  if (!SAFE_ID.test(value)) {
+    throw new InstallerValidationError(
+      `${field} must start with a lowercase letter or digit and contain only a-z, 0-9, ., _, or -`,
+    );
+  }
+}
+
+export function createInstallerDraft(residentId: string): InstallerDraft {
+  if (residentId.trim().length === 0) {
+    throw new InstallerValidationError("residentId must not be empty");
+  }
+  return {
+    schemaVersion: INSTALLER_DRAFT_SCHEMA_VERSION,
+    residentId,
+    credentialRefs: [],
+    bindings: [],
+    frontend: null,
+    memory: null,
+    progress: {
+      currentStep: "credentials",
+      completedSteps: [],
+      status: "in-progress",
+    },
+  };
+}
+
+function requireNonEmpty(value: string, field: string): void {
+  if (value.trim().length === 0) {
+    throw new InstallerValidationError(`${field} must not be empty`);
+  }
+}
+
+export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
+  if (draft.schemaVersion !== INSTALLER_DRAFT_SCHEMA_VERSION) {
+    throw new InstallerValidationError(
+      `unsupported installer draft schemaVersion: ${draft.schemaVersion}`,
+    );
+  }
+  requireNonEmpty(draft.residentId, "residentId");
+  if (draft.credentialRefs.length === 0) {
+    throw new InstallerValidationError("at least one credential is required");
+  }
+
+  const credentials = new Map<string, CredentialRef>();
+  const secretRefs = new Set<string>();
+  for (const credential of draft.credentialRefs) {
+    assertSafeInstallerId(credential.id, "credential id");
+    assertSafeInstallerId(credential.secretRef, "credential secretRef");
+    requireNonEmpty(credential.label, `credential ${credential.id} label`);
+    requireNonEmpty(credential.providerId, `credential ${credential.id} providerId`);
+    if (credential.status !== "ready") {
+      throw new InstallerValidationError(`credential ${credential.id} is incomplete`);
+    }
+    if (credentials.has(credential.id)) {
+      throw new InstallerValidationError(`duplicate credential id: ${credential.id}`);
+    }
+    if (secretRefs.has(credential.secretRef)) {
+      throw new InstallerValidationError(`duplicate credential secretRef: ${credential.secretRef}`);
+    }
+    credentials.set(credential.id, credential);
+    secretRefs.add(credential.secretRef);
+  }
+
+  const bindings = new Set<string>();
+  for (const binding of draft.bindings) {
+    requireNonEmpty(binding.residentId, "binding residentId");
+    requireNonEmpty(binding.adapterId, "binding adapterId");
+    const bindingKey = `${binding.residentId}\u0000${binding.purpose}`;
+    if (bindings.has(bindingKey)) {
+      throw new InstallerValidationError(
+        `duplicate ${binding.purpose} binding for resident ${binding.residentId}`,
+      );
+    }
+    bindings.add(bindingKey);
+    const credential = credentials.get(binding.credentialId);
+    if (credential === undefined) {
+      throw new InstallerValidationError(
+        `binding references unknown credential: ${binding.credentialId}`,
+      );
+    }
+    if (
+      credential.adapterConstraint !== undefined &&
+      credential.adapterConstraint !== binding.adapterId
+    ) {
+      throw new InstallerValidationError(
+        `credential ${credential.id} requires adapter ${credential.adapterConstraint}`,
+      );
+    }
+  }
+  if (!draft.bindings.some((binding) => binding.purpose === "main")) {
+    throw new InstallerValidationError("a main channel binding is required");
+  }
+  if (draft.frontend === null) {
+    throw new InstallerValidationError("frontend choice is required");
+  }
+  if (draft.frontend.kind === "official-skin" && draft.frontend.installation !== "installed") {
+    throw new InstallerValidationError(
+      "official skin is pending issues #49 and #51 and cannot be activated yet",
+    );
+  }
+  if (draft.memory === null) {
+    throw new InstallerValidationError("memory choice is required");
+  }
+  requireNonEmpty(draft.memory.path, "memory path");
+
+  return {
+    schemaVersion: INSTALL_CONFIG_SCHEMA_VERSION,
+    residentId: draft.residentId,
+    credentialRefs: draft.credentialRefs.map((credential) => ({ ...credential })),
+    bindings: draft.bindings.map((binding) => ({ ...binding })),
+    frontend: { ...draft.frontend },
+    memory: { ...draft.memory },
+  };
+}

--- a/src/installer/contracts.ts
+++ b/src/installer/contracts.ts
@@ -152,6 +152,66 @@ function requireNonEmpty(value: string, field: string): void {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new InstallerValidationError(`${field} must be a string`);
+  }
+  requireNonEmpty(value, field);
+  return value;
+}
+
+function validateFrontendChoice(value: unknown): FrontendChoice {
+  if (!isRecord(value)) {
+    throw new InstallerValidationError("frontend choice has an unsupported shape");
+  }
+  switch (value.kind) {
+    case "external":
+      if (value.integration !== "mist-session-api") {
+        throw new InstallerValidationError(
+          `external frontend has unsupported integration: ${String(value.integration)}`,
+        );
+      }
+      return { kind: "external", integration: "mist-session-api" };
+    case "official-skin":
+      if (value.pluginId !== "mist-official-skin") {
+        throw new InstallerValidationError(
+          `official frontend has unsupported pluginId: ${String(value.pluginId)}`,
+        );
+      }
+      if (value.installation !== "pending" && value.installation !== "installed") {
+        throw new InstallerValidationError(
+          `official frontend has unsupported installation: ${String(value.installation)}`,
+        );
+      }
+      return {
+        kind: "official-skin",
+        pluginId: "mist-official-skin",
+        installation: value.installation,
+      };
+    default:
+      throw new InstallerValidationError(`unsupported frontend kind: ${String(value.kind)}`);
+  }
+}
+
+function validateMemoryChoice(value: unknown): MemoryChoice {
+  if (!isRecord(value)) {
+    throw new InstallerValidationError("memory choice has an unsupported shape");
+  }
+  const path = requireString(value.path, "memory path");
+  switch (value.kind) {
+    case "existing":
+      return { kind: "existing", path };
+    case "create":
+      return { kind: "create", path };
+    default:
+      throw new InstallerValidationError(`unsupported memory kind: ${String(value.kind)}`);
+  }
+}
+
 function validateCredentialIssuer(credential: InstallerCredential): void {
   const expectedIssuer = credential.ref.type === "api_key" ? "mist-installer-api-key" : "pi";
   if (credential.ref.issuerId !== expectedIssuer) {
@@ -293,7 +353,8 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
   if (draft.frontend === null) {
     throw new InstallerValidationError("frontend choice is required");
   }
-  if (draft.frontend.kind === "official-skin" && draft.frontend.installation !== "installed") {
+  const frontend = validateFrontendChoice(draft.frontend);
+  if (frontend.kind === "official-skin" && frontend.installation !== "installed") {
     throw new InstallerValidationError(
       "official skin is pending issues #49 and #51 and cannot be activated yet",
     );
@@ -301,14 +362,14 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
   if (draft.memory === null) {
     throw new InstallerValidationError("memory choice is required");
   }
-  requireNonEmpty(draft.memory.path, "memory path");
+  const memory = validateMemoryChoice(draft.memory);
 
   return {
     schemaVersion: INSTALL_CONFIG_SCHEMA_VERSION,
     residentId: draft.residentId,
     credentialRefs: draft.credentials.map((credential) => ({ ...credential.ref })),
     bindings: draft.bindings.map((binding) => structuredClone(binding)),
-    frontend: { ...draft.frontend },
-    memory: { ...draft.memory },
+    frontend,
+    memory,
   };
 }

--- a/src/installer/contracts.ts
+++ b/src/installer/contracts.ts
@@ -5,24 +5,32 @@ export type InstallerStep = "credentials" | "bindings" | "frontend" | "memory" |
 
 export type CredentialMethod = "oauth" | "api-key";
 export type CredentialStatus = "ready" | "incomplete";
-export type BindingPurpose = "main" | "coding";
+export type CredentialType = "claude_oauth" | "codex_oauth" | "grok_oauth" | "api_key";
+export type Lane = "primary" | "coding";
 
+/** Public credential shape from plugin protocol v0. Secret material stays in the credential store. */
 export interface CredentialRef {
   id: string;
-  label: string;
-  providerId: string;
-  method: CredentialMethod;
-  secretRef: string;
-  status: CredentialStatus;
-  /** Claude OAuth may only execute through the Claude Agent SDK adapter. */
-  adapterConstraint?: "claude-agent-sdk";
+  type: CredentialType;
 }
 
-export interface ChannelBinding {
+/** Installer-only metadata. This is never embedded in a lane binding or active config. */
+export interface InstallerCredential {
+  ref: CredentialRef;
+  label: string;
+  providerId: string;
+  status: CredentialStatus;
+}
+
+export interface LaneBinding {
   residentId: string;
-  purpose: BindingPurpose;
+  lane: Lane;
   adapterId: string;
-  credentialId: string;
+  credentialRef: CredentialRef;
+  adapterConfig?: {
+    baseUrl?: string;
+    tokenCredentialRef?: CredentialRef;
+  };
 }
 
 export type FrontendChoice =
@@ -53,20 +61,26 @@ export interface InstallerProgress {
   status: "in-progress" | "ready-to-commit";
 }
 
+export type InstallerSideEffect = {
+  kind: "memory_dir_created";
+  path: string;
+};
+
 /**
  * Resumable installer state. It contains references only: secret material lives in the
  * draft credential store and never enters this JSON document.
  *
- * This is an installer-local contract, not the final plugin RFC from issue #51. The commit
- * boundary is the only place that will need to translate when that RFC freezes.
+ * This is an installer-local contract. Its public CredentialRef and LaneBinding fields match
+ * plugin protocol v0; the remaining draft-only fields do not claim to be plugin protocol.
  */
 export interface InstallerDraft {
   schemaVersion: typeof INSTALLER_DRAFT_SCHEMA_VERSION;
   residentId: string;
-  credentialRefs: CredentialRef[];
-  bindings: ChannelBinding[];
+  credentials: InstallerCredential[];
+  bindings: LaneBinding[];
   frontend: FrontendChoice | null;
   memory: MemoryChoice | null;
+  sideEffects: InstallerSideEffect[];
   progress: InstallerProgress;
 }
 
@@ -74,7 +88,7 @@ export interface MistInstallConfigV0 {
   schemaVersion: typeof INSTALL_CONFIG_SCHEMA_VERSION;
   residentId: string;
   credentialRefs: CredentialRef[];
-  bindings: ChannelBinding[];
+  bindings: LaneBinding[];
   frontend: FrontendChoice;
   memory: MemoryChoice;
 }
@@ -101,6 +115,11 @@ export function assertSafeInstallerId(value: string, field: string): void {
   }
 }
 
+export function credentialSecretRef(credential: CredentialRef): string {
+  assertSafeInstallerId(credential.id, "credential id");
+  return `${credential.id}.credential`;
+}
+
 export function createInstallerDraft(residentId: string): InstallerDraft {
   if (residentId.trim().length === 0) {
     throw new InstallerValidationError("residentId must not be empty");
@@ -108,10 +127,11 @@ export function createInstallerDraft(residentId: string): InstallerDraft {
   return {
     schemaVersion: INSTALLER_DRAFT_SCHEMA_VERSION,
     residentId,
-    credentialRefs: [],
+    credentials: [],
     bindings: [],
     frontend: null,
     memory: null,
+    sideEffects: [],
     progress: {
       currentStep: "credentials",
       completedSteps: [],
@@ -126,6 +146,28 @@ function requireNonEmpty(value: string, field: string): void {
   }
 }
 
+function validateBindingCredential(
+  binding: LaneBinding,
+  credentials: ReadonlyMap<string, InstallerCredential>,
+): void {
+  const credential = credentials.get(binding.credentialRef.id);
+  if (credential === undefined) {
+    throw new InstallerValidationError(
+      `binding references unknown credential: ${binding.credentialRef.id}`,
+    );
+  }
+  if (credential.ref.type !== binding.credentialRef.type) {
+    throw new InstallerValidationError(
+      `binding credential type does not match stored ref: ${binding.credentialRef.id}`,
+    );
+  }
+  if (credential.ref.type === "claude_oauth" && binding.adapterId !== "claude-agent-sdk") {
+    throw new InstallerValidationError(
+      `credential ${credential.ref.id} requires adapter claude-agent-sdk`,
+    );
+  }
+}
+
 export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
   if (draft.schemaVersion !== INSTALLER_DRAFT_SCHEMA_VERSION) {
     throw new InstallerValidationError(
@@ -133,58 +175,58 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
     );
   }
   requireNonEmpty(draft.residentId, "residentId");
-  if (draft.credentialRefs.length === 0) {
+  if (draft.credentials.length === 0) {
     throw new InstallerValidationError("at least one credential is required");
   }
 
-  const credentials = new Map<string, CredentialRef>();
-  const secretRefs = new Set<string>();
-  for (const credential of draft.credentialRefs) {
-    assertSafeInstallerId(credential.id, "credential id");
-    assertSafeInstallerId(credential.secretRef, "credential secretRef");
-    requireNonEmpty(credential.label, `credential ${credential.id} label`);
-    requireNonEmpty(credential.providerId, `credential ${credential.id} providerId`);
+  const credentials = new Map<string, InstallerCredential>();
+  for (const credential of draft.credentials) {
+    assertSafeInstallerId(credential.ref.id, "credential id");
+    requireNonEmpty(credential.label, `credential ${credential.ref.id} label`);
+    requireNonEmpty(credential.providerId, `credential ${credential.ref.id} providerId`);
     if (credential.status !== "ready") {
-      throw new InstallerValidationError(`credential ${credential.id} is incomplete`);
+      throw new InstallerValidationError(`credential ${credential.ref.id} is incomplete`);
     }
-    if (credentials.has(credential.id)) {
-      throw new InstallerValidationError(`duplicate credential id: ${credential.id}`);
+    if (credentials.has(credential.ref.id)) {
+      throw new InstallerValidationError(`duplicate credential id: ${credential.ref.id}`);
     }
-    if (secretRefs.has(credential.secretRef)) {
-      throw new InstallerValidationError(`duplicate credential secretRef: ${credential.secretRef}`);
-    }
-    credentials.set(credential.id, credential);
-    secretRefs.add(credential.secretRef);
+    credentials.set(credential.ref.id, credential);
   }
 
   const bindings = new Set<string>();
   for (const binding of draft.bindings) {
     requireNonEmpty(binding.residentId, "binding residentId");
     requireNonEmpty(binding.adapterId, "binding adapterId");
-    const bindingKey = `${binding.residentId}\u0000${binding.purpose}`;
+    const bindingKey = `${binding.residentId}\u0000${binding.lane}`;
     if (bindings.has(bindingKey)) {
       throw new InstallerValidationError(
-        `duplicate ${binding.purpose} binding for resident ${binding.residentId}`,
+        `duplicate ${binding.lane} binding for resident ${binding.residentId}`,
       );
     }
     bindings.add(bindingKey);
-    const credential = credentials.get(binding.credentialId);
-    if (credential === undefined) {
-      throw new InstallerValidationError(
-        `binding references unknown credential: ${binding.credentialId}`,
-      );
-    }
-    if (
-      credential.adapterConstraint !== undefined &&
-      credential.adapterConstraint !== binding.adapterId
-    ) {
-      throw new InstallerValidationError(
-        `credential ${credential.id} requires adapter ${credential.adapterConstraint}`,
-      );
+    validateBindingCredential(binding, credentials);
+    const adapterConfig = binding.adapterConfig;
+    if (adapterConfig !== undefined) {
+      if (adapterConfig.baseUrl === undefined || adapterConfig.tokenCredentialRef === undefined) {
+        throw new InstallerValidationError(
+          `binding ${binding.lane} custom gateway requires baseUrl and tokenCredentialRef`,
+        );
+      }
+      requireNonEmpty(adapterConfig.baseUrl, `binding ${binding.lane} baseUrl`);
+      const tokenCredential = credentials.get(adapterConfig.tokenCredentialRef.id);
+      if (
+        tokenCredential === undefined ||
+        tokenCredential.ref.type !== "api_key" ||
+        adapterConfig.tokenCredentialRef.type !== "api_key"
+      ) {
+        throw new InstallerValidationError(
+          `binding ${binding.lane} tokenCredentialRef must reference an api_key`,
+        );
+      }
     }
   }
-  if (!draft.bindings.some((binding) => binding.purpose === "main")) {
-    throw new InstallerValidationError("a main channel binding is required");
+  if (!draft.bindings.some((binding) => binding.lane === "primary")) {
+    throw new InstallerValidationError("a primary lane binding is required");
   }
   if (draft.frontend === null) {
     throw new InstallerValidationError("frontend choice is required");
@@ -202,8 +244,8 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
   return {
     schemaVersion: INSTALL_CONFIG_SCHEMA_VERSION,
     residentId: draft.residentId,
-    credentialRefs: draft.credentialRefs.map((credential) => ({ ...credential })),
-    bindings: draft.bindings.map((binding) => ({ ...binding })),
+    credentialRefs: draft.credentials.map((credential) => ({ ...credential.ref })),
+    bindings: draft.bindings.map((binding) => structuredClone(binding)),
     frontend: { ...draft.frontend },
     memory: { ...draft.memory },
   };

--- a/src/installer/controller.ts
+++ b/src/installer/controller.ts
@@ -1,0 +1,135 @@
+import {
+  type ChannelBinding,
+  type CredentialRef,
+  type FrontendChoice,
+  type InstallCommitReceipt,
+  type InstallerDraft,
+  type InstallerStep,
+  InstallerValidationError,
+  type MemoryChoice,
+  createInstallerDraft,
+} from "./contracts.ts";
+import type { InstallerStateStore } from "./state-store.ts";
+
+export type ExistingDraftChoice = "resume" | "discard";
+
+function cloneDraft(draft: InstallerDraft): InstallerDraft {
+  return structuredClone(draft);
+}
+
+function completeStep(draft: InstallerDraft, step: InstallerStep, next: InstallerStep): void {
+  if (!draft.progress.completedSteps.includes(step)) {
+    draft.progress.completedSteps.push(step);
+  }
+  draft.progress.currentStep = next;
+  draft.progress.status = next === "review" ? "ready-to-commit" : "in-progress";
+}
+
+/** Resumable application service. Prompt rendering is deliberately outside this class. */
+export class InstallerController {
+  readonly #store: InstallerStateStore;
+  #draft: InstallerDraft | null = null;
+  #lastReceipt: InstallCommitReceipt | null = null;
+
+  constructor(store: InstallerStateStore) {
+    this.#store = store;
+  }
+
+  start(residentId: string, existingDraftChoice: ExistingDraftChoice = "resume"): InstallerDraft {
+    const existing = this.#store.loadDraft();
+    if (existing !== null && existingDraftChoice === "resume") {
+      if (existing.residentId !== residentId) {
+        throw new InstallerValidationError(
+          `draft belongs to resident ${existing.residentId}, not ${residentId}`,
+        );
+      }
+      this.#draft = existing;
+      return cloneDraft(existing);
+    }
+    if (existing !== null) this.#store.discardDraft();
+    const draft = createInstallerDraft(residentId);
+    this.#store.saveDraft(draft);
+    this.#draft = draft;
+    return cloneDraft(draft);
+  }
+
+  current(): InstallerDraft {
+    return cloneDraft(this.#requireDraft());
+  }
+
+  saveCredentials(entries: readonly { ref: CredentialRef; secret?: string }[]): InstallerDraft {
+    const draft = cloneDraft(this.#requireDraft());
+    if (entries.length === 0) {
+      throw new InstallerValidationError("at least one credential is required");
+    }
+    const refs: CredentialRef[] = [];
+    for (const entry of entries) {
+      if (entry.secret !== undefined) {
+        this.#store.stageSecret(entry.ref.secretRef, entry.secret);
+      }
+      const status = this.#store.hasStagedSecret(entry.ref.secretRef) ? "ready" : "incomplete";
+      refs.push({ ...entry.ref, status });
+    }
+    draft.credentialRefs = refs;
+    completeStep(draft, "credentials", "bindings");
+    this.#persist(draft);
+    return cloneDraft(draft);
+  }
+
+  saveBindings(bindings: readonly ChannelBinding[]): InstallerDraft {
+    const draft = cloneDraft(this.#requireDraft());
+    if (!bindings.some((binding) => binding.purpose === "main")) {
+      throw new InstallerValidationError("a main channel binding is required");
+    }
+    draft.bindings = bindings.map((binding) => ({ ...binding }));
+    completeStep(draft, "bindings", "frontend");
+    this.#persist(draft);
+    return cloneDraft(draft);
+  }
+
+  saveFrontend(frontend: FrontendChoice): InstallerDraft {
+    const draft = cloneDraft(this.#requireDraft());
+    draft.frontend = { ...frontend };
+    completeStep(draft, "frontend", "memory");
+    this.#persist(draft);
+    return cloneDraft(draft);
+  }
+
+  saveMemory(memory: MemoryChoice): InstallerDraft {
+    const draft = cloneDraft(this.#requireDraft());
+    if (memory.path.trim().length === 0) {
+      throw new InstallerValidationError("memory path must not be empty");
+    }
+    draft.memory = { ...memory };
+    completeStep(draft, "memory", "review");
+    this.#persist(draft);
+    return cloneDraft(draft);
+  }
+
+  commit(): InstallCommitReceipt {
+    if (this.#draft === null && this.#lastReceipt !== null) {
+      return structuredClone(this.#lastReceipt);
+    }
+    const receipt = this.#store.commit(this.#requireDraft());
+    this.#draft = null;
+    this.#lastReceipt = receipt;
+    return structuredClone(receipt);
+  }
+
+  discard(): void {
+    this.#store.discardDraft();
+    this.#draft = null;
+  }
+
+  #requireDraft(): InstallerDraft {
+    if (this.#draft === null) {
+      throw new InstallerValidationError("installer has not been started");
+    }
+    return this.#draft;
+  }
+
+  #persist(draft: InstallerDraft): void {
+    this.#store.saveDraft(draft);
+    this.#draft = draft;
+  }
+}

--- a/src/installer/controller.ts
+++ b/src/installer/controller.ts
@@ -1,13 +1,14 @@
 import {
-  type ChannelBinding,
-  type CredentialRef,
   type FrontendChoice,
   type InstallCommitReceipt,
+  type InstallerCredential,
   type InstallerDraft,
   type InstallerStep,
   InstallerValidationError,
+  type LaneBinding,
   type MemoryChoice,
   createInstallerDraft,
+  credentialSecretRef,
 } from "./contracts.ts";
 import type { InstallerStateStore } from "./state-store.ts";
 
@@ -57,31 +58,58 @@ export class InstallerController {
     return cloneDraft(this.#requireDraft());
   }
 
-  saveCredentials(entries: readonly { ref: CredentialRef; secret?: string }[]): InstallerDraft {
+  revisitCredentials(): InstallerDraft {
+    const draft = cloneDraft(this.#requireDraft());
+    draft.progress.currentStep = "credentials";
+    draft.progress.status = "in-progress";
+    draft.progress.completedSteps = draft.progress.completedSteps.filter(
+      (step) => step !== "credentials" && step !== "bindings",
+    );
+    draft.bindings = [];
+    this.#persist(draft);
+    return cloneDraft(draft);
+  }
+
+  revisitFrontend(): InstallerDraft {
+    const draft = cloneDraft(this.#requireDraft());
+    draft.progress.currentStep = "frontend";
+    draft.progress.status = "in-progress";
+    draft.progress.completedSteps = draft.progress.completedSteps.filter(
+      (step) => step !== "frontend",
+    );
+    draft.frontend = null;
+    this.#persist(draft);
+    return cloneDraft(draft);
+  }
+
+  saveCredentials(
+    entries: readonly { credential: InstallerCredential; secret?: string }[],
+  ): InstallerDraft {
     const draft = cloneDraft(this.#requireDraft());
     if (entries.length === 0) {
       throw new InstallerValidationError("at least one credential is required");
     }
-    const refs: CredentialRef[] = [];
+    const credentials: InstallerCredential[] = [];
     for (const entry of entries) {
+      const secretRef = credentialSecretRef(entry.credential.ref);
       if (entry.secret !== undefined) {
-        this.#store.stageSecret(entry.ref.secretRef, entry.secret);
+        this.#store.stageSecret(secretRef, entry.secret);
       }
-      const status = this.#store.hasStagedSecret(entry.ref.secretRef) ? "ready" : "incomplete";
-      refs.push({ ...entry.ref, status });
+      const status = this.#store.hasStagedSecret(secretRef) ? "ready" : "incomplete";
+      credentials.push({ ...entry.credential, ref: { ...entry.credential.ref }, status });
     }
-    draft.credentialRefs = refs;
+    draft.credentials = credentials;
     completeStep(draft, "credentials", "bindings");
     this.#persist(draft);
     return cloneDraft(draft);
   }
 
-  saveBindings(bindings: readonly ChannelBinding[]): InstallerDraft {
+  saveBindings(bindings: readonly LaneBinding[]): InstallerDraft {
     const draft = cloneDraft(this.#requireDraft());
-    if (!bindings.some((binding) => binding.purpose === "main")) {
-      throw new InstallerValidationError("a main channel binding is required");
+    if (!bindings.some((binding) => binding.lane === "primary")) {
+      throw new InstallerValidationError("a primary lane binding is required");
     }
-    draft.bindings = bindings.map((binding) => ({ ...binding }));
+    draft.bindings = bindings.map((binding) => structuredClone(binding));
     completeStep(draft, "bindings", "frontend");
     this.#persist(draft);
     return cloneDraft(draft);
@@ -90,7 +118,7 @@ export class InstallerController {
   saveFrontend(frontend: FrontendChoice): InstallerDraft {
     const draft = cloneDraft(this.#requireDraft());
     draft.frontend = { ...frontend };
-    completeStep(draft, "frontend", "memory");
+    completeStep(draft, "frontend", draft.memory === null ? "memory" : "review");
     this.#persist(draft);
     return cloneDraft(draft);
   }
@@ -101,6 +129,8 @@ export class InstallerController {
       throw new InstallerValidationError("memory path must not be empty");
     }
     draft.memory = { ...memory };
+    draft.sideEffects =
+      memory.kind === "create" ? [{ kind: "memory_dir_created", path: memory.path }] : [];
     completeStep(draft, "memory", "review");
     this.#persist(draft);
     return cloneDraft(draft);

--- a/src/installer/controller.ts
+++ b/src/installer/controller.ts
@@ -47,7 +47,7 @@ export class InstallerController {
       this.#draft = existing;
       return cloneDraft(existing);
     }
-    if (existing !== null) this.#store.discardDraft();
+    if (existing !== null) this.#store.discardDraft(existing.draftId);
     const draft = createInstallerDraft(residentId);
     this.#store.saveDraft(draft);
     this.#draft = draft;
@@ -93,9 +93,9 @@ export class InstallerController {
     for (const entry of entries) {
       const secretRef = credentialSecretRef(entry.credential.ref);
       if (entry.secret !== undefined) {
-        this.#store.stageSecret(secretRef, entry.secret);
+        this.#store.stageSecret(draft.draftId, secretRef, entry.secret);
       }
-      const status = this.#store.hasStagedSecret(secretRef) ? "ready" : "incomplete";
+      const status = this.#store.hasStagedSecret(draft.draftId, secretRef) ? "ready" : "incomplete";
       credentials.push({ ...entry.credential, ref: { ...entry.credential.ref }, status });
     }
     draft.credentials = credentials;
@@ -130,7 +130,9 @@ export class InstallerController {
     }
     draft.memory = { ...memory };
     draft.sideEffects =
-      memory.kind === "create" ? [{ kind: "memory_dir_created", path: memory.path }] : [];
+      memory.kind === "create"
+        ? [{ kind: "memory_dir_created", path: memory.path, ownerDraftId: draft.draftId }]
+        : [];
     completeStep(draft, "memory", "review");
     this.#persist(draft);
     return cloneDraft(draft);
@@ -147,7 +149,7 @@ export class InstallerController {
   }
 
   discard(): void {
-    this.#store.discardDraft();
+    this.#store.discardDraft(this.#requireDraft().draftId);
     this.#draft = null;
   }
 

--- a/src/installer/memory-library.ts
+++ b/src/installer/memory-library.ts
@@ -12,12 +12,36 @@ import {
 import { dirname, join } from "node:path";
 
 const MARKER_NAME = ".mist-memory.json";
-const MARKER_BODY = JSON.stringify({ schemaVersion: 1, kind: "mist-empty-library" });
+
+interface EmptyLibraryMarker {
+  schemaVersion: 1;
+  kind: "mist-empty-library";
+  ownerDraftId: string;
+}
+
+function markerBody(ownerDraftId: string): string {
+  return JSON.stringify({ schemaVersion: 1, kind: "mist-empty-library", ownerDraftId });
+}
+
+function markerOwner(path: string): string | null {
+  try {
+    const marker = JSON.parse(
+      readFileSync(join(path, MARKER_NAME), "utf8"),
+    ) as Partial<EmptyLibraryMarker>;
+    return marker.schemaVersion === 1 &&
+      marker.kind === "mist-empty-library" &&
+      typeof marker.ownerDraftId === "string"
+      ? marker.ownerDraftId
+      : null;
+  } catch {
+    return null;
+  }
+}
 
 export interface MemoryLibraryPort {
   assertExisting(path: string): void;
-  createEmpty(path: string): void;
-  discardEmpty(path: string): boolean;
+  createEmpty(path: string, ownerDraftId: string): void;
+  discardEmpty(path: string, ownerDraftId: string): boolean;
 }
 
 /** Creates a complete empty library by sibling-directory rename and only removes its own marker. */
@@ -28,17 +52,16 @@ export class FileMemoryLibrary implements MemoryLibraryPort {
     }
   }
 
-  createEmpty(path: string): void {
+  createEmpty(path: string, ownerDraftId: string): void {
     if (existsSync(path)) {
-      const markerPath = join(path, MARKER_NAME);
-      if (existsSync(markerPath) && readFileSync(markerPath, "utf8") === MARKER_BODY) return;
+      if (markerOwner(path) !== null) return;
       throw new Error(`memory library path already exists: ${path}`);
     }
     mkdirSync(dirname(path), { recursive: true });
     const temporaryPath = `${path}.mist-tmp-${randomUUID()}`;
     try {
       mkdirSync(temporaryPath, { mode: 0o700 });
-      writeFileSync(join(temporaryPath, MARKER_NAME), MARKER_BODY, { mode: 0o600 });
+      writeFileSync(join(temporaryPath, MARKER_NAME), markerBody(ownerDraftId), { mode: 0o600 });
       renameSync(temporaryPath, path);
     } catch (error) {
       rmSync(temporaryPath, { recursive: true, force: true });
@@ -46,7 +69,7 @@ export class FileMemoryLibrary implements MemoryLibraryPort {
     }
   }
 
-  discardEmpty(path: string): boolean {
+  discardEmpty(path: string, ownerDraftId: string): boolean {
     if (!existsSync(path)) return true;
     const entries = readdirSync(path);
     const markerPath = join(path, MARKER_NAME);
@@ -54,7 +77,7 @@ export class FileMemoryLibrary implements MemoryLibraryPort {
       entries.length !== 1 ||
       entries[0] !== MARKER_NAME ||
       !existsSync(markerPath) ||
-      readFileSync(markerPath, "utf8") !== MARKER_BODY
+      markerOwner(path) !== ownerDraftId
     ) {
       return false;
     }

--- a/src/installer/memory-library.ts
+++ b/src/installer/memory-library.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+const MARKER_NAME = ".mist-memory.json";
+const MARKER_BODY = JSON.stringify({ schemaVersion: 1, kind: "mist-empty-library" });
+
+export interface MemoryLibraryPort {
+  assertExisting(path: string): void;
+  createEmpty(path: string): void;
+  discardEmpty(path: string): boolean;
+}
+
+/** Creates a complete empty library by sibling-directory rename and only removes its own marker. */
+export class FileMemoryLibrary implements MemoryLibraryPort {
+  assertExisting(path: string): void {
+    if (!existsSync(path) || !statSync(path).isDirectory()) {
+      throw new Error(`memory library does not exist or is not a directory: ${path}`);
+    }
+  }
+
+  createEmpty(path: string): void {
+    if (existsSync(path)) {
+      const markerPath = join(path, MARKER_NAME);
+      if (existsSync(markerPath) && readFileSync(markerPath, "utf8") === MARKER_BODY) return;
+      throw new Error(`memory library path already exists: ${path}`);
+    }
+    mkdirSync(dirname(path), { recursive: true });
+    const temporaryPath = `${path}.mist-tmp-${randomUUID()}`;
+    try {
+      mkdirSync(temporaryPath, { mode: 0o700 });
+      writeFileSync(join(temporaryPath, MARKER_NAME), MARKER_BODY, { mode: 0o600 });
+      renameSync(temporaryPath, path);
+    } catch (error) {
+      rmSync(temporaryPath, { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  discardEmpty(path: string): boolean {
+    if (!existsSync(path)) return true;
+    const entries = readdirSync(path);
+    const markerPath = join(path, MARKER_NAME);
+    if (
+      entries.length !== 1 ||
+      entries[0] !== MARKER_NAME ||
+      !existsSync(markerPath) ||
+      readFileSync(markerPath, "utf8") !== MARKER_BODY
+    ) {
+      return false;
+    }
+    rmSync(path, { recursive: true });
+    return true;
+  }
+}

--- a/src/installer/pi-login.ts
+++ b/src/installer/pi-login.ts
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ProviderCapability } from "./providers.ts";
+
+export interface OAuthLoginReceipt {
+  /** Opaque locator only. Token/access/refresh values never cross this interface. */
+  locator: string;
+}
+
+export interface OAuthLoginPort {
+  login(provider: ProviderCapability): Promise<OAuthLoginReceipt>;
+}
+
+export interface PiInteractiveLoginOptions {
+  command?: string;
+  authPath?: string;
+  beforeLaunch?: (message: string) => void;
+  /** Test seam; production defaults to spawning the configured Pi command. */
+  launch?: () => Promise<void>;
+}
+
+function runInteractive(command: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [], { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`pi login process exited with ${code ?? signal ?? "unknown status"}`));
+    });
+  });
+}
+
+/** Launches Pi as the OAuth owner, then confirms only that the selected auth key exists. */
+export class PiInteractiveLogin implements OAuthLoginPort {
+  readonly #command: string;
+  readonly #authPath: string;
+  readonly #beforeLaunch: (message: string) => void;
+  readonly #launch: () => Promise<void>;
+
+  constructor(options: PiInteractiveLoginOptions = {}) {
+    this.#command = options.command ?? "pi";
+    this.#authPath = options.authPath ?? join(homedir(), ".pi", "agent", "auth.json");
+    this.#beforeLaunch =
+      options.beforeLaunch ?? ((message) => process.stdout.write(`${message}\n`));
+    this.#launch = options.launch ?? (() => runInteractive(this.#command));
+  }
+
+  async login(provider: ProviderCapability): Promise<OAuthLoginReceipt> {
+    if (!provider.methods.includes("oauth")) {
+      throw new Error(`${provider.label} does not expose OAuth through Pi`);
+    }
+    this.#beforeLaunch(
+      `Pi will open now. Run /login, choose ${provider.label}, finish authorization, then quit Pi.`,
+    );
+    await this.#launch();
+    const auth = JSON.parse(await readFile(this.#authPath, "utf8")) as Record<string, unknown>;
+    if (!Object.hasOwn(auth, provider.piAuthKey)) {
+      throw new Error(
+        `Pi exited without a ${provider.label} credential in its auth store; the installer draft was kept`,
+      );
+    }
+    return { locator: `pi-auth://${provider.piAuthKey}` };
+  }
+}

--- a/src/installer/prompt-port.ts
+++ b/src/installer/prompt-port.ts
@@ -1,0 +1,52 @@
+import { confirm, input, password, select } from "@inquirer/prompts";
+
+export interface PromptChoice<Value extends string> {
+  value: Value;
+  name: string;
+  description?: string;
+}
+
+export interface PromptPort {
+  select<Value extends string>(options: {
+    message: string;
+    choices: readonly PromptChoice<Value>[];
+    default?: Value;
+  }): Promise<Value>;
+  input(options: { message: string; default?: string }): Promise<string>;
+  secret(options: { message: string }): Promise<string>;
+  confirm(options: { message: string; default: boolean }): Promise<boolean>;
+  info(message: string): void;
+}
+
+export class InquirerPromptPort implements PromptPort {
+  async select<Value extends string>(options: {
+    message: string;
+    choices: readonly PromptChoice<Value>[];
+    default?: Value;
+  }): Promise<Value> {
+    return select({
+      message: options.message,
+      choices: options.choices,
+      ...(options.default === undefined ? {} : { default: options.default }),
+    });
+  }
+
+  async input(options: { message: string; default?: string }): Promise<string> {
+    return input({
+      message: options.message,
+      ...(options.default === undefined ? {} : { default: options.default }),
+    });
+  }
+
+  async secret(options: { message: string }): Promise<string> {
+    return password({ message: options.message, mask: "•" });
+  }
+
+  async confirm(options: { message: string; default: boolean }): Promise<boolean> {
+    return confirm(options);
+  }
+
+  info(message: string): void {
+    process.stdout.write(`${message}\n`);
+  }
+}

--- a/src/installer/providers.ts
+++ b/src/installer/providers.ts
@@ -1,4 +1,4 @@
-import type { CredentialMethod } from "./contracts.ts";
+import type { CredentialMethod, CredentialType } from "./contracts.ts";
 
 export interface ProviderCapability {
   id: "claude" | "codex" | "grok";
@@ -40,4 +40,19 @@ export function providerById(providerId: string): ProviderCapability {
   const provider = PROVIDERS.find((candidate) => candidate.id === providerId);
   if (provider === undefined) throw new Error(`unsupported provider: ${providerId}`);
   return provider;
+}
+
+export function credentialTypeFor(
+  provider: ProviderCapability,
+  method: CredentialMethod,
+): CredentialType {
+  if (method === "api-key") return "api_key";
+  switch (provider.id) {
+    case "claude":
+      return "claude_oauth";
+    case "codex":
+      return "codex_oauth";
+    case "grok":
+      throw new Error("Grok OAuth has no installed credential issuer");
+  }
 }

--- a/src/installer/providers.ts
+++ b/src/installer/providers.ts
@@ -1,0 +1,43 @@
+import type { CredentialMethod } from "./contracts.ts";
+
+export interface ProviderCapability {
+  id: "claude" | "codex" | "grok";
+  label: string;
+  piAuthKey: string;
+  methods: readonly [CredentialMethod, ...CredentialMethod[]];
+  oauthAdapterConstraint?: "claude-agent-sdk";
+}
+
+/**
+ * Upstream capability table, not a wish list.
+ *
+ * Pi currently documents subscription OAuth for Claude and OpenAI Codex. xAI/Grok is
+ * documented as API-key authentication, so the installer must not offer a dead OAuth path.
+ */
+export const PROVIDERS: readonly ProviderCapability[] = [
+  {
+    id: "claude",
+    label: "Claude",
+    piAuthKey: "anthropic",
+    methods: ["oauth", "api-key"],
+    oauthAdapterConstraint: "claude-agent-sdk",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    piAuthKey: "openai-codex",
+    methods: ["oauth", "api-key"],
+  },
+  {
+    id: "grok",
+    label: "Grok / xAI",
+    piAuthKey: "xai",
+    methods: ["api-key"],
+  },
+] as const;
+
+export function providerById(providerId: string): ProviderCapability {
+  const provider = PROVIDERS.find((candidate) => candidate.id === providerId);
+  if (provider === undefined) throw new Error(`unsupported provider: ${providerId}`);
+  return provider;
+}

--- a/src/installer/providers.ts
+++ b/src/installer/providers.ts
@@ -11,8 +11,8 @@ export interface ProviderCapability {
 /**
  * Upstream capability table, not a wish list.
  *
- * Pi currently documents subscription OAuth for Claude and OpenAI Codex. xAI/Grok is
- * documented as API-key authentication, so the installer must not offer a dead OAuth path.
+ * Pi currently documents subscription OAuth and API-key paths for Claude, OpenAI Codex,
+ * and xAI/Grok. This table is the installer's active acquisition catalog.
  */
 export const PROVIDERS: readonly ProviderCapability[] = [
   {
@@ -32,7 +32,7 @@ export const PROVIDERS: readonly ProviderCapability[] = [
     id: "grok",
     label: "Grok / xAI",
     piAuthKey: "xai",
-    methods: ["api-key"],
+    methods: ["oauth", "api-key"],
   },
 ] as const;
 
@@ -53,6 +53,10 @@ export function credentialTypeFor(
     case "codex":
       return "codex_oauth";
     case "grok":
-      throw new Error("Grok OAuth has no installed credential issuer");
+      return "grok_oauth";
   }
+}
+
+export function credentialIssuerIdFor(method: CredentialMethod): string {
+  return method === "oauth" ? "pi" : "mist-installer-api-key";
 }

--- a/src/installer/providers.ts
+++ b/src/installer/providers.ts
@@ -11,8 +11,8 @@ export interface ProviderCapability {
 /**
  * Upstream capability table, not a wish list.
  *
- * Pi currently documents subscription OAuth and API-key paths for Claude, OpenAI Codex,
- * and xAI/Grok. This table is the installer's active acquisition catalog.
+ * This table is the installer's active acquisition catalog. Pi supports xAI/Grok OAuth,
+ * but issue #50 explicitly defers that path to a later plugin; v0 exposes Grok by API key only.
  */
 export const PROVIDERS: readonly ProviderCapability[] = [
   {
@@ -32,7 +32,7 @@ export const PROVIDERS: readonly ProviderCapability[] = [
     id: "grok",
     label: "Grok / xAI",
     piAuthKey: "xai",
-    methods: ["oauth", "api-key"],
+    methods: ["api-key"],
   },
 ] as const;
 

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -9,6 +9,7 @@ import type {
   LaneBinding,
   MemoryChoice,
 } from "./contracts.ts";
+import { installerAdapterAcceptsCredentialType } from "./contracts.ts";
 import type { InstallerController } from "./controller.ts";
 import type { MemoryLibraryPort } from "./memory-library.ts";
 import type { OAuthLoginPort } from "./pi-login.ts";
@@ -117,10 +118,9 @@ function compatibleCredentials(
   draft: InstallerDraft,
   adapterId: "pi" | "claude-agent-sdk",
 ): InstallerCredential[] {
-  return draft.credentials.filter((credential) => {
-    if (adapterId === "pi") return credential.ref.type !== "claude_oauth";
-    return credential.ref.type === "claude_oauth" || credential.ref.type === "api_key";
-  });
+  return draft.credentials.filter((credential) =>
+    installerAdapterAcceptsCredentialType(adapterId, credential.ref.type),
+  );
 }
 
 async function chooseCredential(
@@ -324,7 +324,7 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
           options.memoryLibraries.createEmpty(draft.memory.path, draft.draftId);
         }
         options.prompt.info(formatReview(draft));
-        if (draft.frontend?.kind === "official-skin" && draft.frontend.installation === "pending") {
+        if (draft.frontend?.kind === "official-skin") {
           options.prompt.info(
             "The official skin is not installed: issues #49 and #51 are still pending. This draft was kept and no active config changed.",
           );

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -1,18 +1,19 @@
+import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
-  ChannelBinding,
   CredentialMethod,
-  CredentialRef,
   FrontendChoice,
   InstallCommitReceipt,
+  InstallerCredential,
   InstallerDraft,
+  LaneBinding,
   MemoryChoice,
 } from "./contracts.ts";
 import type { InstallerController } from "./controller.ts";
 import type { MemoryLibraryPort } from "./memory-library.ts";
 import type { OAuthLoginPort } from "./pi-login.ts";
 import type { PromptPort } from "./prompt-port.ts";
-import { PROVIDERS, providerById } from "./providers.ts";
+import { PROVIDERS, credentialTypeFor, providerById } from "./providers.ts";
 import type { InstallerStateStore } from "./state-store.ts";
 
 export interface RunInstallerOptions {
@@ -40,11 +41,26 @@ function slug(value: string): string {
   return normalized.length === 0 ? "credential" : normalized;
 }
 
-async function collectCredentials(options: RunInstallerOptions): Promise<void> {
-  const entries: { ref: CredentialRef; secret: string }[] = [];
+class MissingCompatibleCredentialError extends Error {
+  readonly adapterId: string;
+
+  constructor(adapterId: string) {
+    super(`no credential can be used with adapter ${adapterId}`);
+    this.name = "MissingCompatibleCredentialError";
+    this.adapterId = adapterId;
+  }
+}
+
+async function collectCredentials(
+  options: RunInstallerOptions,
+  draft: InstallerDraft,
+): Promise<void> {
+  const entries: { credential: InstallerCredential; secret?: string }[] = draft.credentials.map(
+    (credential) => ({ credential }),
+  );
   do {
     const providerId = await options.prompt.select({
-      message: "Choose a credential provider",
+      message: "Step 1/4 · Credential provider",
       choices: PROVIDERS.map((provider) => ({
         value: provider.id,
         name: provider.label,
@@ -64,10 +80,11 @@ async function collectCredentials(options: RunInstallerOptions): Promise<void> {
       default: provider.methods[0],
     });
     const suggestedId = `${provider.id}-${method === "oauth" ? "login" : "key"}`;
-    const id = slug(
-      await options.prompt.input({ message: "Credential name", default: suggestedId }),
-    );
-    const secretRef = `${id}.credential`;
+    const name = await options.prompt.input({
+      message: "Credential name",
+      default: suggestedId,
+    });
+    const id = slug(name);
     let secret: string;
     if (method === "oauth") {
       secret = (await options.oauth.login(provider)).locator;
@@ -75,72 +92,118 @@ async function collectCredentials(options: RunInstallerOptions): Promise<void> {
       secret = await options.prompt.secret({ message: `${provider.label} API key` });
     }
     entries.push({
-      ref: {
-        id,
-        label: provider.label,
+      credential: {
+        ref: { id, type: credentialTypeFor(provider, method) },
+        label: name,
         providerId: provider.id,
-        method,
-        secretRef,
         status: "incomplete",
-        ...(method === "oauth" && provider.oauthAdapterConstraint !== undefined
-          ? { adapterConstraint: provider.oauthAdapterConstraint }
-          : {}),
       },
       secret,
     });
+    if (provider.id === "claude" && method === "oauth") {
+      options.prompt.info(
+        `Saved as ${id}. A Claude subscription login can only run through the Claude Agent SDK adapter.`,
+      );
+    }
   } while (await options.prompt.confirm({ message: "Add another credential?", default: false }));
   options.controller.saveCredentials(entries);
 }
 
-async function chooseBinding(
+function compatibleCredentials(
+  draft: InstallerDraft,
+  adapterId: "pi" | "claude-agent-sdk",
+): InstallerCredential[] {
+  return draft.credentials.filter((credential) => {
+    if (adapterId === "pi") return credential.ref.type !== "claude_oauth";
+    return credential.ref.type === "claude_oauth" || credential.ref.type === "api_key";
+  });
+}
+
+async function chooseCredential(
   options: RunInstallerOptions,
   draft: InstallerDraft,
-  purpose: "main" | "coding",
-): Promise<ChannelBinding> {
-  const adapterId = await options.prompt.select({
-    message: purpose === "main" ? "Daily channel adapter" : "Coding channel adapter",
-    choices: [
-      { value: "pi", name: "Pi" },
-      { value: "claude-agent-sdk", name: "Claude Agent SDK" },
-    ],
-    default: purpose === "main" ? "pi" : "claude-agent-sdk",
-  });
-  const compatible = draft.credentialRefs.filter(
-    (credential) =>
-      credential.adapterConstraint === undefined || credential.adapterConstraint === adapterId,
-  );
+  adapterId: "pi" | "claude-agent-sdk",
+): Promise<InstallerCredential> {
+  const compatible = compatibleCredentials(draft, adapterId);
   if (compatible.length === 0) {
-    throw new Error(`no credential can be used with adapter ${adapterId}`);
+    throw new MissingCompatibleCredentialError(adapterId);
   }
   const defaultCredential = compatible[0];
   if (defaultCredential === undefined) {
     throw new Error(`no credential can be used with adapter ${adapterId}`);
   }
   const credentialId = await options.prompt.select({
-    message: "Credential",
+    message: "Step 2/4 · Primary/coding lane credential",
     choices: compatible.map((credential) => ({
-      value: credential.id,
+      value: credential.ref.id,
       name: credential.label,
-      description: credential.id,
+      description: `${credential.ref.id} · ${credential.ref.type}`,
     })),
-    default: defaultCredential.id,
+    default: defaultCredential.ref.id,
   });
-  return { residentId: draft.residentId, purpose, adapterId, credentialId };
+  const selected = compatible.find((credential) => credential.ref.id === credentialId);
+  if (selected === undefined) throw new Error(`unknown credential selection: ${credentialId}`);
+  return selected;
 }
 
 async function collectBindings(options: RunInstallerOptions, draft: InstallerDraft): Promise<void> {
-  const bindings: ChannelBinding[] = [await chooseBinding(options, draft, "main")];
+  const primaryCredential = await chooseCredential(options, draft, "pi");
+  const bindings: LaneBinding[] = [
+    {
+      residentId: draft.residentId,
+      lane: "primary",
+      adapterId: "pi",
+      credentialRef: { ...primaryCredential.ref },
+    },
+  ];
   if (
     await options.prompt.confirm({ message: "Configure a separate coding channel?", default: true })
   ) {
-    bindings.push(await chooseBinding(options, draft, "coding"));
+    const codingCredential = await chooseCredential(options, draft, "claude-agent-sdk");
+    const codingBinding: LaneBinding = {
+      residentId: draft.residentId,
+      lane: "coding",
+      adapterId: "claude-agent-sdk",
+      credentialRef: { ...codingCredential.ref },
+    };
+    if (
+      await options.prompt.confirm({
+        message: "Use a custom Claude-compatible gateway?",
+        default: false,
+      })
+    ) {
+      const apiKeys = draft.credentials.filter((credential) => credential.ref.type === "api_key");
+      const defaultToken = apiKeys[0];
+      if (defaultToken === undefined) {
+        throw new Error("a custom gateway requires an API key credential");
+      }
+      const baseUrl = await options.prompt.input({ message: "Gateway base URL" });
+      const tokenCredentialId = await options.prompt.select({
+        message: "Gateway token credential",
+        choices: apiKeys.map((credential) => ({
+          value: credential.ref.id,
+          name: credential.label,
+          description: credential.ref.id,
+        })),
+        default: defaultToken.ref.id,
+      });
+      const tokenCredential = apiKeys.find((credential) => credential.ref.id === tokenCredentialId);
+      if (tokenCredential === undefined) {
+        throw new Error(`unknown gateway token credential: ${tokenCredentialId}`);
+      }
+      codingBinding.adapterConfig = {
+        baseUrl,
+        tokenCredentialRef: { ...tokenCredential.ref },
+      };
+    }
+    bindings.push(codingBinding);
   }
   options.controller.saveBindings(bindings);
 }
 
 async function collectFrontend(options: RunInstallerOptions): Promise<void> {
   const kind = await options.prompt.select<FrontendChoice["kind"]>({
-    message: "Frontend",
+    message: "Step 3/4 · Frontend",
     choices: [
       { value: "official-skin", name: "Install the official Mist skin" },
       { value: "external", name: "Connect my own frontend" },
@@ -164,34 +227,40 @@ async function collectFrontend(options: RunInstallerOptions): Promise<void> {
 
 async function collectMemory(options: RunInstallerOptions): Promise<void> {
   const kind = await options.prompt.select<MemoryChoice["kind"]>({
-    message: "Memory library",
+    message: "Step 4/4 · Memory library",
     choices: [
       { value: "existing", name: "Use an existing memory library" },
       { value: "create", name: "Create an empty memory library" },
     ],
     default: "create",
   });
-  const path = await options.prompt.input({
+  const inputPath = await options.prompt.input({
     message: kind === "existing" ? "Existing memory path" : "New memory path",
     default: join(options.dataDir, "memory"),
   });
+  const path =
+    inputPath === "~" || inputPath.startsWith("~/")
+      ? join(homedir(), inputPath.slice(2))
+      : inputPath;
   if (kind === "existing") {
     options.memoryLibraries.assertExisting(path);
     options.controller.saveMemory({ kind, path });
     return;
   }
+  // Record the intended side effect before creating it. If the process dies between these
+  // operations, resume can safely recreate it; discard still knows exactly what may be removed.
+  options.controller.saveMemory({ kind, path });
   options.memoryLibraries.createEmpty(path);
-  try {
-    options.controller.saveMemory({ kind, path });
-  } catch (error) {
-    options.memoryLibraries.discardEmpty(path);
-    throw error;
-  }
 }
 
 export async function runInstaller(options: RunInstallerOptions): Promise<RunInstallerResult> {
   const existing = options.store.loadDraft();
   const current = options.store.loadCurrentConfig();
+  if (existing === null && current === null) {
+    options.prompt.info(
+      "Welcome to Mist setup. Four steps: credentials → channels → frontend → memory. You can quit any time; only a draft is kept until you confirm.",
+    );
+  }
   if (existing === null && current !== null) {
     const choice = await options.prompt.select({
       message: "Mist is already configured",
@@ -214,18 +283,30 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
           ],
           default: "resume",
         });
-  if (existing !== null && choice === "discard" && existing.memory?.kind === "create") {
-    options.memoryLibraries.discardEmpty(existing.memory.path);
+  if (existing !== null && choice === "discard") {
+    for (const sideEffect of existing.sideEffects) {
+      if (sideEffect.kind === "memory_dir_created") {
+        options.memoryLibraries.discardEmpty(sideEffect.path);
+      }
+    }
   }
   let draft = options.controller.start(options.residentId, choice);
 
   while (true) {
     switch (draft.progress.currentStep) {
       case "credentials":
-        await collectCredentials(options);
+        await collectCredentials(options, draft);
         break;
       case "bindings":
-        await collectBindings(options, draft);
+        try {
+          await collectBindings(options, draft);
+        } catch (error) {
+          if (!(error instanceof MissingCompatibleCredentialError)) throw error;
+          options.prompt.info(
+            `No saved credential can be used with ${error.adapterId}. Add one now — your draft is kept.`,
+          );
+          options.controller.revisitCredentials();
+        }
         break;
       case "frontend":
         await collectFrontend(options);
@@ -234,11 +315,28 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
         await collectMemory(options);
         break;
       case "review": {
+        if (draft.memory?.kind === "create") {
+          // Idempotently finish a creation interrupted after the draft was persisted.
+          options.memoryLibraries.createEmpty(draft.memory.path);
+        }
+        options.prompt.info(formatReview(draft));
         if (draft.frontend?.kind === "official-skin" && draft.frontend.installation === "pending") {
           options.prompt.info(
             "The official skin is not installed: issues #49 and #51 are still pending. This draft was kept and no active config changed.",
           );
-          return { status: "dependency-pending", draft, dependencies: ["#49", "#51"] };
+          const pendingChoice = await options.prompt.select({
+            message: "Official skin dependencies are still pending",
+            choices: [
+              { value: "keep", name: "Keep this draft and exit" },
+              { value: "change", name: "Choose a different frontend" },
+            ],
+            default: "keep",
+          });
+          if (pendingChoice === "keep") {
+            return { status: "dependency-pending", draft, dependencies: ["#49", "#51"] };
+          }
+          options.controller.revisitFrontend();
+          break;
         }
         const shouldCommit = await options.prompt.confirm({
           message: "Save this setup?",
@@ -250,4 +348,30 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
     }
     draft = options.controller.current();
   }
+}
+
+function formatReview(draft: InstallerDraft): string {
+  const credentials = draft.credentials
+    .map(
+      (credential) =>
+        `${credential.ref.id} (${credential.providerId}, ${credential.ref.type}, ${credential.status})`,
+    )
+    .join(", ");
+  const bindings = draft.bindings
+    .map(
+      (binding) =>
+        `${binding.lane}: ${binding.adapterId} · ${binding.credentialRef.id}${
+          binding.adapterConfig?.baseUrl === undefined
+            ? ""
+            : ` · gateway ${binding.adapterConfig.baseUrl}`
+        }`,
+    )
+    .join("\n  ");
+  const frontend =
+    draft.frontend?.kind === "external"
+      ? "external · mist-session-api"
+      : "official-skin · pending #49/#51";
+  const memory =
+    draft.memory === null ? "not configured" : `${draft.memory.kind} · ${draft.memory.path}`;
+  return `Review your setup (active config is unchanged):\n  Credentials: ${credentials}\n  ${bindings}\n  Frontend: ${frontend}\n  Memory: ${memory}`;
 }

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -253,8 +253,8 @@ async function collectMemory(options: RunInstallerOptions): Promise<void> {
   }
   // Record the intended side effect before creating it. If the process dies between these
   // operations, resume can safely recreate it; discard still knows exactly what may be removed.
-  options.controller.saveMemory({ kind, path });
-  options.memoryLibraries.createEmpty(path);
+  const draft = options.controller.saveMemory({ kind, path });
+  options.memoryLibraries.createEmpty(path, draft.draftId);
 }
 
 export async function runInstaller(options: RunInstallerOptions): Promise<RunInstallerResult> {
@@ -290,7 +290,7 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
   if (existing !== null && choice === "discard") {
     for (const sideEffect of existing.sideEffects) {
       if (sideEffect.kind === "memory_dir_created") {
-        options.memoryLibraries.discardEmpty(sideEffect.path);
+        options.memoryLibraries.discardEmpty(sideEffect.path, sideEffect.ownerDraftId);
       }
     }
   }
@@ -321,7 +321,7 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
       case "review": {
         if (draft.memory?.kind === "create") {
           // Idempotently finish a creation interrupted after the draft was persisted.
-          options.memoryLibraries.createEmpty(draft.memory.path);
+          options.memoryLibraries.createEmpty(draft.memory.path, draft.draftId);
         }
         options.prompt.info(formatReview(draft));
         if (draft.frontend?.kind === "official-skin" && draft.frontend.installation === "pending") {

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -13,7 +13,7 @@ import type { InstallerController } from "./controller.ts";
 import type { MemoryLibraryPort } from "./memory-library.ts";
 import type { OAuthLoginPort } from "./pi-login.ts";
 import type { PromptPort } from "./prompt-port.ts";
-import { PROVIDERS, credentialTypeFor, providerById } from "./providers.ts";
+import { PROVIDERS, credentialIssuerIdFor, credentialTypeFor, providerById } from "./providers.ts";
 import type { InstallerStateStore } from "./state-store.ts";
 
 export interface RunInstallerOptions {
@@ -93,7 +93,11 @@ async function collectCredentials(
     }
     entries.push({
       credential: {
-        ref: { id, type: credentialTypeFor(provider, method) },
+        ref: {
+          id,
+          type: credentialTypeFor(provider, method),
+          issuerId: credentialIssuerIdFor(method),
+        },
         label: name,
         providerId: provider.id,
         status: "incomplete",
@@ -354,7 +358,7 @@ function formatReview(draft: InstallerDraft): string {
   const credentials = draft.credentials
     .map(
       (credential) =>
-        `${credential.ref.id} (${credential.providerId}, ${credential.ref.type}, ${credential.status})`,
+        `${credential.ref.id} (${credential.providerId}, ${credential.ref.type}, ${credential.ref.issuerId}, ${credential.status})`,
     )
     .join(", ");
   const bindings = draft.bindings

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -1,0 +1,253 @@
+import { join } from "node:path";
+import type {
+  ChannelBinding,
+  CredentialMethod,
+  CredentialRef,
+  FrontendChoice,
+  InstallCommitReceipt,
+  InstallerDraft,
+  MemoryChoice,
+} from "./contracts.ts";
+import type { InstallerController } from "./controller.ts";
+import type { MemoryLibraryPort } from "./memory-library.ts";
+import type { OAuthLoginPort } from "./pi-login.ts";
+import type { PromptPort } from "./prompt-port.ts";
+import { PROVIDERS, providerById } from "./providers.ts";
+import type { InstallerStateStore } from "./state-store.ts";
+
+export interface RunInstallerOptions {
+  residentId: string;
+  dataDir: string;
+  controller: InstallerController;
+  store: InstallerStateStore;
+  prompt: PromptPort;
+  oauth: OAuthLoginPort;
+  memoryLibraries: MemoryLibraryPort;
+}
+
+export type RunInstallerResult =
+  | { status: "committed"; receipt: InstallCommitReceipt }
+  | { status: "paused"; draft: InstallerDraft }
+  | { status: "dependency-pending"; draft: InstallerDraft; dependencies: ["#49", "#51"] }
+  | { status: "already-configured" };
+
+function slug(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized.length === 0 ? "credential" : normalized;
+}
+
+async function collectCredentials(options: RunInstallerOptions): Promise<void> {
+  const entries: { ref: CredentialRef; secret: string }[] = [];
+  do {
+    const providerId = await options.prompt.select({
+      message: "Choose a credential provider",
+      choices: PROVIDERS.map((provider) => ({
+        value: provider.id,
+        name: provider.label,
+        description: provider.methods.includes("oauth")
+          ? "Pi OAuth or API key"
+          : "API key (Pi does not currently expose OAuth for this provider)",
+      })),
+      default: "codex",
+    });
+    const provider = providerById(providerId);
+    const method = await options.prompt.select<CredentialMethod>({
+      message: `How should ${provider.label} authenticate?`,
+      choices: provider.methods.map((candidate) => ({
+        value: candidate,
+        name: candidate === "oauth" ? "Sign in through Pi" : "Enter an API key",
+      })),
+      default: provider.methods[0],
+    });
+    const suggestedId = `${provider.id}-${method === "oauth" ? "login" : "key"}`;
+    const id = slug(
+      await options.prompt.input({ message: "Credential name", default: suggestedId }),
+    );
+    const secretRef = `${id}.credential`;
+    let secret: string;
+    if (method === "oauth") {
+      secret = (await options.oauth.login(provider)).locator;
+    } else {
+      secret = await options.prompt.secret({ message: `${provider.label} API key` });
+    }
+    entries.push({
+      ref: {
+        id,
+        label: provider.label,
+        providerId: provider.id,
+        method,
+        secretRef,
+        status: "incomplete",
+        ...(method === "oauth" && provider.oauthAdapterConstraint !== undefined
+          ? { adapterConstraint: provider.oauthAdapterConstraint }
+          : {}),
+      },
+      secret,
+    });
+  } while (await options.prompt.confirm({ message: "Add another credential?", default: false }));
+  options.controller.saveCredentials(entries);
+}
+
+async function chooseBinding(
+  options: RunInstallerOptions,
+  draft: InstallerDraft,
+  purpose: "main" | "coding",
+): Promise<ChannelBinding> {
+  const adapterId = await options.prompt.select({
+    message: purpose === "main" ? "Daily channel adapter" : "Coding channel adapter",
+    choices: [
+      { value: "pi", name: "Pi" },
+      { value: "claude-agent-sdk", name: "Claude Agent SDK" },
+    ],
+    default: purpose === "main" ? "pi" : "claude-agent-sdk",
+  });
+  const compatible = draft.credentialRefs.filter(
+    (credential) =>
+      credential.adapterConstraint === undefined || credential.adapterConstraint === adapterId,
+  );
+  if (compatible.length === 0) {
+    throw new Error(`no credential can be used with adapter ${adapterId}`);
+  }
+  const defaultCredential = compatible[0];
+  if (defaultCredential === undefined) {
+    throw new Error(`no credential can be used with adapter ${adapterId}`);
+  }
+  const credentialId = await options.prompt.select({
+    message: "Credential",
+    choices: compatible.map((credential) => ({
+      value: credential.id,
+      name: credential.label,
+      description: credential.id,
+    })),
+    default: defaultCredential.id,
+  });
+  return { residentId: draft.residentId, purpose, adapterId, credentialId };
+}
+
+async function collectBindings(options: RunInstallerOptions, draft: InstallerDraft): Promise<void> {
+  const bindings: ChannelBinding[] = [await chooseBinding(options, draft, "main")];
+  if (
+    await options.prompt.confirm({ message: "Configure a separate coding channel?", default: true })
+  ) {
+    bindings.push(await chooseBinding(options, draft, "coding"));
+  }
+  options.controller.saveBindings(bindings);
+}
+
+async function collectFrontend(options: RunInstallerOptions): Promise<void> {
+  const kind = await options.prompt.select<FrontendChoice["kind"]>({
+    message: "Frontend",
+    choices: [
+      { value: "official-skin", name: "Install the official Mist skin" },
+      { value: "external", name: "Connect my own frontend" },
+    ],
+    default: "official-skin",
+  });
+  if (kind === "official-skin") {
+    options.prompt.info(
+      "The official skin install seam is reserved. It will activate when issues #49 and #51 land.",
+    );
+    options.controller.saveFrontend({
+      kind,
+      pluginId: "mist-official-skin",
+      installation: "pending",
+    });
+    return;
+  }
+  options.prompt.info("Use the Mist session API contract to connect your existing frontend.");
+  options.controller.saveFrontend({ kind, integration: "mist-session-api" });
+}
+
+async function collectMemory(options: RunInstallerOptions): Promise<void> {
+  const kind = await options.prompt.select<MemoryChoice["kind"]>({
+    message: "Memory library",
+    choices: [
+      { value: "existing", name: "Use an existing memory library" },
+      { value: "create", name: "Create an empty memory library" },
+    ],
+    default: "create",
+  });
+  const path = await options.prompt.input({
+    message: kind === "existing" ? "Existing memory path" : "New memory path",
+    default: join(options.dataDir, "memory"),
+  });
+  if (kind === "existing") {
+    options.memoryLibraries.assertExisting(path);
+    options.controller.saveMemory({ kind, path });
+    return;
+  }
+  options.memoryLibraries.createEmpty(path);
+  try {
+    options.controller.saveMemory({ kind, path });
+  } catch (error) {
+    options.memoryLibraries.discardEmpty(path);
+    throw error;
+  }
+}
+
+export async function runInstaller(options: RunInstallerOptions): Promise<RunInstallerResult> {
+  const existing = options.store.loadDraft();
+  const current = options.store.loadCurrentConfig();
+  if (existing === null && current !== null) {
+    const choice = await options.prompt.select({
+      message: "Mist is already configured",
+      choices: [
+        { value: "keep", name: "Keep the current setup" },
+        { value: "reconfigure", name: "Start a replacement draft" },
+      ],
+      default: "keep",
+    });
+    if (choice === "keep") return { status: "already-configured" };
+  }
+  const choice =
+    existing === null
+      ? "resume"
+      : await options.prompt.select({
+          message: "An unfinished setup was found",
+          choices: [
+            { value: "resume", name: "Continue where I stopped" },
+            { value: "discard", name: "Discard it and start over" },
+          ],
+          default: "resume",
+        });
+  if (existing !== null && choice === "discard" && existing.memory?.kind === "create") {
+    options.memoryLibraries.discardEmpty(existing.memory.path);
+  }
+  let draft = options.controller.start(options.residentId, choice);
+
+  while (true) {
+    switch (draft.progress.currentStep) {
+      case "credentials":
+        await collectCredentials(options);
+        break;
+      case "bindings":
+        await collectBindings(options, draft);
+        break;
+      case "frontend":
+        await collectFrontend(options);
+        break;
+      case "memory":
+        await collectMemory(options);
+        break;
+      case "review": {
+        if (draft.frontend?.kind === "official-skin" && draft.frontend.installation === "pending") {
+          options.prompt.info(
+            "The official skin is not installed: issues #49 and #51 are still pending. This draft was kept and no active config changed.",
+          );
+          return { status: "dependency-pending", draft, dependencies: ["#49", "#51"] };
+        }
+        const shouldCommit = await options.prompt.confirm({
+          message: "Save this setup?",
+          default: true,
+        });
+        if (!shouldCommit) return { status: "paused", draft };
+        return { status: "committed", receipt: options.controller.commit() };
+      }
+    }
+    draft = options.controller.current();
+  }
+}

--- a/src/installer/state-store.ts
+++ b/src/installer/state-store.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import {
+  INSTALLER_DRAFT_SCHEMA_VERSION,
   type InstallCommitReceipt,
   type InstallerDraft,
   InstallerValidationError,
@@ -24,6 +25,7 @@ import {
 interface CurrentPointer {
   schemaVersion: 1;
   snapshotId: string;
+  sourceDraftId?: string;
 }
 
 function fsyncDirectory(path: string): void {
@@ -91,10 +93,34 @@ export class InstallerStateStore {
   loadDraft(): InstallerDraft | null {
     try {
       const draft = parseJson<InstallerDraft>(this.#draftPath);
-      if (draft.schemaVersion !== 1 || !Array.isArray(draft.credentials)) {
+      if (
+        draft.schemaVersion !== INSTALLER_DRAFT_SCHEMA_VERSION ||
+        typeof draft.draftId !== "string" ||
+        !Array.isArray(draft.credentials)
+      ) {
         throw new InstallerValidationError("installer draft has an unsupported shape");
       }
+      assertSafeInstallerId(draft.draftId, "draft id");
       if (!Array.isArray(draft.sideEffects)) draft.sideEffects = [];
+      for (const sideEffect of draft.sideEffects) {
+        if (
+          sideEffect.kind !== "memory_dir_created" ||
+          typeof sideEffect.path !== "string" ||
+          sideEffect.path.trim().length === 0 ||
+          sideEffect.ownerDraftId !== draft.draftId
+        ) {
+          throw new InstallerValidationError("installer draft has an invalid side-effect receipt");
+        }
+      }
+      const pointer = this.#loadCurrentPointer();
+      if (pointer?.sourceDraftId === draft.draftId) {
+        try {
+          this.discardDraft(draft.draftId);
+        } catch {
+          // The current pointer proves this draft committed. Never expose it as resumable.
+        }
+        return null;
+      }
       return draft;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
@@ -106,19 +132,22 @@ export class InstallerStateStore {
     writePrivateFile(this.#draftPath, JSON.stringify(draft, null, 2));
   }
 
-  stageSecret(secretRef: string, secret: string): void {
+  stageSecret(draftId: string, secretRef: string, secret: string): void {
+    assertSafeInstallerId(draftId, "draft id");
     assertSafeInstallerId(secretRef, "credential secretRef");
     if (secret.length === 0) {
       throw new InstallerValidationError("credential secret must not be empty");
     }
-    mkdirSync(this.#draftSecretsDir, { recursive: true, mode: 0o700 });
-    writePrivateFile(join(this.#draftSecretsDir, secretRef), secret);
+    const draftSecrets = join(this.#draftSecretsDir, draftId);
+    mkdirSync(draftSecrets, { recursive: true, mode: 0o700 });
+    writePrivateFile(join(draftSecrets, secretRef), secret);
   }
 
-  hasStagedSecret(secretRef: string): boolean {
+  hasStagedSecret(draftId: string, secretRef: string): boolean {
+    assertSafeInstallerId(draftId, "draft id");
     assertSafeInstallerId(secretRef, "credential secretRef");
     try {
-      readFileSync(join(this.#draftSecretsDir, secretRef));
+      readFileSync(join(this.#draftSecretsDir, draftId, secretRef));
       return true;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
@@ -126,16 +155,27 @@ export class InstallerStateStore {
     }
   }
 
-  discardDraft(): void {
-    rmSync(this.#draftPath, { force: true });
-    rmSync(this.#draftSecretsDir, { recursive: true, force: true });
+  discardDraft(expectedDraftId: string): void {
+    assertSafeInstallerId(expectedDraftId, "draft id");
+    try {
+      const stored = parseJson<InstallerDraft>(this.#draftPath);
+      if (stored.draftId !== expectedDraftId) {
+        throw new InstallerValidationError(
+          `refusing to discard draft ${stored.draftId}; expected ${expectedDraftId}`,
+        );
+      }
+      rmSync(this.#draftPath, { force: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    rmSync(join(this.#draftSecretsDir, expectedDraftId), { recursive: true, force: true });
   }
 
   commit(draft: InstallerDraft): InstallCommitReceipt {
     const config = validateReadyDraft(draft);
     for (const credential of draft.credentials) {
       const secretRef = credentialSecretRef(credential.ref);
-      if (!this.hasStagedSecret(secretRef)) {
+      if (!this.hasStagedSecret(draft.draftId, secretRef)) {
         throw new InstallerValidationError(
           `credential ${credential.ref.id} has no staged secret material`,
         );
@@ -151,12 +191,16 @@ export class InstallerStateStore {
       writePrivateFile(join(temporarySnapshot, "config.json"), JSON.stringify(config, null, 2));
       for (const credential of draft.credentials) {
         const secretRef = credentialSecretRef(credential.ref);
-        const secret = readFileSync(join(this.#draftSecretsDir, secretRef), "utf8");
+        const secret = readFileSync(join(this.#draftSecretsDir, draft.draftId, secretRef), "utf8");
         writePrivateFile(join(credentialsDirectory, secretRef), secret);
       }
       renameSync(temporarySnapshot, finalSnapshot);
       fsyncDirectory(this.#snapshotsDir);
-      const pointer: CurrentPointer = { schemaVersion: 1, snapshotId };
+      const pointer: CurrentPointer = {
+        schemaVersion: 1,
+        snapshotId,
+        sourceDraftId: draft.draftId,
+      };
       writePrivateFile(this.#currentPath, JSON.stringify(pointer));
     } catch (error) {
       rmSync(temporarySnapshot, { recursive: true, force: true });
@@ -166,21 +210,17 @@ export class InstallerStateStore {
     // The new snapshot is already authoritative. Cleanup must never turn a successful commit
     // into a reported failure, because callers might retry and create a second installation.
     try {
-      this.discardDraft();
+      this.discardDraft(draft.draftId);
     } catch {
-      // A stale draft is harmless: current.json remains the single authoritative pointer.
+      // loadDraft reconciles sourceDraftId against current.json and never resumes this stale draft.
     }
     return { snapshotId, config };
   }
 
   loadCurrentConfig(): MistInstallConfigV0 | null {
     try {
-      const pointer = parseJson<CurrentPointer>(this.#currentPath);
-      if (pointer.schemaVersion !== 1) {
-        throw new InstallerValidationError(
-          `unsupported current pointer schemaVersion: ${pointer.schemaVersion}`,
-        );
-      }
+      const pointer = this.#loadCurrentPointer();
+      if (pointer === null) return null;
       assertSafeInstallerId(pointer.snapshotId, "snapshot id");
       return parseJson<MistInstallConfigV0>(
         join(this.#snapshotsDir, pointer.snapshotId, "config.json"),
@@ -198,5 +238,23 @@ export class InstallerStateStore {
       join(this.#snapshotsDir, pointer.snapshotId, "credentials", secretRef),
       "utf8",
     );
+  }
+
+  #loadCurrentPointer(): CurrentPointer | null {
+    try {
+      const pointer = parseJson<CurrentPointer>(this.#currentPath);
+      if (pointer.schemaVersion !== 1) {
+        throw new InstallerValidationError(
+          `unsupported current pointer schemaVersion: ${pointer.schemaVersion}`,
+        );
+      }
+      if (pointer.sourceDraftId !== undefined) {
+        assertSafeInstallerId(pointer.sourceDraftId, "source draft id");
+      }
+      return pointer;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
   }
 }

--- a/src/installer/state-store.ts
+++ b/src/installer/state-store.ts
@@ -17,6 +17,7 @@ import {
   InstallerValidationError,
   type MistInstallConfigV0,
   assertSafeInstallerId,
+  credentialSecretRef,
   validateReadyDraft,
 } from "./contracts.ts";
 
@@ -90,9 +91,10 @@ export class InstallerStateStore {
   loadDraft(): InstallerDraft | null {
     try {
       const draft = parseJson<InstallerDraft>(this.#draftPath);
-      if (draft.schemaVersion !== 1 || !Array.isArray(draft.credentialRefs)) {
+      if (draft.schemaVersion !== 1 || !Array.isArray(draft.credentials)) {
         throw new InstallerValidationError("installer draft has an unsupported shape");
       }
+      if (!Array.isArray(draft.sideEffects)) draft.sideEffects = [];
       return draft;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
@@ -131,10 +133,11 @@ export class InstallerStateStore {
 
   commit(draft: InstallerDraft): InstallCommitReceipt {
     const config = validateReadyDraft(draft);
-    for (const credential of config.credentialRefs) {
-      if (!this.hasStagedSecret(credential.secretRef)) {
+    for (const credential of draft.credentials) {
+      const secretRef = credentialSecretRef(credential.ref);
+      if (!this.hasStagedSecret(secretRef)) {
         throw new InstallerValidationError(
-          `credential ${credential.id} has no staged secret material`,
+          `credential ${credential.ref.id} has no staged secret material`,
         );
       }
     }
@@ -146,9 +149,10 @@ export class InstallerStateStore {
     mkdirSync(credentialsDirectory, { recursive: true, mode: 0o700 });
     try {
       writePrivateFile(join(temporarySnapshot, "config.json"), JSON.stringify(config, null, 2));
-      for (const credential of config.credentialRefs) {
-        const secret = readFileSync(join(this.#draftSecretsDir, credential.secretRef), "utf8");
-        writePrivateFile(join(credentialsDirectory, credential.secretRef), secret);
+      for (const credential of draft.credentials) {
+        const secretRef = credentialSecretRef(credential.ref);
+        const secret = readFileSync(join(this.#draftSecretsDir, secretRef), "utf8");
+        writePrivateFile(join(credentialsDirectory, secretRef), secret);
       }
       renameSync(temporarySnapshot, finalSnapshot);
       fsyncDirectory(this.#snapshotsDir);
@@ -187,8 +191,8 @@ export class InstallerStateStore {
     }
   }
 
-  readCredentialSecret(secretRef: string): string {
-    assertSafeInstallerId(secretRef, "credential secretRef");
+  readCredentialSecret(credentialId: string): string {
+    const secretRef = credentialSecretRef({ id: credentialId, type: "api_key" });
     const pointer = parseJson<CurrentPointer>(this.#currentPath);
     return readFileSync(
       join(this.#snapshotsDir, pointer.snapshotId, "credentials", secretRef),

--- a/src/installer/state-store.ts
+++ b/src/installer/state-store.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  fchmodSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  type InstallCommitReceipt,
+  type InstallerDraft,
+  InstallerValidationError,
+  type MistInstallConfigV0,
+  assertSafeInstallerId,
+  validateReadyDraft,
+} from "./contracts.ts";
+
+interface CurrentPointer {
+  schemaVersion: 1;
+  snapshotId: string;
+}
+
+function fsyncDirectory(path: string): void {
+  const descriptor = openSync(path, "r");
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function writePrivateFile(path: string, content: string): void {
+  const temporaryPath = `${path}.tmp-${process.pid}-${randomUUID()}`;
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(temporaryPath, "wx", 0o600);
+    fchmodSync(descriptor, 0o600);
+    writeSync(descriptor, content);
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = null;
+    renameSync(temporaryPath, path);
+    fsyncDirectory(dirname(path));
+  } catch (error) {
+    if (descriptor !== null) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        // Preserve the original write error.
+      }
+    }
+    rmSync(temporaryPath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+function parseJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+/**
+ * File-backed installer transaction store.
+ *
+ * Draft metadata and draft secrets are separate. Commit writes an immutable snapshot first,
+ * then atomically switches current.json. A crash before the pointer switch leaves the previous
+ * installation authoritative; a crash after it leaves a complete new snapshot authoritative.
+ */
+export class InstallerStateStore {
+  readonly #rootDir: string;
+  readonly #draftPath: string;
+  readonly #draftSecretsDir: string;
+  readonly #snapshotsDir: string;
+  readonly #currentPath: string;
+
+  constructor(rootDir: string) {
+    this.#rootDir = rootDir;
+    this.#draftPath = join(rootDir, "installer-draft.json");
+    this.#draftSecretsDir = join(rootDir, "draft-secrets");
+    this.#snapshotsDir = join(rootDir, "snapshots");
+    this.#currentPath = join(rootDir, "current.json");
+    mkdirSync(this.#rootDir, { recursive: true, mode: 0o700 });
+    mkdirSync(this.#snapshotsDir, { recursive: true, mode: 0o700 });
+  }
+
+  loadDraft(): InstallerDraft | null {
+    try {
+      const draft = parseJson<InstallerDraft>(this.#draftPath);
+      if (draft.schemaVersion !== 1 || !Array.isArray(draft.credentialRefs)) {
+        throw new InstallerValidationError("installer draft has an unsupported shape");
+      }
+      return draft;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+  }
+
+  saveDraft(draft: InstallerDraft): void {
+    writePrivateFile(this.#draftPath, JSON.stringify(draft, null, 2));
+  }
+
+  stageSecret(secretRef: string, secret: string): void {
+    assertSafeInstallerId(secretRef, "credential secretRef");
+    if (secret.length === 0) {
+      throw new InstallerValidationError("credential secret must not be empty");
+    }
+    mkdirSync(this.#draftSecretsDir, { recursive: true, mode: 0o700 });
+    writePrivateFile(join(this.#draftSecretsDir, secretRef), secret);
+  }
+
+  hasStagedSecret(secretRef: string): boolean {
+    assertSafeInstallerId(secretRef, "credential secretRef");
+    try {
+      readFileSync(join(this.#draftSecretsDir, secretRef));
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw error;
+    }
+  }
+
+  discardDraft(): void {
+    rmSync(this.#draftPath, { force: true });
+    rmSync(this.#draftSecretsDir, { recursive: true, force: true });
+  }
+
+  commit(draft: InstallerDraft): InstallCommitReceipt {
+    const config = validateReadyDraft(draft);
+    for (const credential of config.credentialRefs) {
+      if (!this.hasStagedSecret(credential.secretRef)) {
+        throw new InstallerValidationError(
+          `credential ${credential.id} has no staged secret material`,
+        );
+      }
+    }
+
+    const snapshotId = `install-${randomUUID()}`;
+    const temporarySnapshot = join(this.#snapshotsDir, `.${snapshotId}.tmp`);
+    const finalSnapshot = join(this.#snapshotsDir, snapshotId);
+    const credentialsDirectory = join(temporarySnapshot, "credentials");
+    mkdirSync(credentialsDirectory, { recursive: true, mode: 0o700 });
+    try {
+      writePrivateFile(join(temporarySnapshot, "config.json"), JSON.stringify(config, null, 2));
+      for (const credential of config.credentialRefs) {
+        const secret = readFileSync(join(this.#draftSecretsDir, credential.secretRef), "utf8");
+        writePrivateFile(join(credentialsDirectory, credential.secretRef), secret);
+      }
+      renameSync(temporarySnapshot, finalSnapshot);
+      fsyncDirectory(this.#snapshotsDir);
+      const pointer: CurrentPointer = { schemaVersion: 1, snapshotId };
+      writePrivateFile(this.#currentPath, JSON.stringify(pointer));
+    } catch (error) {
+      rmSync(temporarySnapshot, { recursive: true, force: true });
+      throw error;
+    }
+
+    // The new snapshot is already authoritative. Cleanup must never turn a successful commit
+    // into a reported failure, because callers might retry and create a second installation.
+    try {
+      this.discardDraft();
+    } catch {
+      // A stale draft is harmless: current.json remains the single authoritative pointer.
+    }
+    return { snapshotId, config };
+  }
+
+  loadCurrentConfig(): MistInstallConfigV0 | null {
+    try {
+      const pointer = parseJson<CurrentPointer>(this.#currentPath);
+      if (pointer.schemaVersion !== 1) {
+        throw new InstallerValidationError(
+          `unsupported current pointer schemaVersion: ${pointer.schemaVersion}`,
+        );
+      }
+      assertSafeInstallerId(pointer.snapshotId, "snapshot id");
+      return parseJson<MistInstallConfigV0>(
+        join(this.#snapshotsDir, pointer.snapshotId, "config.json"),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+  }
+
+  readCredentialSecret(secretRef: string): string {
+    assertSafeInstallerId(secretRef, "credential secretRef");
+    const pointer = parseJson<CurrentPointer>(this.#currentPath);
+    return readFileSync(
+      join(this.#snapshotsDir, pointer.snapshotId, "credentials", secretRef),
+      "utf8",
+    );
+  }
+}

--- a/src/installer/state-store.ts
+++ b/src/installer/state-store.ts
@@ -192,7 +192,7 @@ export class InstallerStateStore {
   }
 
   readCredentialSecret(credentialId: string): string {
-    const secretRef = credentialSecretRef({ id: credentialId, type: "api_key" });
+    const secretRef = credentialSecretRef({ id: credentialId });
     const pointer = parseJson<CurrentPointer>(this.#currentPath);
     return readFileSync(
       join(this.#snapshotsDir, pointer.snapshotId, "credentials", secretRef),

--- a/tests/installer-controller.test.ts
+++ b/tests/installer-controller.test.ts
@@ -354,6 +354,48 @@ describe("installer controller", () => {
     expect(() => store.loadDraft()).toThrow(/invalid side-effect receipt/);
   });
 
+  it("rebuilds active config from whitelisted nested fields", () => {
+    const directory = freshDirectory();
+    const store = new InstallerStateStore(directory);
+    const controller = new InstallerController(store);
+    const draft = completeDraft(controller);
+    const credential = draft.credentials[0];
+    const binding = draft.bindings[0];
+    if (credential === undefined || binding === undefined) throw new Error("missing fixture");
+
+    Object.assign(credential.ref, { secretMaterial: "should-not-persist" });
+    Object.assign(binding, { unexpected: "should-not-persist" });
+    Object.assign(binding.credentialRef, { secretMaterial: "should-not-persist" });
+    const tokenCredentialRef = {
+      ...credential.ref,
+      type: "api_key" as const,
+      issuerId: "mist-installer-api-key",
+    };
+    Object.assign(tokenCredentialRef, { secretMaterial: "should-not-persist" });
+    binding.adapterConfig = {
+      baseUrl: "https://gateway.example.test",
+      tokenCredentialRef,
+      unexpected: "should-not-persist",
+    } as never;
+    store.saveDraft(draft);
+
+    const resumed = new InstallerController(store);
+    resumed.start("resident-1", "resume");
+    const receipt = resumed.commit();
+
+    expect(JSON.stringify(receipt.config)).not.toContain("should-not-persist");
+    expect(receipt.config.credentialRefs).toEqual([apiCredential().ref]);
+    expect(receipt.config.bindings).toEqual([
+      {
+        ...primaryBinding(),
+        adapterConfig: {
+          baseUrl: "https://gateway.example.test",
+          tokenCredentialRef: apiCredential().ref,
+        },
+      },
+    ]);
+  });
+
   it("refuses a binding whose issuer does not match the stored credential ref", () => {
     const directory = freshDirectory();
     const controller = new InstallerController(new InstallerStateStore(directory));

--- a/tests/installer-controller.test.ts
+++ b/tests/installer-controller.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -48,6 +48,15 @@ function completeDraft(controller: InstallerController): InstallerDraft {
   controller.saveBindings([primaryBinding()]);
   controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
   return controller.saveMemory({ kind: "create", path: "/tmp/mist-memory" });
+}
+
+class CleanupFailingStore extends InstallerStateStore {
+  failCleanup = false;
+
+  override discardDraft(expectedDraftId: string): void {
+    if (this.failCleanup) throw new Error("injected cleanup failure");
+    super.discardDraft(expectedDraftId);
+  }
 }
 
 describe("installer controller", () => {
@@ -111,11 +120,12 @@ describe("installer controller", () => {
     const controller = new InstallerController(new InstallerStateStore(directory));
     controller.start("resident-1");
     controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+    const draftId = controller.current().draftId;
     controller.discard();
 
     const store = new InstallerStateStore(directory);
     expect(store.loadDraft()).toBeNull();
-    expect(store.hasStagedSecret("codex-main.credential")).toBe(false);
+    expect(store.hasStagedSecret(draftId, "codex-main.credential")).toBe(false);
   });
 
   it("commits a complete snapshot without putting secret text in config or draft", () => {
@@ -130,6 +140,24 @@ describe("installer controller", () => {
     expect(store.readCredentialSecret("codex-main")).toBe("secret-value");
     expect(JSON.stringify(receipt.config)).not.toContain("secret-value");
     expect(readFileSync(join(directory, "current.json"), "utf8")).not.toContain("secret-value");
+  });
+
+  it("reconciles a committed current pointer even when draft cleanup fails", () => {
+    const directory = freshDirectory();
+    const store = new CleanupFailingStore(directory);
+    const controller = new InstallerController(store);
+    const committedDraft = completeDraft(controller);
+    store.failCleanup = true;
+
+    const receipt = controller.commit();
+
+    expect(existsSync(join(directory, "installer-draft.json"))).toBe(true);
+    expect(store.loadCurrentConfig()).toEqual(receipt.config);
+    expect(store.loadDraft()).toBeNull();
+
+    const replacement = new InstallerController(store).start("resident-1");
+    expect(replacement.draftId).not.toBe(committedDraft.draftId);
+    expect(store.hasStagedSecret(replacement.draftId, "codex-main.credential")).toBe(false);
   });
 
   it("writes draft, config, pointer, and credential files with owner-only permissions", () => {
@@ -174,7 +202,113 @@ describe("installer controller", () => {
     controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
     controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
 
-    expect(() => controller.commit()).toThrow(/requires adapter claude-agent-sdk/);
+    expect(() => controller.commit()).toThrow(/does not accept credential type claude_oauth/);
+  });
+
+  it("refuses a binding for a different resident at commit time", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+    controller.saveBindings([{ ...primaryBinding(), residentId: "other-resident" }]);
+    controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+    controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
+
+    expect(() => controller.commit()).toThrow(/does not match draft resident/);
+  });
+
+  it("enforces each adapter's declared credential types at commit time", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([
+      {
+        credential: {
+          ...apiCredential("codex-login"),
+          ref: { id: "codex-login", type: "codex_oauth", issuerId: "pi" },
+        },
+        secret: "oauth-material",
+      },
+    ]);
+    controller.saveBindings([
+      {
+        residentId: "resident-1",
+        lane: "primary",
+        adapterId: "claude-agent-sdk",
+        credentialRef: { id: "codex-login", type: "codex_oauth", issuerId: "pi" },
+      },
+    ]);
+    controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+    controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
+
+    expect(() => controller.commit()).toThrow(
+      /claude-agent-sdk does not accept credential type codex_oauth/,
+    );
+  });
+
+  it.each([
+    {
+      name: "credential type",
+      mutate(draft: InstallerDraft) {
+        const credential = draft.credentials[0];
+        const binding = draft.bindings[0];
+        if (credential === undefined || binding === undefined) throw new Error("missing fixture");
+        credential.ref.type = "future_oauth" as never;
+        binding.credentialRef.type = "future_oauth" as never;
+      },
+      error: /unsupported type/,
+    },
+    {
+      name: "credential status",
+      mutate(draft: InstallerDraft) {
+        const credential = draft.credentials[0];
+        if (credential === undefined) throw new Error("missing fixture");
+        credential.status = "unknown" as never;
+      },
+      error: /unsupported status/,
+    },
+    {
+      name: "lane",
+      mutate(draft: InstallerDraft) {
+        const binding = draft.bindings[0];
+        if (binding === undefined) throw new Error("missing fixture");
+        binding.lane = "sideways" as never;
+      },
+      error: /unsupported binding lane/,
+    },
+    {
+      name: "adapter",
+      mutate(draft: InstallerDraft) {
+        const binding = draft.bindings[0];
+        if (binding === undefined) throw new Error("missing fixture");
+        binding.adapterId = "unknown-adapter";
+      },
+      error: /unsupported binding adapter/,
+    },
+  ])("rejects a corrupted runtime $name enum", ({ mutate, error }) => {
+    const directory = freshDirectory();
+    const store = new InstallerStateStore(directory);
+    const controller = new InstallerController(store);
+    const draft = completeDraft(controller);
+    mutate(draft);
+    store.saveDraft(draft);
+    const resumed = new InstallerController(store);
+    resumed.start("resident-1", "resume");
+
+    expect(() => resumed.commit()).toThrow(error);
+  });
+
+  it("rejects a corrupted memory ownership receipt before it can be discarded", () => {
+    const directory = freshDirectory();
+    const store = new InstallerStateStore(directory);
+    const controller = new InstallerController(store);
+    const draft = completeDraft(controller);
+    const sideEffect = draft.sideEffects[0];
+    if (sideEffect === undefined) throw new Error("missing fixture");
+    sideEffect.ownerDraftId = "another-draft";
+    store.saveDraft(draft);
+
+    expect(() => store.loadDraft()).toThrow(/invalid side-effect receipt/);
   });
 
   it("refuses a binding whose issuer does not match the stored credential ref", () => {

--- a/tests/installer-controller.test.ts
+++ b/tests/installer-controller.test.ts
@@ -26,7 +26,7 @@ afterEach(() => {
 
 function apiCredential(id = "codex-main"): InstallerCredential {
   return {
-    ref: { id, type: "api_key" },
+    ref: { id, type: "api_key", issuerId: "mist-installer-api-key" },
     label: "Codex main",
     providerId: "codex",
     status: "incomplete",
@@ -38,7 +38,7 @@ function primaryBinding(id = "codex-main"): LaneBinding {
     residentId: "resident-1",
     lane: "primary",
     adapterId: "pi",
-    credentialRef: { id, type: "api_key" },
+    credentialRef: { id, type: "api_key", issuerId: "mist-installer-api-key" },
   };
 }
 
@@ -157,7 +157,7 @@ describe("installer controller", () => {
       {
         credential: {
           ...apiCredential("claude-login"),
-          ref: { id: "claude-login", type: "claude_oauth" },
+          ref: { id: "claude-login", type: "claude_oauth", issuerId: "pi" },
           providerId: "claude",
         },
         secret: "oauth-material",
@@ -168,13 +168,53 @@ describe("installer controller", () => {
         residentId: "resident-1",
         lane: "primary",
         adapterId: "pi",
-        credentialRef: { id: "claude-login", type: "claude_oauth" },
+        credentialRef: { id: "claude-login", type: "claude_oauth", issuerId: "pi" },
       },
     ]);
     controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
     controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
 
     expect(() => controller.commit()).toThrow(/requires adapter claude-agent-sdk/);
+  });
+
+  it("refuses a binding whose issuer does not match the stored credential ref", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+    controller.saveBindings([
+      {
+        ...primaryBinding(),
+        credentialRef: {
+          id: "codex-main",
+          type: "api_key",
+          issuerId: "unregistered-issuer",
+        },
+      },
+    ]);
+    controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+    controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
+
+    expect(() => controller.commit()).toThrow(/type or issuer does not match/);
+  });
+
+  it("refuses a credential ref that cannot name an active issuer", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    const credential = apiCredential();
+    credential.ref.issuerId = "unregistered-issuer";
+    controller.start("resident-1");
+    controller.saveCredentials([{ credential, secret: "secret-value" }]);
+    controller.saveBindings([
+      {
+        ...primaryBinding(),
+        credentialRef: { ...credential.ref },
+      },
+    ]);
+    controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+    controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
+
+    expect(() => controller.commit()).toThrow(/issuer is unavailable/);
   });
 
   it("rejects a second binding for the same resident and lane", () => {
@@ -187,13 +227,21 @@ describe("installer controller", () => {
         residentId: "resident-1",
         lane: "primary",
         adapterId: "pi",
-        credentialRef: { id: "codex-main", type: "api_key" },
+        credentialRef: {
+          id: "codex-main",
+          type: "api_key",
+          issuerId: "mist-installer-api-key",
+        },
       },
       {
         residentId: "resident-1",
         lane: "primary",
         adapterId: "other",
-        credentialRef: { id: "codex-main", type: "api_key" },
+        credentialRef: {
+          id: "codex-main",
+          type: "api_key",
+          issuerId: "mist-installer-api-key",
+        },
       },
     ]);
     controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
@@ -240,10 +288,18 @@ describe("installer controller", () => {
         residentId: "resident-1",
         lane: "coding",
         adapterId: "claude-agent-sdk",
-        credentialRef: { id: "codex-main", type: "api_key" },
+        credentialRef: {
+          id: "codex-main",
+          type: "api_key",
+          issuerId: "mist-installer-api-key",
+        },
         adapterConfig: {
           baseUrl: "https://gateway.example.test",
-          tokenCredentialRef: { id: "codex-main", type: "api_key" },
+          tokenCredentialRef: {
+            id: "codex-main",
+            type: "api_key",
+            issuerId: "mist-installer-api-key",
+          },
         },
       },
     ]);

--- a/tests/installer-controller.test.ts
+++ b/tests/installer-controller.test.ts
@@ -1,0 +1,200 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CredentialRef, InstallerDraft } from "../src/installer/contracts.ts";
+import { InstallerController } from "../src/installer/controller.ts";
+import { InstallerStateStore } from "../src/installer/state-store.ts";
+
+const temporaryDirectories: string[] = [];
+
+function freshDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "mist-installer-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function apiCredential(id = "codex-main"): CredentialRef {
+  return {
+    id,
+    label: "Codex main",
+    providerId: "codex",
+    method: "api-key",
+    secretRef: `${id}.token`,
+    status: "incomplete",
+  };
+}
+
+function completeDraft(controller: InstallerController): InstallerDraft {
+  controller.start("resident-1");
+  controller.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
+  controller.saveBindings([
+    {
+      residentId: "resident-1",
+      purpose: "main",
+      adapterId: "pi",
+      credentialId: "codex-main",
+    },
+  ]);
+  controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+  return controller.saveMemory({ kind: "create", path: "/tmp/mist-memory" });
+}
+
+describe("installer controller", () => {
+  it("persists progress after every step and resumes at the exact next screen", () => {
+    const directory = freshDirectory();
+    const first = new InstallerController(new InstallerStateStore(directory));
+    first.start("resident-1");
+    first.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
+    first.saveBindings([
+      {
+        residentId: "resident-1",
+        purpose: "main",
+        adapterId: "pi",
+        credentialId: "codex-main",
+      },
+    ]);
+
+    const resumed = new InstallerController(new InstallerStateStore(directory));
+    const draft = resumed.start("resident-1", "resume");
+    expect(draft.progress.currentStep).toBe("frontend");
+    expect(draft.progress.completedSteps).toEqual(["credentials", "bindings"]);
+    expect(draft.credentialRefs[0]?.status).toBe("ready");
+  });
+
+  it("discard removes both the visible draft and staged credential material", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
+    controller.discard();
+
+    const store = new InstallerStateStore(directory);
+    expect(store.loadDraft()).toBeNull();
+    expect(store.hasStagedSecret("codex-main.token")).toBe(false);
+  });
+
+  it("commits a complete snapshot without putting secret text in config or draft", () => {
+    const directory = freshDirectory();
+    const store = new InstallerStateStore(directory);
+    const controller = new InstallerController(store);
+    completeDraft(controller);
+    const receipt = controller.commit();
+
+    expect(store.loadDraft()).toBeNull();
+    expect(store.loadCurrentConfig()).toEqual(receipt.config);
+    expect(store.readCredentialSecret("codex-main.token")).toBe("secret-value");
+    expect(JSON.stringify(receipt.config)).not.toContain("secret-value");
+    expect(readFileSync(join(directory, "current.json"), "utf8")).not.toContain("secret-value");
+  });
+
+  it("writes draft, config, pointer, and credential files with owner-only permissions", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    completeDraft(controller);
+    expect(statSync(join(directory, "installer-draft.json")).mode & 0o777).toBe(0o600);
+    const receipt = controller.commit();
+    expect(statSync(join(directory, "current.json")).mode & 0o777).toBe(0o600);
+    expect(
+      statSync(join(directory, "snapshots", receipt.snapshotId, "config.json")).mode & 0o777,
+    ).toBe(0o600);
+    expect(
+      statSync(join(directory, "snapshots", receipt.snapshotId, "credentials", "codex-main.token"))
+        .mode & 0o777,
+    ).toBe(0o600);
+  });
+
+  it("refuses adapter bindings that violate a credential constraint", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([
+      {
+        ref: {
+          ...apiCredential("claude-login"),
+          providerId: "claude",
+          method: "oauth",
+          adapterConstraint: "claude-agent-sdk",
+        },
+        secret: "oauth-material",
+      },
+    ]);
+    controller.saveBindings([
+      {
+        residentId: "resident-1",
+        purpose: "main",
+        adapterId: "pi",
+        credentialId: "claude-login",
+      },
+    ]);
+    controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+    controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
+
+    expect(() => controller.commit()).toThrow(/requires adapter claude-agent-sdk/);
+  });
+
+  it("rejects a second binding for the same resident and purpose", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
+    controller.saveBindings([
+      {
+        residentId: "resident-1",
+        purpose: "main",
+        adapterId: "pi",
+        credentialId: "codex-main",
+      },
+      {
+        residentId: "resident-1",
+        purpose: "main",
+        adapterId: "other",
+        credentialId: "codex-main",
+      },
+    ]);
+    controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+    controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
+
+    expect(() => controller.commit()).toThrow(/duplicate main binding/);
+  });
+
+  it("returns the same receipt when commit is retried in the same controller", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    completeDraft(controller);
+
+    const first = controller.commit();
+    const second = controller.commit();
+
+    expect(second).toEqual(first);
+  });
+
+  it("refuses to activate the official-skin stub before its dependencies land", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
+    controller.saveBindings([
+      {
+        residentId: "resident-1",
+        purpose: "main",
+        adapterId: "pi",
+        credentialId: "codex-main",
+      },
+    ]);
+    controller.saveFrontend({
+      kind: "official-skin",
+      pluginId: "mist-official-skin",
+      installation: "pending",
+    });
+    controller.saveMemory({ kind: "create", path: "/tmp/mist-memory" });
+
+    expect(() => controller.commit()).toThrow(/cannot be activated yet/);
+  });
+});

--- a/tests/installer-controller.test.ts
+++ b/tests/installer-controller.test.ts
@@ -2,7 +2,11 @@ import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { CredentialRef, InstallerDraft } from "../src/installer/contracts.ts";
+import type {
+  InstallerCredential,
+  InstallerDraft,
+  LaneBinding,
+} from "../src/installer/contracts.ts";
 import { InstallerController } from "../src/installer/controller.ts";
 import { InstallerStateStore } from "../src/installer/state-store.ts";
 
@@ -20,28 +24,28 @@ afterEach(() => {
   }
 });
 
-function apiCredential(id = "codex-main"): CredentialRef {
+function apiCredential(id = "codex-main"): InstallerCredential {
   return {
-    id,
+    ref: { id, type: "api_key" },
     label: "Codex main",
     providerId: "codex",
-    method: "api-key",
-    secretRef: `${id}.token`,
     status: "incomplete",
+  };
+}
+
+function primaryBinding(id = "codex-main"): LaneBinding {
+  return {
+    residentId: "resident-1",
+    lane: "primary",
+    adapterId: "pi",
+    credentialRef: { id, type: "api_key" },
   };
 }
 
 function completeDraft(controller: InstallerController): InstallerDraft {
   controller.start("resident-1");
-  controller.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
-  controller.saveBindings([
-    {
-      residentId: "resident-1",
-      purpose: "main",
-      adapterId: "pi",
-      credentialId: "codex-main",
-    },
-  ]);
+  controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+  controller.saveBindings([primaryBinding()]);
   controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
   return controller.saveMemory({ kind: "create", path: "/tmp/mist-memory" });
 }
@@ -51,33 +55,67 @@ describe("installer controller", () => {
     const directory = freshDirectory();
     const first = new InstallerController(new InstallerStateStore(directory));
     first.start("resident-1");
-    first.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
-    first.saveBindings([
-      {
-        residentId: "resident-1",
-        purpose: "main",
-        adapterId: "pi",
-        credentialId: "codex-main",
-      },
-    ]);
+    first.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+    first.saveBindings([primaryBinding()]);
 
     const resumed = new InstallerController(new InstallerStateStore(directory));
     const draft = resumed.start("resident-1", "resume");
     expect(draft.progress.currentStep).toBe("frontend");
     expect(draft.progress.completedSteps).toEqual(["credentials", "bindings"]);
-    expect(draft.credentialRefs[0]?.status).toBe("ready");
+    expect(draft.credentials[0]?.status).toBe("ready");
+  });
+
+  it("returns to credentials without discarding saved credentials when a lane cannot be bound", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+    controller.saveBindings([primaryBinding()]);
+
+    const draft = controller.revisitCredentials();
+
+    expect(draft.progress.currentStep).toBe("credentials");
+    expect(draft.progress.completedSteps).toEqual([]);
+    expect(draft.credentials).toHaveLength(1);
+    expect(draft.credentials[0]?.ref.id).toBe("codex-main");
+    expect(draft.bindings).toEqual([]);
+  });
+
+  it("returns a pending review to frontend while preserving completed memory", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+    controller.saveBindings([primaryBinding()]);
+    controller.saveFrontend({
+      kind: "official-skin",
+      pluginId: "mist-official-skin",
+      installation: "pending",
+    });
+    controller.saveMemory({ kind: "create", path: "/tmp/mist-memory" });
+
+    const revisited = controller.revisitFrontend();
+    expect(revisited.progress.currentStep).toBe("frontend");
+    expect(revisited.memory).toEqual({ kind: "create", path: "/tmp/mist-memory" });
+
+    const changed = controller.saveFrontend({
+      kind: "external",
+      integration: "mist-session-api",
+    });
+    expect(changed.progress.currentStep).toBe("review");
+    expect(changed.memory).toEqual(revisited.memory);
   });
 
   it("discard removes both the visible draft and staged credential material", () => {
     const directory = freshDirectory();
     const controller = new InstallerController(new InstallerStateStore(directory));
     controller.start("resident-1");
-    controller.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
+    controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
     controller.discard();
 
     const store = new InstallerStateStore(directory);
     expect(store.loadDraft()).toBeNull();
-    expect(store.hasStagedSecret("codex-main.token")).toBe(false);
+    expect(store.hasStagedSecret("codex-main.credential")).toBe(false);
   });
 
   it("commits a complete snapshot without putting secret text in config or draft", () => {
@@ -89,7 +127,7 @@ describe("installer controller", () => {
 
     expect(store.loadDraft()).toBeNull();
     expect(store.loadCurrentConfig()).toEqual(receipt.config);
-    expect(store.readCredentialSecret("codex-main.token")).toBe("secret-value");
+    expect(store.readCredentialSecret("codex-main")).toBe("secret-value");
     expect(JSON.stringify(receipt.config)).not.toContain("secret-value");
     expect(readFileSync(join(directory, "current.json"), "utf8")).not.toContain("secret-value");
   });
@@ -105,8 +143,9 @@ describe("installer controller", () => {
       statSync(join(directory, "snapshots", receipt.snapshotId, "config.json")).mode & 0o777,
     ).toBe(0o600);
     expect(
-      statSync(join(directory, "snapshots", receipt.snapshotId, "credentials", "codex-main.token"))
-        .mode & 0o777,
+      statSync(
+        join(directory, "snapshots", receipt.snapshotId, "credentials", "codex-main.credential"),
+      ).mode & 0o777,
     ).toBe(0o600);
   });
 
@@ -116,11 +155,10 @@ describe("installer controller", () => {
     controller.start("resident-1");
     controller.saveCredentials([
       {
-        ref: {
+        credential: {
           ...apiCredential("claude-login"),
+          ref: { id: "claude-login", type: "claude_oauth" },
           providerId: "claude",
-          method: "oauth",
-          adapterConstraint: "claude-agent-sdk",
         },
         secret: "oauth-material",
       },
@@ -128,9 +166,9 @@ describe("installer controller", () => {
     controller.saveBindings([
       {
         residentId: "resident-1",
-        purpose: "main",
+        lane: "primary",
         adapterId: "pi",
-        credentialId: "claude-login",
+        credentialRef: { id: "claude-login", type: "claude_oauth" },
       },
     ]);
     controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
@@ -139,29 +177,29 @@ describe("installer controller", () => {
     expect(() => controller.commit()).toThrow(/requires adapter claude-agent-sdk/);
   });
 
-  it("rejects a second binding for the same resident and purpose", () => {
+  it("rejects a second binding for the same resident and lane", () => {
     const directory = freshDirectory();
     const controller = new InstallerController(new InstallerStateStore(directory));
     controller.start("resident-1");
-    controller.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
+    controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
     controller.saveBindings([
       {
         residentId: "resident-1",
-        purpose: "main",
+        lane: "primary",
         adapterId: "pi",
-        credentialId: "codex-main",
+        credentialRef: { id: "codex-main", type: "api_key" },
       },
       {
         residentId: "resident-1",
-        purpose: "main",
+        lane: "primary",
         adapterId: "other",
-        credentialId: "codex-main",
+        credentialRef: { id: "codex-main", type: "api_key" },
       },
     ]);
     controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
     controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
 
-    expect(() => controller.commit()).toThrow(/duplicate main binding/);
+    expect(() => controller.commit()).toThrow(/duplicate primary binding/);
   });
 
   it("returns the same receipt when commit is retried in the same controller", () => {
@@ -179,15 +217,8 @@ describe("installer controller", () => {
     const directory = freshDirectory();
     const controller = new InstallerController(new InstallerStateStore(directory));
     controller.start("resident-1");
-    controller.saveCredentials([{ ref: apiCredential(), secret: "secret-value" }]);
-    controller.saveBindings([
-      {
-        residentId: "resident-1",
-        purpose: "main",
-        adapterId: "pi",
-        credentialId: "codex-main",
-      },
-    ]);
+    controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+    controller.saveBindings([primaryBinding()]);
     controller.saveFrontend({
       kind: "official-skin",
       pluginId: "mist-official-skin",
@@ -196,5 +227,29 @@ describe("installer controller", () => {
     controller.saveMemory({ kind: "create", path: "/tmp/mist-memory" });
 
     expect(() => controller.commit()).toThrow(/cannot be activated yet/);
+  });
+
+  it("validates a Claude-compatible gateway using an API key reference", () => {
+    const directory = freshDirectory();
+    const controller = new InstallerController(new InstallerStateStore(directory));
+    controller.start("resident-1");
+    controller.saveCredentials([{ credential: apiCredential(), secret: "secret-value" }]);
+    controller.saveBindings([
+      primaryBinding(),
+      {
+        residentId: "resident-1",
+        lane: "coding",
+        adapterId: "claude-agent-sdk",
+        credentialRef: { id: "codex-main", type: "api_key" },
+        adapterConfig: {
+          baseUrl: "https://gateway.example.test",
+          tokenCredentialRef: { id: "codex-main", type: "api_key" },
+        },
+      },
+    ]);
+    controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+    controller.saveMemory({ kind: "existing", path: "/tmp/existing" });
+
+    expect(() => controller.commit()).not.toThrow();
   });
 });

--- a/tests/installer-controller.test.ts
+++ b/tests/installer-controller.test.ts
@@ -322,6 +322,31 @@ describe("installer controller", () => {
       error: /unsupported installation/,
     },
     {
+      name: "official frontend installed stub",
+      mutate(draft: InstallerDraft) {
+        draft.frontend = {
+          kind: "official-skin",
+          pluginId: "mist-official-skin",
+          installation: "installed",
+        };
+      },
+      error: /cannot be activated yet/,
+    },
+    {
+      name: "deferred Grok OAuth credential",
+      mutate(draft: InstallerDraft) {
+        const credential = draft.credentials[0];
+        const binding = draft.bindings[0];
+        if (credential === undefined || binding === undefined) throw new Error("missing fixture");
+        credential.ref.type = "grok_oauth";
+        credential.ref.issuerId = "pi";
+        credential.providerId = "grok";
+        binding.credentialRef.type = "grok_oauth";
+        binding.credentialRef.issuerId = "pi";
+      },
+      error: /unsupported type/,
+    },
+    {
       name: "memory kind",
       mutate(draft: InstallerDraft) {
         draft.memory = { kind: "future-memory", path: "/tmp/existing" } as never;

--- a/tests/installer-controller.test.ts
+++ b/tests/installer-controller.test.ts
@@ -285,6 +285,49 @@ describe("installer controller", () => {
       },
       error: /unsupported binding adapter/,
     },
+    {
+      name: "frontend kind",
+      mutate(draft: InstallerDraft) {
+        draft.frontend = { kind: "future-frontend" } as never;
+      },
+      error: /unsupported frontend kind/,
+    },
+    {
+      name: "external frontend integration",
+      mutate(draft: InstallerDraft) {
+        draft.frontend = { kind: "external", integration: "future-api" } as never;
+      },
+      error: /unsupported integration/,
+    },
+    {
+      name: "official frontend plugin",
+      mutate(draft: InstallerDraft) {
+        draft.frontend = {
+          kind: "official-skin",
+          pluginId: "future-skin",
+          installation: "installed",
+        } as never;
+      },
+      error: /unsupported pluginId/,
+    },
+    {
+      name: "official frontend installation",
+      mutate(draft: InstallerDraft) {
+        draft.frontend = {
+          kind: "official-skin",
+          pluginId: "mist-official-skin",
+          installation: "future-state",
+        } as never;
+      },
+      error: /unsupported installation/,
+    },
+    {
+      name: "memory kind",
+      mutate(draft: InstallerDraft) {
+        draft.memory = { kind: "future-memory", path: "/tmp/existing" } as never;
+      },
+      error: /unsupported memory kind/,
+    },
   ])("rejects a corrupted runtime $name enum", ({ mutate, error }) => {
     const directory = freshDirectory();
     const store = new InstallerStateStore(directory);

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -1,0 +1,379 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { InstallerController } from "../src/installer/controller.ts";
+import { FileMemoryLibrary } from "../src/installer/memory-library.ts";
+import type { OAuthLoginPort } from "../src/installer/pi-login.ts";
+import type { PromptPort } from "../src/installer/prompt-port.ts";
+import { runInstaller } from "../src/installer/run.ts";
+import { InstallerStateStore } from "../src/installer/state-store.ts";
+
+const temporaryDirectories: string[] = [];
+
+function freshDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "mist-installer-run-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+class ScriptedPrompt implements PromptPort {
+  readonly #selects: string[];
+  readonly #inputs: string[];
+  readonly #secrets: string[];
+  readonly #confirms: boolean[];
+  readonly infoMessages: string[] = [];
+
+  constructor(options: {
+    selects: string[];
+    inputs: string[];
+    secrets: string[];
+    confirms: boolean[];
+  }) {
+    this.#selects = [...options.selects];
+    this.#inputs = [...options.inputs];
+    this.#secrets = [...options.secrets];
+    this.#confirms = [...options.confirms];
+  }
+
+  async select<Value extends string>(): Promise<Value> {
+    const value = this.#selects.shift();
+    if (value === undefined) throw new Error("missing scripted select answer");
+    return value as Value;
+  }
+
+  async input(): Promise<string> {
+    const value = this.#inputs.shift();
+    if (value === undefined) throw new Error("missing scripted input answer");
+    return value;
+  }
+
+  async secret(): Promise<string> {
+    const value = this.#secrets.shift();
+    if (value === undefined) throw new Error("missing scripted secret answer");
+    return value;
+  }
+
+  async confirm(): Promise<boolean> {
+    const value = this.#confirms.shift();
+    if (value === undefined) throw new Error("missing scripted confirm answer");
+    return value;
+  }
+
+  info(message: string): void {
+    this.infoMessages.push(message);
+  }
+
+  expectExhausted(): void {
+    expect(this.#selects).toEqual([]);
+    expect(this.#inputs).toEqual([]);
+    expect(this.#secrets).toEqual([]);
+    expect(this.#confirms).toEqual([]);
+  }
+}
+
+const noOAuth: OAuthLoginPort = {
+  async login() {
+    throw new Error("OAuth was not expected in this test");
+  },
+};
+
+describe.each([
+  { frontend: "external", memory: "existing", expectedStatus: "committed" },
+  { frontend: "external", memory: "create", expectedStatus: "committed" },
+  { frontend: "official-skin", memory: "existing", expectedStatus: "dependency-pending" },
+  { frontend: "official-skin", memory: "create", expectedStatus: "dependency-pending" },
+] as const)("installer runner: $frontend + $memory", ({ frontend, memory, expectedStatus }) => {
+  it("finishes safely without leaking credential text", async () => {
+    const directory = freshDirectory();
+    const store = new InstallerStateStore(directory);
+    const memoryPath = join(directory, "memory-choice");
+    if (memory === "existing") mkdirSync(memoryPath);
+    const prompt = new ScriptedPrompt({
+      selects: ["codex", "api-key", "pi", "codex-key", frontend, memory],
+      inputs: ["codex-key", memoryPath],
+      secrets: ["credential-text"],
+      confirms: frontend === "external" ? [false, false, true] : [false, false],
+    });
+    const result = await runInstaller({
+      residentId: "resident-1",
+      dataDir: directory,
+      controller: new InstallerController(store),
+      store,
+      prompt,
+      oauth: noOAuth,
+      memoryLibraries: new FileMemoryLibrary(),
+    });
+
+    expect(result.status).toBe(expectedStatus);
+    if (result.status === "committed") {
+      expect(result.receipt.config.frontend.kind).toBe(frontend);
+      expect(result.receipt.config.memory.kind).toBe(memory);
+      expect(JSON.stringify(result.receipt.config)).not.toContain("credential-text");
+      expect(store.readCredentialSecret("codex-key.credential")).toBe("credential-text");
+    } else if (result.status === "dependency-pending") {
+      expect(result.draft.frontend?.kind).toBe("official-skin");
+      expect(result.draft.memory?.kind).toBe(memory);
+      expect(store.loadCurrentConfig()).toBeNull();
+      expect(store.loadDraft()?.progress.currentStep).toBe("review");
+    }
+    expect(existsSync(memoryPath)).toBe(true);
+    prompt.expectExhausted();
+  });
+});
+
+it("writes main Pi and coding Claude SDK bindings to separate purposes", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const prompt = new ScriptedPrompt({
+    selects: [
+      "codex",
+      "api-key",
+      "claude",
+      "oauth",
+      "pi",
+      "codex-key",
+      "claude-agent-sdk",
+      "claude-login",
+      "external",
+      "create",
+    ],
+    inputs: ["codex-key", "claude-login", join(directory, "memory")],
+    secrets: ["codex-api-key"],
+    confirms: [true, false, true, true],
+  });
+  const oauth: OAuthLoginPort = {
+    async login() {
+      return { locator: "pi-auth://anthropic" };
+    },
+  };
+
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  if (result.status !== "committed") throw new Error("expected committed setup");
+  expect(result.receipt.config.bindings).toEqual([
+    {
+      residentId: "resident-1",
+      purpose: "main",
+      adapterId: "pi",
+      credentialId: "codex-key",
+    },
+    {
+      residentId: "resident-1",
+      purpose: "coding",
+      adapterId: "claude-agent-sdk",
+      credentialId: "claude-login",
+    },
+  ]);
+  prompt.expectExhausted();
+});
+
+it("resumes from the persisted next step instead of asking for credentials again", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const first = new InstallerController(store);
+  first.start("resident-1");
+  first.saveCredentials([
+    {
+      ref: {
+        id: "codex-login",
+        label: "Codex",
+        providerId: "codex",
+        method: "oauth",
+        secretRef: "codex-login.credential",
+        status: "incomplete",
+      },
+      secret: "pi-auth://openai-codex",
+    },
+  ]);
+
+  const prompt = new ScriptedPrompt({
+    selects: ["resume", "pi", "codex-login", "external", "create"],
+    inputs: [join(directory, "memory")],
+    secrets: [],
+    confirms: [false, true],
+  });
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  prompt.expectExhausted();
+});
+
+it("keeps the exact review draft when commit is declined", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const controller = new InstallerController(store);
+  controller.start("resident-1");
+  controller.saveCredentials([
+    {
+      ref: {
+        id: "codex-key",
+        label: "Codex",
+        providerId: "codex",
+        method: "api-key",
+        secretRef: "codex-key.credential",
+        status: "incomplete",
+      },
+      secret: "credential-text",
+    },
+  ]);
+  controller.saveBindings([
+    {
+      residentId: "resident-1",
+      purpose: "main",
+      adapterId: "pi",
+      credentialId: "codex-key",
+    },
+  ]);
+  controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+  controller.saveMemory({ kind: "create", path: join(directory, "memory") });
+
+  const prompt = new ScriptedPrompt({
+    selects: ["resume"],
+    inputs: [],
+    secrets: [],
+    confirms: [false],
+  });
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("paused");
+  expect(store.loadDraft()?.progress.currentStep).toBe("review");
+  prompt.expectExhausted();
+});
+
+it("keeps an existing installation by default instead of creating a second snapshot", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const controller = new InstallerController(store);
+  controller.start("resident-1");
+  controller.saveCredentials([
+    {
+      ref: {
+        id: "codex-key",
+        label: "Codex",
+        providerId: "codex",
+        method: "api-key",
+        secretRef: "codex-key.credential",
+        status: "incomplete",
+      },
+      secret: "credential-text",
+    },
+  ]);
+  controller.saveBindings([
+    {
+      residentId: "resident-1",
+      purpose: "main",
+      adapterId: "pi",
+      credentialId: "codex-key",
+    },
+  ]);
+  controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
+  controller.saveMemory({ kind: "create", path: join(directory, "memory") });
+  const first = controller.commit();
+
+  const prompt = new ScriptedPrompt({
+    selects: ["keep"],
+    inputs: [],
+    secrets: [],
+    confirms: [],
+  });
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("already-configured");
+  expect(store.loadCurrentConfig()).toEqual(first.config);
+  prompt.expectExhausted();
+});
+
+it("removes an untouched installer-created memory library when its draft is discarded", async () => {
+  const directory = freshDirectory();
+  const memoryPath = join(directory, "old-memory");
+  const store = new InstallerStateStore(directory);
+  const libraries = new FileMemoryLibrary();
+  const old = new InstallerController(store);
+  old.start("resident-1");
+  old.saveCredentials([
+    {
+      ref: {
+        id: "old-key",
+        label: "Old",
+        providerId: "codex",
+        method: "api-key",
+        secretRef: "old-key.credential",
+        status: "incomplete",
+      },
+      secret: "old-secret",
+    },
+  ]);
+  old.saveBindings([
+    {
+      residentId: "resident-1",
+      purpose: "main",
+      adapterId: "pi",
+      credentialId: "old-key",
+    },
+  ]);
+  old.saveFrontend({ kind: "external", integration: "mist-session-api" });
+  libraries.createEmpty(memoryPath);
+  old.saveMemory({ kind: "create", path: memoryPath });
+
+  const replacementPath = join(directory, "replacement-memory");
+  const prompt = new ScriptedPrompt({
+    selects: ["discard", "codex", "api-key", "pi", "new-key", "external", "create"],
+    inputs: ["new-key", replacementPath],
+    secrets: ["new-secret"],
+    confirms: [false, false, true],
+  });
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: libraries,
+  });
+
+  expect(result.status).toBe("committed");
+  expect(existsSync(memoryPath)).toBe(false);
+  expect(existsSync(replacementPath)).toBe(true);
+  prompt.expectExhausted();
+});

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -96,7 +96,10 @@ describe.each([
     const memoryPath = join(directory, "memory-choice");
     if (memory === "existing") mkdirSync(memoryPath);
     const prompt = new ScriptedPrompt({
-      selects: ["codex", "api-key", "pi", "codex-key", frontend, memory],
+      selects:
+        frontend === "official-skin"
+          ? ["codex", "api-key", "codex-key", frontend, memory, "keep"]
+          : ["codex", "api-key", "codex-key", frontend, memory],
       inputs: ["codex-key", memoryPath],
       secrets: ["credential-text"],
       confirms: frontend === "external" ? [false, false, true] : [false, false],
@@ -116,7 +119,7 @@ describe.each([
       expect(result.receipt.config.frontend.kind).toBe(frontend);
       expect(result.receipt.config.memory.kind).toBe(memory);
       expect(JSON.stringify(result.receipt.config)).not.toContain("credential-text");
-      expect(store.readCredentialSecret("codex-key.credential")).toBe("credential-text");
+      expect(store.readCredentialSecret("codex-key")).toBe("credential-text");
     } else if (result.status === "dependency-pending") {
       expect(result.draft.frontend?.kind).toBe("official-skin");
       expect(result.draft.memory?.kind).toBe(memory);
@@ -128,7 +131,7 @@ describe.each([
   });
 });
 
-it("writes main Pi and coding Claude SDK bindings to separate purposes", async () => {
+it("writes primary Pi and coding Claude SDK bindings to separate lanes", async () => {
   const directory = freshDirectory();
   const store = new InstallerStateStore(directory);
   const prompt = new ScriptedPrompt({
@@ -137,16 +140,20 @@ it("writes main Pi and coding Claude SDK bindings to separate purposes", async (
       "api-key",
       "claude",
       "oauth",
-      "pi",
       "codex-key",
-      "claude-agent-sdk",
       "claude-login",
+      "codex-key",
       "external",
       "create",
     ],
-    inputs: ["codex-key", "claude-login", join(directory, "memory")],
+    inputs: [
+      "codex-key",
+      "claude-login",
+      "https://gateway.example.test",
+      join(directory, "memory"),
+    ],
     secrets: ["codex-api-key"],
-    confirms: [true, false, true, true],
+    confirms: [true, false, true, true, true],
   });
   const oauth: OAuthLoginPort = {
     async login() {
@@ -169,15 +176,19 @@ it("writes main Pi and coding Claude SDK bindings to separate purposes", async (
   expect(result.receipt.config.bindings).toEqual([
     {
       residentId: "resident-1",
-      purpose: "main",
+      lane: "primary",
       adapterId: "pi",
-      credentialId: "codex-key",
+      credentialRef: { id: "codex-key", type: "api_key" },
     },
     {
       residentId: "resident-1",
-      purpose: "coding",
+      lane: "coding",
       adapterId: "claude-agent-sdk",
-      credentialId: "claude-login",
+      credentialRef: { id: "claude-login", type: "claude_oauth" },
+      adapterConfig: {
+        baseUrl: "https://gateway.example.test",
+        tokenCredentialRef: { id: "codex-key", type: "api_key" },
+      },
     },
   ]);
   prompt.expectExhausted();
@@ -190,12 +201,10 @@ it("resumes from the persisted next step instead of asking for credentials again
   first.start("resident-1");
   first.saveCredentials([
     {
-      ref: {
-        id: "codex-login",
+      credential: {
+        ref: { id: "codex-login", type: "codex_oauth" },
         label: "Codex",
         providerId: "codex",
-        method: "oauth",
-        secretRef: "codex-login.credential",
         status: "incomplete",
       },
       secret: "pi-auth://openai-codex",
@@ -203,7 +212,7 @@ it("resumes from the persisted next step instead of asking for credentials again
   ]);
 
   const prompt = new ScriptedPrompt({
-    selects: ["resume", "pi", "codex-login", "external", "create"],
+    selects: ["resume", "codex-login", "external", "create"],
     inputs: [join(directory, "memory")],
     secrets: [],
     confirms: [false, true],
@@ -222,6 +231,55 @@ it("resumes from the persisted next step instead of asking for credentials again
   prompt.expectExhausted();
 });
 
+it("returns to credentials when the primary lane has no compatible credential", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const first = new InstallerController(store);
+  first.start("resident-1");
+  first.saveCredentials([
+    {
+      credential: {
+        ref: { id: "claude-login", type: "claude_oauth" },
+        label: "Claude login",
+        providerId: "claude",
+        status: "incomplete",
+      },
+      secret: "pi-auth://anthropic",
+    },
+  ]);
+
+  const prompt = new ScriptedPrompt({
+    selects: ["resume", "codex", "api-key", "codex-key", "claude-login", "external", "create"],
+    inputs: ["Codex key", join(directory, "memory")],
+    secrets: ["codex-secret"],
+    confirms: [false, true, false, true],
+  });
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  if (result.status !== "committed") throw new Error("expected committed setup");
+  expect(result.receipt.config.credentialRefs).toEqual([
+    { id: "claude-login", type: "claude_oauth" },
+    { id: "codex-key", type: "api_key" },
+  ]);
+  expect(result.receipt.config.bindings.map((binding) => binding.lane)).toEqual([
+    "primary",
+    "coding",
+  ]);
+  expect(prompt.infoMessages).toContain(
+    "No saved credential can be used with pi. Add one now — your draft is kept.",
+  );
+  prompt.expectExhausted();
+});
+
 it("keeps the exact review draft when commit is declined", async () => {
   const directory = freshDirectory();
   const store = new InstallerStateStore(directory);
@@ -229,12 +287,10 @@ it("keeps the exact review draft when commit is declined", async () => {
   controller.start("resident-1");
   controller.saveCredentials([
     {
-      ref: {
-        id: "codex-key",
+      credential: {
+        ref: { id: "codex-key", type: "api_key" },
         label: "Codex",
         providerId: "codex",
-        method: "api-key",
-        secretRef: "codex-key.credential",
         status: "incomplete",
       },
       secret: "credential-text",
@@ -243,9 +299,9 @@ it("keeps the exact review draft when commit is declined", async () => {
   controller.saveBindings([
     {
       residentId: "resident-1",
-      purpose: "main",
+      lane: "primary",
       adapterId: "pi",
-      credentialId: "codex-key",
+      credentialRef: { id: "codex-key", type: "api_key" },
     },
   ]);
   controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
@@ -269,6 +325,68 @@ it("keeps the exact review draft when commit is declined", async () => {
 
   expect(result.status).toBe("paused");
   expect(store.loadDraft()?.progress.currentStep).toBe("review");
+  expect(prompt.infoMessages.join("\n")).toContain("primary: pi · codex-key");
+  expect(prompt.infoMessages.join("\n")).not.toContain("credential-text");
+  prompt.expectExhausted();
+});
+
+it("lets a pending official-skin draft switch to an external frontend without redoing memory", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const memoryPath = join(directory, "memory");
+  const libraries = new FileMemoryLibrary();
+  const first = new InstallerController(store);
+  first.start("resident-1");
+  first.saveCredentials([
+    {
+      credential: {
+        ref: { id: "codex-key", type: "api_key" },
+        label: "Codex",
+        providerId: "codex",
+        status: "incomplete",
+      },
+      secret: "credential-text",
+    },
+  ]);
+  first.saveBindings([
+    {
+      residentId: "resident-1",
+      lane: "primary",
+      adapterId: "pi",
+      credentialRef: { id: "codex-key", type: "api_key" },
+    },
+  ]);
+  first.saveFrontend({
+    kind: "official-skin",
+    pluginId: "mist-official-skin",
+    installation: "pending",
+  });
+  first.saveMemory({ kind: "create", path: memoryPath });
+  libraries.createEmpty(memoryPath);
+
+  const prompt = new ScriptedPrompt({
+    selects: ["resume", "change", "external"],
+    inputs: [],
+    secrets: [],
+    confirms: [true],
+  });
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: libraries,
+  });
+
+  expect(result.status).toBe("committed");
+  if (result.status !== "committed") throw new Error("expected committed setup");
+  expect(result.receipt.config.frontend).toEqual({
+    kind: "external",
+    integration: "mist-session-api",
+  });
+  expect(result.receipt.config.memory.path).toBe(memoryPath);
   prompt.expectExhausted();
 });
 
@@ -279,12 +397,10 @@ it("keeps an existing installation by default instead of creating a second snaps
   controller.start("resident-1");
   controller.saveCredentials([
     {
-      ref: {
-        id: "codex-key",
+      credential: {
+        ref: { id: "codex-key", type: "api_key" },
         label: "Codex",
         providerId: "codex",
-        method: "api-key",
-        secretRef: "codex-key.credential",
         status: "incomplete",
       },
       secret: "credential-text",
@@ -293,9 +409,9 @@ it("keeps an existing installation by default instead of creating a second snaps
   controller.saveBindings([
     {
       residentId: "resident-1",
-      purpose: "main",
+      lane: "primary",
       adapterId: "pi",
-      credentialId: "codex-key",
+      credentialRef: { id: "codex-key", type: "api_key" },
     },
   ]);
   controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
@@ -332,12 +448,10 @@ it("removes an untouched installer-created memory library when its draft is disc
   old.start("resident-1");
   old.saveCredentials([
     {
-      ref: {
-        id: "old-key",
+      credential: {
+        ref: { id: "old-key", type: "api_key" },
         label: "Old",
         providerId: "codex",
-        method: "api-key",
-        secretRef: "old-key.credential",
         status: "incomplete",
       },
       secret: "old-secret",
@@ -346,9 +460,9 @@ it("removes an untouched installer-created memory library when its draft is disc
   old.saveBindings([
     {
       residentId: "resident-1",
-      purpose: "main",
+      lane: "primary",
       adapterId: "pi",
-      credentialId: "old-key",
+      credentialRef: { id: "old-key", type: "api_key" },
     },
   ]);
   old.saveFrontend({ kind: "external", integration: "mist-session-api" });
@@ -357,7 +471,7 @@ it("removes an untouched installer-created memory library when its draft is disc
 
   const replacementPath = join(directory, "replacement-memory");
   const prompt = new ScriptedPrompt({
-    selects: ["discard", "codex", "api-key", "pi", "new-key", "external", "create"],
+    selects: ["discard", "codex", "api-key", "new-key", "external", "create"],
     inputs: ["new-key", replacementPath],
     secrets: ["new-secret"],
     confirms: [false, false, true],

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -401,8 +401,8 @@ it("lets a pending official-skin draft switch to an external frontend without re
     pluginId: "mist-official-skin",
     installation: "pending",
   });
-  first.saveMemory({ kind: "create", path: memoryPath });
-  libraries.createEmpty(memoryPath);
+  const reviewDraft = first.saveMemory({ kind: "create", path: memoryPath });
+  libraries.createEmpty(memoryPath, reviewDraft.draftId);
 
   const prompt = new ScriptedPrompt({
     selects: ["resume", "change", "external"],
@@ -506,8 +506,8 @@ it("removes an untouched installer-created memory library when its draft is disc
     },
   ]);
   old.saveFrontend({ kind: "external", integration: "mist-session-api" });
-  libraries.createEmpty(memoryPath);
-  old.saveMemory({ kind: "create", path: memoryPath });
+  const reviewDraft = old.saveMemory({ kind: "create", path: memoryPath });
+  libraries.createEmpty(memoryPath, reviewDraft.draftId);
 
   const replacementPath = join(directory, "replacement-memory");
   const prompt = new ScriptedPrompt({
@@ -529,5 +529,84 @@ it("removes an untouched installer-created memory library when its draft is disc
   expect(result.status).toBe("committed");
   expect(existsSync(memoryPath)).toBe(false);
   expect(existsSync(replacementPath)).toBe(true);
+  prompt.expectExhausted();
+});
+
+it("does not delete the active memory library when a same-path replacement draft is discarded", async () => {
+  const directory = freshDirectory();
+  const memoryPath = join(directory, "active-memory");
+  const store = new InstallerStateStore(directory);
+  const libraries = new FileMemoryLibrary();
+
+  const active = new InstallerController(store);
+  active.start("resident-1");
+  active.saveCredentials([
+    {
+      credential: {
+        ref: apiKeyRef("active-key"),
+        label: "Active",
+        providerId: "codex",
+        status: "incomplete",
+      },
+      secret: "active-secret",
+    },
+  ]);
+  active.saveBindings([
+    {
+      residentId: "resident-1",
+      lane: "primary",
+      adapterId: "pi",
+      credentialRef: apiKeyRef("active-key"),
+    },
+  ]);
+  active.saveFrontend({ kind: "external", integration: "mist-session-api" });
+  const activeDraft = active.saveMemory({ kind: "create", path: memoryPath });
+  libraries.createEmpty(memoryPath, activeDraft.draftId);
+  active.commit();
+
+  const abandoned = new InstallerController(store);
+  abandoned.start("resident-1");
+  abandoned.saveCredentials([
+    {
+      credential: {
+        ref: apiKeyRef("abandoned-key"),
+        label: "Abandoned",
+        providerId: "codex",
+        status: "incomplete",
+      },
+      secret: "abandoned-secret",
+    },
+  ]);
+  abandoned.saveBindings([
+    {
+      residentId: "resident-1",
+      lane: "primary",
+      adapterId: "pi",
+      credentialRef: apiKeyRef("abandoned-key"),
+    },
+  ]);
+  abandoned.saveFrontend({ kind: "external", integration: "mist-session-api" });
+  const abandonedDraft = abandoned.saveMemory({ kind: "create", path: memoryPath });
+  libraries.createEmpty(memoryPath, abandonedDraft.draftId);
+
+  const prompt = new ScriptedPrompt({
+    selects: ["discard", "codex", "api-key", "replacement-key", "external", "existing"],
+    inputs: ["replacement-key", memoryPath],
+    secrets: ["replacement-secret"],
+    confirms: [false, false, true],
+  });
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: libraries,
+  });
+
+  expect(result.status).toBe("committed");
+  expect(existsSync(memoryPath)).toBe(true);
+  expect(store.loadCurrentConfig()?.memory).toEqual({ kind: "existing", path: memoryPath });
   prompt.expectExhausted();
 });

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -6,6 +6,7 @@ import { InstallerController } from "../src/installer/controller.ts";
 import { FileMemoryLibrary } from "../src/installer/memory-library.ts";
 import type { OAuthLoginPort } from "../src/installer/pi-login.ts";
 import type { PromptPort } from "../src/installer/prompt-port.ts";
+import { PROVIDERS } from "../src/installer/providers.ts";
 import { runInstaller } from "../src/installer/run.ts";
 import { InstallerStateStore } from "../src/installer/state-store.ts";
 
@@ -202,36 +203,11 @@ it("writes primary Pi and coding Claude SDK bindings to separate lanes", async (
   prompt.expectExhausted();
 });
 
-it("records Pi as the issuer for Grok subscription OAuth", async () => {
-  const directory = freshDirectory();
-  const store = new InstallerStateStore(directory);
-  const prompt = new ScriptedPrompt({
-    selects: ["grok", "oauth", "grok-login", "external", "create"],
-    inputs: ["grok-login", join(directory, "memory")],
-    secrets: [],
-    confirms: [false, false, true],
-  });
-  const oauth: OAuthLoginPort = {
-    async login(provider) {
-      expect(provider.piAuthKey).toBe("xai");
-      return { locator: "pi-auth://xai" };
-    },
-  };
+it("keeps Grok OAuth out of the v0 installer acquisition catalog", () => {
+  const grok = PROVIDERS.find((provider) => provider.id === "grok");
 
-  const result = await runInstaller({
-    residentId: "resident-1",
-    dataDir: directory,
-    controller: new InstallerController(store),
-    store,
-    prompt,
-    oauth,
-    memoryLibraries: new FileMemoryLibrary(),
-  });
-
-  expect(result.status).toBe("committed");
-  if (result.status !== "committed") throw new Error("expected committed setup");
-  expect(result.receipt.config.credentialRefs).toEqual([oauthRef("grok-login", "grok_oauth")]);
-  prompt.expectExhausted();
+  expect(grok?.piAuthKey).toBe("xai");
+  expect(grok?.methods).toEqual(["api-key"]);
 });
 
 it("resumes from the persisted next step instead of asking for credentials again", async () => {

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -84,6 +84,14 @@ const noOAuth: OAuthLoginPort = {
   },
 };
 
+function apiKeyRef(id: string) {
+  return { id, type: "api_key" as const, issuerId: "mist-installer-api-key" };
+}
+
+function oauthRef(id: string, type: "claude_oauth" | "codex_oauth" | "grok_oauth") {
+  return { id, type, issuerId: "pi" };
+}
+
 describe.each([
   { frontend: "external", memory: "existing", expectedStatus: "committed" },
   { frontend: "external", memory: "create", expectedStatus: "committed" },
@@ -178,19 +186,51 @@ it("writes primary Pi and coding Claude SDK bindings to separate lanes", async (
       residentId: "resident-1",
       lane: "primary",
       adapterId: "pi",
-      credentialRef: { id: "codex-key", type: "api_key" },
+      credentialRef: apiKeyRef("codex-key"),
     },
     {
       residentId: "resident-1",
       lane: "coding",
       adapterId: "claude-agent-sdk",
-      credentialRef: { id: "claude-login", type: "claude_oauth" },
+      credentialRef: oauthRef("claude-login", "claude_oauth"),
       adapterConfig: {
         baseUrl: "https://gateway.example.test",
-        tokenCredentialRef: { id: "codex-key", type: "api_key" },
+        tokenCredentialRef: apiKeyRef("codex-key"),
       },
     },
   ]);
+  prompt.expectExhausted();
+});
+
+it("records Pi as the issuer for Grok subscription OAuth", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const prompt = new ScriptedPrompt({
+    selects: ["grok", "oauth", "grok-login", "external", "create"],
+    inputs: ["grok-login", join(directory, "memory")],
+    secrets: [],
+    confirms: [false, false, true],
+  });
+  const oauth: OAuthLoginPort = {
+    async login(provider) {
+      expect(provider.piAuthKey).toBe("xai");
+      return { locator: "pi-auth://xai" };
+    },
+  };
+
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  if (result.status !== "committed") throw new Error("expected committed setup");
+  expect(result.receipt.config.credentialRefs).toEqual([oauthRef("grok-login", "grok_oauth")]);
   prompt.expectExhausted();
 });
 
@@ -202,7 +242,7 @@ it("resumes from the persisted next step instead of asking for credentials again
   first.saveCredentials([
     {
       credential: {
-        ref: { id: "codex-login", type: "codex_oauth" },
+        ref: oauthRef("codex-login", "codex_oauth"),
         label: "Codex",
         providerId: "codex",
         status: "incomplete",
@@ -239,7 +279,7 @@ it("returns to credentials when the primary lane has no compatible credential", 
   first.saveCredentials([
     {
       credential: {
-        ref: { id: "claude-login", type: "claude_oauth" },
+        ref: oauthRef("claude-login", "claude_oauth"),
         label: "Claude login",
         providerId: "claude",
         status: "incomplete",
@@ -267,8 +307,8 @@ it("returns to credentials when the primary lane has no compatible credential", 
   expect(result.status).toBe("committed");
   if (result.status !== "committed") throw new Error("expected committed setup");
   expect(result.receipt.config.credentialRefs).toEqual([
-    { id: "claude-login", type: "claude_oauth" },
-    { id: "codex-key", type: "api_key" },
+    oauthRef("claude-login", "claude_oauth"),
+    apiKeyRef("codex-key"),
   ]);
   expect(result.receipt.config.bindings.map((binding) => binding.lane)).toEqual([
     "primary",
@@ -288,7 +328,7 @@ it("keeps the exact review draft when commit is declined", async () => {
   controller.saveCredentials([
     {
       credential: {
-        ref: { id: "codex-key", type: "api_key" },
+        ref: apiKeyRef("codex-key"),
         label: "Codex",
         providerId: "codex",
         status: "incomplete",
@@ -301,7 +341,7 @@ it("keeps the exact review draft when commit is declined", async () => {
       residentId: "resident-1",
       lane: "primary",
       adapterId: "pi",
-      credentialRef: { id: "codex-key", type: "api_key" },
+      credentialRef: apiKeyRef("codex-key"),
     },
   ]);
   controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
@@ -340,7 +380,7 @@ it("lets a pending official-skin draft switch to an external frontend without re
   first.saveCredentials([
     {
       credential: {
-        ref: { id: "codex-key", type: "api_key" },
+        ref: apiKeyRef("codex-key"),
         label: "Codex",
         providerId: "codex",
         status: "incomplete",
@@ -353,7 +393,7 @@ it("lets a pending official-skin draft switch to an external frontend without re
       residentId: "resident-1",
       lane: "primary",
       adapterId: "pi",
-      credentialRef: { id: "codex-key", type: "api_key" },
+      credentialRef: apiKeyRef("codex-key"),
     },
   ]);
   first.saveFrontend({
@@ -398,7 +438,7 @@ it("keeps an existing installation by default instead of creating a second snaps
   controller.saveCredentials([
     {
       credential: {
-        ref: { id: "codex-key", type: "api_key" },
+        ref: apiKeyRef("codex-key"),
         label: "Codex",
         providerId: "codex",
         status: "incomplete",
@@ -411,7 +451,7 @@ it("keeps an existing installation by default instead of creating a second snaps
       residentId: "resident-1",
       lane: "primary",
       adapterId: "pi",
-      credentialRef: { id: "codex-key", type: "api_key" },
+      credentialRef: apiKeyRef("codex-key"),
     },
   ]);
   controller.saveFrontend({ kind: "external", integration: "mist-session-api" });
@@ -449,7 +489,7 @@ it("removes an untouched installer-created memory library when its draft is disc
   old.saveCredentials([
     {
       credential: {
-        ref: { id: "old-key", type: "api_key" },
+        ref: apiKeyRef("old-key"),
         label: "Old",
         providerId: "codex",
         status: "incomplete",
@@ -462,7 +502,7 @@ it("removes an untouched installer-created memory library when its draft is disc
       residentId: "resident-1",
       lane: "primary",
       adapterId: "pi",
-      credentialRef: { id: "old-key", type: "api_key" },
+      credentialRef: apiKeyRef("old-key"),
     },
   ]);
   old.saveFrontend({ kind: "external", integration: "mist-session-api" });

--- a/tests/memory-library.test.ts
+++ b/tests/memory-library.test.ts
@@ -24,21 +24,34 @@ describe("file memory library", () => {
     const path = join(root, "memory");
     const libraries = new FileMemoryLibrary();
 
-    libraries.createEmpty(path);
-    libraries.createEmpty(path);
+    libraries.createEmpty(path, "draft-one");
+    libraries.createEmpty(path, "draft-one");
     expect(existsSync(join(path, ".mist-memory.json"))).toBe(true);
-    expect(libraries.discardEmpty(path)).toBe(true);
+    expect(libraries.discardEmpty(path, "draft-one")).toBe(true);
     expect(existsSync(path)).toBe(false);
+  });
+
+  it("does not let a replacement draft claim or delete an existing empty library", () => {
+    const root = freshDirectory();
+    const path = join(root, "memory");
+    const libraries = new FileMemoryLibrary();
+
+    libraries.createEmpty(path, "active-draft");
+    libraries.createEmpty(path, "replacement-draft");
+
+    expect(libraries.discardEmpty(path, "replacement-draft")).toBe(false);
+    expect(existsSync(path)).toBe(true);
+    expect(libraries.discardEmpty(path, "active-draft")).toBe(true);
   });
 
   it("does not remove a library after a user adds content", () => {
     const root = freshDirectory();
     const path = join(root, "memory");
     const libraries = new FileMemoryLibrary();
-    libraries.createEmpty(path);
+    libraries.createEmpty(path, "draft-one");
     writeFileSync(join(path, "note.md"), "kept");
 
-    expect(libraries.discardEmpty(path)).toBe(false);
+    expect(libraries.discardEmpty(path, "draft-one")).toBe(false);
     expect(existsSync(join(path, "note.md"))).toBe(true);
   });
 

--- a/tests/memory-library.test.ts
+++ b/tests/memory-library.test.ts
@@ -1,0 +1,54 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileMemoryLibrary } from "../src/installer/memory-library.ts";
+
+const temporaryDirectories: string[] = [];
+
+function freshDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "mist-memory-library-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("file memory library", () => {
+  it("creates a resumable empty library and safely removes it when discarded", () => {
+    const root = freshDirectory();
+    const path = join(root, "memory");
+    const libraries = new FileMemoryLibrary();
+
+    libraries.createEmpty(path);
+    libraries.createEmpty(path);
+    expect(existsSync(join(path, ".mist-memory.json"))).toBe(true);
+    expect(libraries.discardEmpty(path)).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("does not remove a library after a user adds content", () => {
+    const root = freshDirectory();
+    const path = join(root, "memory");
+    const libraries = new FileMemoryLibrary();
+    libraries.createEmpty(path);
+    writeFileSync(join(path, "note.md"), "kept");
+
+    expect(libraries.discardEmpty(path)).toBe(false);
+    expect(existsSync(join(path, "note.md"))).toBe(true);
+  });
+
+  it("validates existing paths without claiming or modifying them", () => {
+    const root = freshDirectory();
+    const path = join(root, "existing");
+    mkdirSync(path);
+    const libraries = new FileMemoryLibrary();
+
+    expect(() => libraries.assertExisting(path)).not.toThrow();
+    expect(() => libraries.assertExisting(join(root, "missing"))).toThrow(/does not exist/);
+  });
+});

--- a/tests/pi-login.test.ts
+++ b/tests/pi-login.test.ts
@@ -50,11 +50,13 @@ describe("Pi interactive OAuth", () => {
     await expect(login.login(providerById("codex"))).rejects.toThrow(/without a Codex credential/);
   });
 
-  it("does not launch a dead OAuth path for Grok", async () => {
+  it("uses Pi's documented xAI issuer for Grok subscription OAuth", async () => {
+    const authPath = freshAuthPath();
+    writeFileSync(authPath, JSON.stringify({ xai: { access: "sensitive-token" } }));
     const launch = vi.fn(async () => undefined);
-    const login = new PiInteractiveLogin({ authPath: freshAuthPath(), launch });
+    const login = new PiInteractiveLogin({ authPath, launch, beforeLaunch: () => undefined });
 
-    await expect(login.login(providerById("grok"))).rejects.toThrow(/does not expose OAuth/);
-    expect(launch).not.toHaveBeenCalled();
+    await expect(login.login(providerById("grok"))).resolves.toEqual({ locator: "pi-auth://xai" });
+    expect(launch).toHaveBeenCalledOnce();
   });
 });

--- a/tests/pi-login.test.ts
+++ b/tests/pi-login.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PiInteractiveLogin } from "../src/installer/pi-login.ts";
+import { providerById } from "../src/installer/providers.ts";
+
+const temporaryDirectories: string[] = [];
+
+function freshAuthPath(): string {
+  const directory = mkdtempSync(join(tmpdir(), "mist-pi-login-"));
+  temporaryDirectories.push(directory);
+  return join(directory, "auth.json");
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Pi interactive OAuth", () => {
+  it("returns only an opaque locator after Pi owns the OAuth exchange", async () => {
+    const authPath = freshAuthPath();
+    writeFileSync(authPath, JSON.stringify({ "openai-codex": { access: "sensitive-token" } }));
+    const launch = vi.fn(async () => undefined);
+    const messages: string[] = [];
+    const login = new PiInteractiveLogin({
+      authPath,
+      launch,
+      beforeLaunch: (message) => messages.push(message),
+    });
+
+    const receipt = await login.login(providerById("codex"));
+
+    expect(receipt).toEqual({ locator: "pi-auth://openai-codex" });
+    expect(JSON.stringify({ receipt, messages })).not.toContain("sensitive-token");
+    expect(launch).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the draft incomplete when Pi exits without the selected provider", async () => {
+    const authPath = freshAuthPath();
+    writeFileSync(authPath, JSON.stringify({ anthropic: {} }));
+    const login = new PiInteractiveLogin({
+      authPath,
+      launch: async () => undefined,
+      beforeLaunch: () => undefined,
+    });
+
+    await expect(login.login(providerById("codex"))).rejects.toThrow(/without a Codex credential/);
+  });
+
+  it("does not launch a dead OAuth path for Grok", async () => {
+    const launch = vi.fn(async () => undefined);
+    const login = new PiInteractiveLogin({ authPath: freshAuthPath(), launch });
+
+    await expect(login.login(providerById("grok"))).rejects.toThrow(/does not expose OAuth/);
+    expect(launch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/pi-login.test.ts
+++ b/tests/pi-login.test.ts
@@ -50,13 +50,13 @@ describe("Pi interactive OAuth", () => {
     await expect(login.login(providerById("codex"))).rejects.toThrow(/without a Codex credential/);
   });
 
-  it("uses Pi's documented xAI issuer for Grok subscription OAuth", async () => {
+  it("does not launch Pi for Grok OAuth while issue #50 keeps it out of v0", async () => {
     const authPath = freshAuthPath();
     writeFileSync(authPath, JSON.stringify({ xai: { access: "sensitive-token" } }));
     const launch = vi.fn(async () => undefined);
     const login = new PiInteractiveLogin({ authPath, launch, beforeLaunch: () => undefined });
 
-    await expect(login.login(providerById("grok"))).resolves.toEqual({ locator: "pi-auth://xai" });
-    expect(launch).toHaveBeenCalledOnce();
+    await expect(login.login(providerById("grok"))).rejects.toThrow(/does not expose OAuth/);
+    expect(launch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #50.

## What changed

- adds a four-step terminal installer for credentials, primary/coding lane bindings, frontend selection, and memory setup
- persists a resumable draft after each step, stages secrets separately with owner-only permissions, and activates an immutable snapshot through an atomic current pointer
- aligns CredentialRef and LaneBinding with the latest plugin protocol v0 draft in #52, including issuerId and an optional Claude-compatible gateway
- supports the active v0 acquisition paths for Claude and Codex OAuth plus installer-entered API keys; xAI/Grok OAuth remains a protocol type but is deferred by #50 and cannot enter active config
- keeps the official-skin path fail-closed until #49 and #51 land, while allowing the user to return and choose an external frontend
- includes Laurie’s user-path walkthrough and recovery copy in the same branch

## User impact

A fresh Mist install can now be configured through npm run setup. Interrupted runs resume at the saved step, active configuration remains unchanged until confirmation, and credential values never enter draft or active config JSON.

## Validation

- npm run lint
- npm run typecheck
- npm test — 26 files, 216 tests passed
- npm run acceptance:strict — 6/6
- live TTY run through the external-frontend/create-memory path; the key remained masked, public files contained no secret text, and generated files were mode 0600
- GitHub Actions CI passed on the current head

## Review focus

- draft → validate → immutable snapshot → atomic pointer transaction
- recovery from missing compatible credentials and pending official-skin dependencies
- issuer/type enforcement and lane-binding compatibility with #52