### PR TITLE
chore(ci): 根仓 lint/test 不扫 vendored webui/**（主笔 A 案裁定落地）

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,16 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "ignoreUnknown": true },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "ignore": [
+      "webui/**"
+    ]
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
@@ -10,9 +19,13 @@
   },
   "linter": {
     "enabled": true,
-    "rules": { "recommended": true }
+    "rules": {
+      "recommended": true
+    }
   },
   "javascript": {
-    "formatter": { "quoteStyle": "double" }
+    "formatter": {
+      "quoteStyle": "double"
+    }
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig, configDefaults } from "vitest/config";
+
+// webui/ 是 vendored 冻结树（dsh 官方素皮整包，SHA 对账、字节稳定）。
+// 界内测试由 webui 自带 pnpm 流水线（oxlint+build+753 项）自管，
+// 根仓 vitest 不扫入，避免双套测试体系互踩。
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, "webui/**"],
+  },
+});


### PR DESCRIPTION
落地主笔 2026-08-18 的 A 案裁定（#56 楼）：vendored webui/** 整包冻结树不进根仓 biome 与 vitest 扫描范围，界内归其自带 oxlint+pnpm 流水线自管。解锁 #56、#61 两条 lane 的 lint 红灯。