### PR TITLE
style: biome 格式两处直修（解 #64 后 main lint 红）

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,9 +7,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "ignore": [
-      "webui/**"
-    ]
+    "ignore": ["webui/**"]
   },
   "formatter": {
     "enabled": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, configDefaults } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 // webui/ 是 vendored 冻结树（dsh 官方素皮整包，SHA 对账、字节稳定）。
 // 界内测试由 webui 自带 pnpm 流水线（oxlint+build+753 项）自管，


### PR DESCRIPTION
#64 合入时带进两处格式偏差：`biome.json` 的 `files.ignore` 数组收单行、`vitest.config.ts` import 排序。`biome check --write` 直出，无逻辑改动；本地 root 216 测试全绿。

main 自 911f441 起 push run 即红，所有在途 PR（#61 等）继承此红被挡门——本 PR 落地后各枝 rebase 重跑即可回绿。情报来源：#61 楼獭獭 2026-08-18 04:12 评论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)