### PR TITLE
docs: complete issue #67 protocol wording

### DIFF
--- a/acceptance/plugin-protocol-v0.md
+++ b/acceptance/plugin-protocol-v0.md
@@ -10,97 +10,102 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
 
 ## A. Manifest 与兼容性
 
-- [ ] **PV0-A01 合法 manifest 可进入 prepare**：四类插件各一份最小合法 fixture；校验后
+- [ ] **[PV0-A01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 合法 manifest 可进入 prepare**：四类插件各一份最小合法 fixture；校验后
   状态为 discovered/validated，尚未出现在能力目录。
-- [ ] **PV0-A02 未知 schema fail-closed**：把 `manifestSchemaVersion` 改为 99；插件代码
+- [ ] **[PV0-A02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 未知 schema fail-closed**：把 `manifestSchemaVersion` 改为 99；插件代码
   未加载、无资源注册，返回 `HOST_INCOMPATIBLE`。
-- [ ] **PV0-A03 requiresMist 不可猜**：分别使用不匹配范围和不可解析字符串；两者均在
+- [ ] **[PV0-A03](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) requiresMist 不可猜**：分别使用不匹配范围和不可解析字符串；两者均在
   加载代码前返回 `HOST_INCOMPATIBLE`。
-- [ ] **PV0-A04 路径与枚举封口**：entrypoint 或 context injection source 逃出插件根、
-  未知 kind/effect/injection mode、重复 capability/context injection id 分别返回
+- [ ] **[PV0-A04](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 路径与枚举封口**：entrypoint 或 context injection source 逃出插件根、
+  未知 kind/effect/injection mode、重复 capability/context injection manifest `id` 分别返回
   `MANIFEST_INVALID`，且无部分注册。
-- [ ] **PV0-A05 缺要求不降级装**：删除 required env、配置或 credential ref；返回
+- [ ] **[PV0-A05](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 缺要求不降级装**：删除 required env、配置或 credential ref；返回
   `REQUIREMENT_MISSING`。optional 缺失则可继续，但 readiness 明列缺失 scope。
-- [ ] **PV0-A06 manifest 无需执行代码**：插件 entrypoint 顶层放置会抛错的探针；校验
+- [ ] **[PV0-A06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) manifest 无需执行代码**：插件 entrypoint 顶层放置会抛错的探针；校验
   非法 `mist-plugin.json` 时探针计数为零，证明宿主在 import 前完成拒装。
-- [ ] **PV0-A07 停用是真卸载**：enabled 从 true 切到 false 后完整经过 dispose，能力与
+- [ ] **[PV0-A07](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 停用是真卸载**：enabled 从 true 切到 false 后完整经过 dispose，能力与
   资源不可达但设置仍在；重新启用时重新 validate/prepare/activate，不复用旧 handle。
-- [ ] **PV0-A08 plugin id 封口**：大写、空白、路径分隔符和 `../evil` 均返回
+- [ ] **[PV0-A08](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) plugin id 封口**：大写、空白、路径分隔符和 `../evil` 均返回
   `MANIFEST_INVALID` 且不加载代码；普通安装复用现役 id 返回 `PLUGIN_ID_CONFLICT`，
   只有显式 upgrade 能携同 id 进入 E 区事务。
-- [ ] **PV0-A09 env 绑定形状不可混用**：逐一测试 secret×value、secret×secretRef、
+- [ ] **[PV0-A09](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) env 绑定形状不可混用**：逐一测试 secret×value、secret×secretRef、
   plain×value、plain×secretRef；只有中间两种匹配组合中的 secret×secretRef 与
   plain×value 通过，错配返回 `CONFIG_INVALID`，明文 secret 不进入配置快照。
 
 ## B. 权限、secret 与工具翻译
 
-- [ ] **PV0-B01 字面量权限真收窄**：授权 `terminal_send.text=["/new"]`；发送 `/new`
-  通过，发送 `/reset` 在执行前返回 `PERMISSION_DENIED`，执行器调用次数不增加。
-- [ ] **PV0-B02 空数组不是通配**：operations 或 literals 为空时调用任意值均被拒绝。
-- [ ] **PV0-B03 effect 不可降级**：插件把已登记 irreversible 操作声明成 read；manifest
+- [ ] **[PV0-B01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 字面量权限真收窄**：授权 `terminal_send.text=["/new"]`；发送 `/new`
+  通过，发送 `/reset` 在执行前返回 `PERMISSION_DENIED`，执行器调用次数不增加；插件为
+  宿主契约未登记为可收窄参数的字段自造 literal 限制时，manifest 返回 `MANIFEST_INVALID`。
+- [ ] **[PV0-B02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 空数组不是通配**：operations 或 literals 为空时调用任意值均被拒绝。
+- [ ] **[PV0-B03](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) effect 不可降级**：插件把已登记 irreversible 操作声明成 read；manifest
   校验返回 `MANIFEST_INVALID`，不能以插件声明覆盖宿主能力契约。
-- [ ] **PV0-B04 secret 全面不落字**：将唯一标记放入 secret env 和凭证值，覆盖成功、
+- [ ] **[PV0-B04](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) secret 全面不落字**：将唯一标记放入 secret env 和凭证值，覆盖成功、
   prepare 失败、运行时失败、dispose 失败四条路径；配置快照、日志、事件、错误文本和带
   来源标记的住户上下文快照均不含标记。
-- [ ] **PV0-B05 翻译不扩权**：同一 tool capability 分别经 Claude SDK 和 pi 适配器翻译；
+- [ ] **[PV0-B05](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s6) 翻译不扩权**：同一 tool capability 分别经 Claude SDK 和 pi 适配器翻译；
   输出仍带原 capability/plugin id、effect、operations 与 literals，未授权操作不可达。
-- [ ] **PV0-B06 MCP 经 host 收编**：MCP server 暴露声明外工具；该工具不进入住户工具集，
+- [ ] **[PV0-B06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s6) MCP 经 host 收编**：MCP server 暴露声明外工具；该工具不进入住户工具集，
   主 agent 精简集和 subagent 任务集只包含各自策略交集。
-- [ ] **PV0-B07 翻译输出是闭集**：坏适配器在完整保留 metadata 的同时额外暴露
+- [ ] **[PV0-B07](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s6) 翻译输出是闭集**：坏适配器在完整保留 metadata 的同时额外暴露
   `run_arbitrary`，或静默漏掉一个已授权操作；前者因无源工具、后者因映射不完整而使该
   capability 非 ready，输出集必须与 verified scope 的源操作逐项对应。
-- [ ] **PV0-B08 完整用户输入不进诊断**：使用独立随机长句作为住户原话探针，覆盖成功、
+- [ ] **[PV0-B08](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s8) 完整用户输入不进诊断**：使用独立随机长句作为住户原话探针，覆盖成功、
   prepare 失败、运行时失败、dispose 失败四条路径；日志、事件、错误文本及插件来源的诊断
   注入段均不得含完整探针。原始住户消息本身不属于插件泄漏，断言必须按来源区分。
-- [ ] **PV0-B09 lazy 不预注入 schema**：声明 lazy capability，active 后住户目录只含 id、
+- [ ] **[PV0-B09](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s6) lazy 不预注入 schema**：声明 lazy capability，active 后住户目录只含 id、
   plugin 来源和单行 description，不含完整 operations schema；按需取回后可以调用，且取回前后
   权限结果一致。把 lazy 当 eager 全量铺入上下文时本条变红。
-- [ ] **PV0-B10 注入正文安装前可审计**：声明 resident/session 两种 context injection；
-  模型上下文中的正文逐字来自包内 source，并带 plugin id、注入 id、路径和 scope。换包版本后
+- [ ] **[PV0-B10](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 注入正文安装前可审计**：声明 resident/session 两种 context injection；
+  模型上下文中的正文逐字来自包内 source，并带 plugin id、注入 manifest `id`、路径和 scope。换包版本后
   diff 可见，session 注入不跨会话残留。
-- [ ] **PV0-B11 未声明或漂移的注入显式拒绝**：MCP server 下发 manifest 未声明的
+- [ ] **[PV0-B11](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s2) 未声明或漂移的注入显式拒绝**：MCP server 下发 manifest 未声明的
   instructions，或把已声明正文改一个字；文本不进入住户上下文，返回
   `CONTEXT_INJECTION_MISMATCH`，capability 非 ready，住户能看见拒绝原因而非静默截断。
-- [ ] **PV0-B12 secret 不经插件产物进入模型**：恶意 fixture 分别从工具返回值和已声明
+- [ ] **[PV0-B12](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s8) secret 不经插件产物进入模型**：恶意 fixture 分别从工具返回值和已声明
   context injection 回显执行边界解析过的 secret 标记；两条都在装入模型上下文前返回
   `SENSITIVE_OUTPUT_BLOCKED`，上下文、后续摘要输入和记忆候选中均无该标记。
-- [ ] **PV0-B13 注入随停用与卸载撤下**：active 插件分别装入 resident/session 注入后，将
+- [ ] **[PV0-B13](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) 注入随停用与卸载撤下**：active 插件分别装入 resident/session 注入后，将
   `enabled` 切为 false 并完成 dispose；住户上下文快照、启动包及下一次会话重建输入均不含
   该 plugin id 的注入段。工具与资源已消失但守则仍留在 wakepack 时本条变红。
 
 ## C. 事务注册、隔离与注销
 
-- [ ] **PV0-C01 prepare 不提前公开**：prepare 注册三个资源但未 activate；路由、能力目录
+- [ ] **[PV0-C01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) prepare 不提前公开**：prepare 注册三个资源但未 activate；路由、能力目录
   和绑定接口均查不到它们。
-- [ ] **PV0-C02 部分注册失败全回滚**：第三个资源注册抛错；前两个 handle 按逆序各撤销
+- [ ] **[PV0-C02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) 部分注册失败全回滚**：第三个资源注册抛错；前两个 handle 按逆序各撤销
   一次，插件返回 `PREPARE_FAILED`，能力目录为空。
-- [ ] **PV0-C03 activate 失败全回滚**：prepare 成功、activate 抛错；所有资源撤销，
+- [ ] **[PV0-C03](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) activate 失败全回滚**：prepare 成功、activate 抛错；所有资源撤销，
   rollback 被调用，返回 `ACTIVATE_FAILED`，没有半 active 状态。
-- [ ] **PV0-C04 成功提交原子可见**：activate 成功前目录为零，提交后整批资源同时可见，
+- [ ] **[PV0-C04](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) 成功提交原子可见**：activate 成功前目录为零，提交后整批资源同时可见，
   不允许观察到子集。
-- [ ] **PV0-C05 dispose 幂等**：同一 active 插件连续 dispose 两次；每个资源最多实际撤销
+- [ ] **[PV0-C05](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) dispose 幂等**：同一 active 插件连续 dispose 两次；每个资源最多实际撤销
   一次，两次返回同一终态，无异常、无新资源。
-- [ ] **PV0-C06 注销先断路**：制造一个在途调用后发起卸载；新调用立即拒绝，待在途调用
+- [ ] **[PV0-C06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) 注销先断路**：制造一个在途调用后发起卸载；新调用立即拒绝，待在途调用
   结束或取消后逆序清理，卸载后所有已登记或经宿主管理的路由、监听器、定时器和出站连接不可达。
-- [ ] **PV0-C07 清理失败 fail-closed**：让一个 handle.revoke 失败；返回
+- [ ] **[PV0-C07](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) 清理失败 fail-closed**：让一个 handle.revoke 失败；返回
   `DISPOSE_INCOMPLETE`，状态为 quarantined，资源 id 留在隔离记录，但任何住户都不能再调用。
-- [ ] **PV0-C08 单插件故障不拖地基**：插件运行时同步抛错、异步拒绝、超时各一次；当前
+- [ ] **[PV0-C08](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) 单插件故障不拖地基**：插件运行时同步抛错、异步拒绝、超时各一次；当前
   调用返回 `PLUGIN_RUNTIME_FAILED`，另一插件、住户存储和 boot-time 不变量仍可读写。
-- [ ] **PV0-C09 不自动重试风暴**：失败插件在无显式操作时不再次 prepare/activate/call；
-  计数器在观察窗内保持不变。
-- [ ] **PV0-C10 生命周期中断可恢复**：分别在 ① activate 已创建资源但 active 终态写盘前、
+- [ ] **[PV0-C09](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) 不自动重试风暴**：fixture 先执行一次
+  会返回 `PLUGIN_RUNTIME_FAILED` 的失败 `call`；随后只用可控 fixture clock 或 scheduler tick 推进至少一个
+  失败后的调度周期并排空队列。整个确定性观察窗内 prepare、activate、call 三类计数均不增加；不得使用
+  真实 sleep，也不得为此定义生产 TTL。
+- [ ] **[PV0-C10](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) 生命周期中断可恢复**：分别在 ① activate 已创建资源但 active 终态写盘前、
   ② dispose 已撤销部分资源时杀死宿主进程。重启后先执行操作日志协调且插件入口始终不可达：
   前者按持久化注册日志回滚后停在 `blocked + ACTIVATE_FAILED`，保留 plugin id、operationId、
   `enabled: true` 的启用意图、配置与绑定，等待显式重试或停用；后者从撤销回执继续逆序清理，
   失败则 quarantined。剩余资源 id 与 quarantined 记录跨重启仍可枚举，协调期间返回
-  `LIFECYCLE_RECOVERY_PENDING`，不得把任一孤儿中间态恢复成 ready 或假装从未安装。
-- [ ] **PV0-C11 权威状态先于公开索引**：在 active 四元组原子提交前、提交后但公开前、公开后
+  `LIFECYCLE_RECOVERY_PENDING`，不得把任一孤儿中间态恢复成 ready 或假装从未安装。此处协调
+  是启动时未完成 activate/dispose 日志的恢复，不是用户重试；协调后 blocked 只能显式修复/重试
+  重新走生命周期，或显式停用清理。
+- [ ] **[PV0-C11](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) 权威状态先于公开索引**：在 active 四元组原子提交前、提交后但公开前、公开后
   三个时点分别杀死宿主；每次重启后，可枚举入口、路由索引与工具目录都必须是已持久化
   `{active, config, bindings, verifiedScope}` 的子集。先持久化路由索引再写 active 记录时本条变红。
   本条与 C10 的主证据都由 Vitest 集成测试提供：测试启动真实宿主子进程，在指定时点将其杀死并
   重新拉起，再断言可枚举结果；进程内状态快照对比只能作辅证，不得替代 kill/restart，也不得
   用 mock 重启、清空内存态或临时脚本冒充。
-- [ ] **PV0-C12 quarantined 只能显式清理重试**：制造一次部分撤销失败，确认插件进入
+- [ ] **[PV0-C12](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s3) quarantined 只能显式清理重试**：制造一次部分撤销失败，确认插件进入
   `quarantined` 且所有入口保持 fail-closed；无显式操作时不得再次调用清理。重复调用
   `dispose` 不是显式重试，必须幂等返回同一 `quarantined` 隔离态且不再次执行清理；只有宿主
   独立的显式清理重试（例如 `retryCleanup(pluginId)`）才能继续撤销。重试且全部剩余资源
@@ -109,64 +114,84 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
 
 ## D. 绑定、角色与凭证类型
 
-- [ ] **PV0-D01 绑定键不串房**：两个 resident 的同名 `primary` 车道绑定不同适配器；
+- [ ] **[PV0-D01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) 绑定键不串房**：两个 resident 的同名 `primary` 车道绑定不同适配器；
   并发 dispatch 各命中自己的 adapter/credential ref，互不泄漏。
-- [ ] **PV0-D02 角色与车道正交**：main 和 subagent 使用同一车道时可走同一绑定，但 main
+- [ ] **[PV0-D02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) 角色与车道正交**：main 和 subagent 使用同一车道时可走同一绑定，但 main
   获得住户记忆/精简工具集，subagent 无住户记忆且只获任务工具集。
-- [ ] **PV0-D03 subagent 继承与换道**：未指定 lane 时继承请求车道；显式换到 coding 时
+- [ ] **[PV0-D03](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) subagent 继承与换道**：未指定 lane 时继承请求车道；显式换到 coding 时
   重新校验绑定、权限和工具策略，缺任一项即在 dispatch 前失败。
-- [ ] **PV0-D04 Claude OAuth 专属约束**：`claude_oauth → Claude SDK` 绑定通过；同一 ref
+- [ ] **[PV0-D04](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) Claude OAuth 专属约束**：`claude_oauth → Claude SDK` 绑定通过；同一 ref
   绑定 pi 返回 `CREDENTIAL_TYPE_MISMATCH`，旧绑定不变、凭证不被读取。
-- [ ] **PV0-D05 其他凭证按声明匹配**：codex_oauth、grok_oauth、api_key 只要在适配器
+- [ ] **[PV0-D05](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) 其他凭证按声明匹配**：codex_oauth、grok_oauth、api_key 只要在适配器
   accepts 内即可绑定；不在列表时返回 `CREDENTIAL_TYPE_MISMATCH`。
-- [ ] **PV0-D06 Claude SDK 网关形状**：使用 baseUrl + tokenCredentialRef 可建立适配器，
+- [ ] **[PV0-D06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) Claude SDK 网关形状**：使用 baseUrl + tokenCredentialRef 可建立适配器，
   请求只在执行边界解析 token；配置、绑定与诊断中只有 ref id，没有 token 值。
-- [ ] **PV0-D07 不制造悬空引用**：删除被绑定适配器或凭证时，宿主列出依赖并拒绝直接删；
+- [ ] **[PV0-D07](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) 不制造悬空引用**：删除被绑定适配器或凭证时，宿主列出依赖并拒绝直接删；
   解除或迁移绑定后才能删除。
-- [ ] **PV0-D08 错绑定不覆盖好绑定**：对现有 ready 车道提交无效新绑定；持久化失败后旧绑定
-  仍可 dispatch，verified scope 不变。
-- [ ] **PV0-D09 角色不从名字推导**：分别建立名为 `main`、`subagent`、`coding-subagent`
-  的车道并交叉发送两种 role；最终角色只等于已授权 `DispatchRequest.role`，lane 名、适配器
+- [ ] **[PV0-D08](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) 错绑定不覆盖好绑定**：对现有 ready 车道提交无效新绑定；持久化失败后旧绑定
+  仍可 dispatch，verified scope 不变。host contract 未登记的 lane、错拼、仅大小写不同或前后
+  含空白的 lane 均在绑定和 dispatch 前返回 `CONFIG_INVALID`，不读取凭证、不调用 adapter。
+- [ ] **[PV0-D09](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) 角色不从名字推导**：fixture 先在宿主能力契约登记
+  `main`、`subagent`、`coding-subagent` 三条精确 lane，再交叉发送两种 role；最终角色只等于已授权 `DispatchRequest.role`，lane 名、适配器
   和凭证类型都不能改变角色或记忆挂载规则。
-- [ ] **PV0-D10 凭证获取入口有签发方**：credential type 只在 active issuer 声明后出现在
+- [ ] **[PV0-D10](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s5) 凭证获取入口有签发方**：credential type 只在 active issuer 声明后出现在
   TUI/API；移除 issuer 后入口消失，新建或导入无法回指 issuer 的 ref 返回
-  `CREDENTIAL_ISSUER_UNAVAILABLE`，现役有效 ref 的值不泄漏。
+  `CREDENTIAL_ISSUER_UNAVAILABLE`，现役有效 ref 的值不泄漏；issuer 删除后的现役 ref 处置/迁移
+  策略不属于 v0，本条不替产品决定删除语义。
 
 ## E. 升级、迁移与回滚
 
-- [ ] **PV0-E01 成功升级原子切换**：v1 产生配置和绑定，v2 在副本上 migrate、validate、
+- [ ] **[PV0-E01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s7) 成功升级原子切换**：v1 产生配置和绑定，v2 在副本上 migrate、validate、
   prepare、activate；提交前仍命中 v1，提交后整批命中 v2，再卸载 v1。
-- [ ] **PV0-E02 迁移抛错回到 v1**：v1 → v2 的 migrate 抛错；返回 `MIGRATION_FAILED`，
+- [ ] **[PV0-E02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s7) 迁移抛错回到 v1**：v1 → v2 的 migrate 抛错；返回 `MIGRATION_FAILED`，
   v1 插件、原配置、原绑定和原 verified scope 仍 ready。
-- [ ] **PV0-E03 坏目标 schema 回到 v1**：migrate 返回不符合 v2 schema 的配置；结果同
+- [ ] **[PV0-E03](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s7) 坏目标 schema 回到 v1**：migrate 返回不符合 v2 schema 的配置；结果同
   E02，不能留下被改写的旧配置。
-- [ ] **PV0-E04 v2 激活失败回到 v1**：迁移与 prepare 成功、activate 失败；新版本资源
+- [ ] **[PV0-E04](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s7) v2 激活失败回到 v1**：迁移与 prepare 成功、activate 失败；新版本资源
   全撤销，v1 的原配置、原绑定和原 verified scope 恢复 ready，返回 `ACTIVATE_FAILED`。
-- [ ] **PV0-E05 缺迁移路径拒绝升级**：config schema 改变但插件无对应 migrate；返回
+- [ ] **[PV0-E05](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s7) 缺迁移路径拒绝升级**：config schema 改变但插件无对应 migrate；返回
   `MIGRATION_FAILED`，不尝试猜字段或原地升级。
-- [ ] **PV0-E06 迁移不接触 secret 值**：migrate 输入只有配置副本与 credential refs；
+- [ ] **[PV0-E06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s7) 迁移不接触 secret 值**：migrate 输入只有配置副本与 credential refs；
   用探针凭证库证明迁移函数没有读取凭证值的调用权限。
-- [ ] **PV0-E07 升级扩权须显式确认**：用同一插件的 v1/v2 manifest 覆盖新增 capability、
-  提高 effect、新增 operation、新增 literal 值和移除 v1 literal 限制五种扩权；v2 完成
-  migrate 与目标 schema 校验后、activate 前返回 `UPGRADE_PERMISSION_CONFIRMATION_REQUIRED`，
-  展示 v1/v2 权限差集，v1 插件、绑定、路由和原 verified scope 继续 ready，v2 不得激活或公开。
-  对本次升级给出显式人工确认后，才允许继续 E01 的原子切换；没有扩权的 v2 不弹额外确认，
-  直接走原升级流程。
+- [ ] **[PV0-E07](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s7) 升级扩权须显式确认**：固定同一插件的
+  v1 ready fixture；下列九个分支各自只施加一项 mutation，读取 v1/v2 包内 canonical 注入四元组
+  `{id, source, scope, body}`，其中 manifest `id` 是唯一键，`source` 是规范化的包内相对路径，
+  `body` 是精确 UTF-8 正文，不能使用插件 description、历史确认、第二键或别名。每个分支在 v2
+  完成 migrate 与目标 schema 校验后、activate 前都返回
+  `UPGRADE_PERMISSION_CONFIRMATION_REQUIRED`，展示该分支的 canonical 差集；v1 插件、绑定、路由和原
+  verified scope 继续 ready，v2 不得激活、公开或注入新正文。
+
+  | 独立分支 | 唯一 v2 mutation |
+  |---|---|
+  | E07-P1 | 新增 `PermissionGrant` capability |
+  | E07-P2 | 提高现有 `PermissionGrant.effect` |
+  | E07-P3 | 增加现有 `PermissionGrant.operations` 值 |
+  | E07-P4 | 增加现有 `PermissionGrant.literals` 值 |
+  | E07-P5 | 移除 v1 原有 `PermissionGrant` literal 限制 |
+  | E07-I1 | 新增 canonical context injection `id` |
+  | E07-I2 | 只改变既有 `id` 的 `body` |
+  | E07-I3 | 只改变既有 `id` 的 `source` |
+  | E07-I4 | 只把既有 `id` 的 scope 从 `session` 改为 `resident` |
+
+  另设两个收窄 fixture：删除既有 canonical context injection `id`，以及只把既有 `id` 的 scope 从
+  `resident` 改为 `session`；两者均不触发确认，直接走原升级流程。对任一扩权分支给出本次升级的
+  显式人工确认后，才允许继续 E01 的原子切换；没有扩权的 v2 不弹额外确认，直接走原升级流程。重启、
+  显式取消或新升级会丢弃未确认 v2 副本；v0 不设数字 TTL。
 
 ## F. Readiness、投影与闭环
 
-- [ ] **PV0-F01 readiness 有 scope**：ready/degraded/blocked/quarantined 每种 fixture 都
+- [ ] **[PV0-F01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) readiness 有 scope**：ready/degraded/blocked/quarantined 每种 fixture 都
   返回 resident、lane、operations 和验证时间；换住户或车道后不能沿用旧 ready。
-- [ ] **PV0-F02 原因码稳定可判**：A–E 每条失败路径只以 RFC 第 8 节 reason code 之一
+- [ ] **[PV0-F02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s8) 原因码稳定可判**：A–E 每条失败路径只以 RFC 第 8 节 reason code 之一
   作为机器判决，附加文本变化不影响断言。
-- [ ] **PV0-F03 每条约束都有指定红格**：逐项执行下表登记的 mutation；实测失败集合必须
+- [ ] **[PV0-F03](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s9) 每条约束都有指定红格**：逐项执行下表登记的 mutation；实测失败集合必须
   包含该 mutation 指定的 PV0 id，不能用“任意一格变红”代替。fixture 的宪法常量独立于
   实现配置，不能跟着被测常量一起变化。
-- [ ] **PV0-F04 boot-time 不变量不可卸载**：伪插件尝试覆盖权限闸或事件留史 provider；
+- [ ] **[PV0-F04](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s1) boot-time 不变量不可卸载**：伪插件尝试覆盖权限闸或事件留史 provider；
   安装在 validate 阶段被拒，现有不变量仍可用。
-- [ ] **PV0-F05 壳共享魂私有**：插件包、manifest、配置导出和诊断中扫描住户人格、记忆、
+- [ ] **[PV0-F05](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s1) 壳共享魂私有**：插件包、manifest、配置导出和诊断中扫描住户人格、记忆、
   聊天 fixture 标记；均不得出现，插件只能经受控 capability 在当前 scope 临时访问。
-- [ ] **PV0-F06 ready 必须有当前 scope 的可用性收据**：分别用 initialize 握手、版本查询
+- [ ] **[PV0-F06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) ready 必须有当前 scope 的可用性收据**：分别用 initialize 握手、版本查询
   和无副作用探针验证三类 capability；未运行探针、探针超时或返回身份不符时返回
   `CAPABILITY_UNVERIFIED` 且不进 ready 工具集。断言只证明可用性，不声称签名或供应链可信。
 
@@ -207,10 +232,10 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
 | C06 | 卸载清理前仍接受新调用 | C06 |
 | C07 | revoke 失败后仍报告 disposed/ready | C07 |
 | C08 | 把插件运行时异常抛到宿主顶层 | C08 |
-| C09 | 失败后在无显式操作时自动循环重试 | C09 |
-| C10 | activate 中断回滚后清除失败记录并假装未安装，或把孤儿中间态当 ready | C10 |
+| C09 | 一次返回 `PLUGIN_RUNTIME_FAILED` 的失败 call 后，让 scheduler 在可控 tick/队列排空观察窗内自动循环重试 | C09 |
+| C10 | 把启动时 activate/dispose 日志协调当用户重试、协调后自动 ready/active，或清除失败记录并假装未安装 | C10 |
 | C11 | 先持久化公开路由索引，再写 active 四元组 | C11 |
-| C12 | quarantined 进入后自动重试、把重复 dispose 当作显式清理重试、把重试失败当 disposed，或清掉剩余资源/人工处理记录 | C12 |
+| C12 | quarantined 进入后自动重试、把重复 dispose 当作宿主 `retryCleanup` 显式清理重试、把重试失败当 disposed，或清掉剩余资源/人工处理记录 | C12 |
 | D01 | 仅以 lane 为键，忽略 residentId | D01 |
 | D02 | 给 subagent 挂载住户记忆 | D02 |
 | D03 | 显式换道时沿用原车道权限结果 | D03 |
@@ -219,15 +244,23 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
 | D06 | 把网关 token 值内联进 adapterConfig | D06 |
 | D07 | 删除凭证时不检查现役绑定 | D07 |
 | D08 | 无效新绑定覆盖原 ready 绑定 | D08 |
-| D09 | 从 lane 名推导 main/subagent 角色 | D09 |
-| D10 | 无 active issuer 仍展示或签发 credential type | D10 |
+| D09 | 在 host contract 未先精确登记 fixture lane 时，或从 lane 名推导 main/subagent 角色 | D09 |
+| D10 | 无 active issuer 仍展示、签发或导入无 issuer 的 credential ref | D10 |
 | E01 | v2 active 前把调用切到新版本 | E01 |
 | E02 | migrate 抛错后留下被改写的 v1 配置 | E02 |
 | E03 | 跳过 v2 schema 校验并提交坏配置 | E03 |
 | E04 | v2 activate 失败后以缩水的 verified scope 恢复 v1 ready | E04 |
 | E05 | 缺 migrate 时猜字段并原地升级 | E05 |
 | E06 | 给 migrate 暴露读取凭证值的接口 | E06 |
-| E07 | 跳过 v1/v2 PermissionGrant 比对，或把未确认的扩权升级直接激活 | E07 |
+| E07-P1 | 对新增 `PermissionGrant` capability 跳过确认 | E07 |
+| E07-P2 | 对提高 `PermissionGrant.effect` 跳过确认 | E07 |
+| E07-P3 | 对增加 `PermissionGrant.operations` 值跳过确认 | E07 |
+| E07-P4 | 对增加 `PermissionGrant.literals` 值跳过确认 | E07 |
+| E07-P5 | 对移除 v1 `PermissionGrant` literal 限制跳过确认 | E07 |
+| E07-I1 | 对新增 canonical context injection `id` 跳过确认 | E07 |
+| E07-I2 | 对只改变既有 `id` 的 `body` 跳过确认 | E07 |
+| E07-I3 | 对只改变既有 `id` 的 `source` 跳过确认 | E07 |
+| E07-I4 | 对 `session → resident` 跳过确认 | E07 |
 | F01 | 把一个车道的 ready 投影到所有 scope | F01 |
 | F02 | 只返回自由文本错误、不返回稳定 code | F02 |
 | F03 | mutation runner 接受“任意测试变红” | F03 |
@@ -241,3 +274,7 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
 都实际变红；
 `npm run lint && npm run typecheck && npm test && npm run acceptance:strict` 全绿；评审能从
 每个 RFC 约束直接指到一个 PV0 id，并从每个 PV0 id 指回唯一规范段落。
+
+本次 #67 是文档修订；仓库当前没有 mutation runner，**本次 mutation 未执行**。C09、C10、C12
+和 E07 只有在其上述 reason code、fixture、确定性断言和指定 mutation 全部实现并实际变红时，
+才能作为协议实现完成的证据。

--- a/docs/design/plugin-protocol-v0.md
+++ b/docs/design/plugin-protocol-v0.md
@@ -1,11 +1,12 @@
 # 插件协议 v0 RFC
 
-状态：**草案，等待 #51 评审**。本稿只定义协议和可判卷形状，不实现具体插件，
+状态：**草案，#67 收口修订完成，待复审**。本稿只定义协议和可判卷形状，不实现具体插件，
 不设计插件市场。验收清单见
 [../../acceptance/plugin-protocol-v0.md](../../acceptance/plugin-protocol-v0.md)。
 
 规范词 `必须`、`不得`、`可以` 分别表示协议义务、协议禁令和实现可选项。
 
+<a id="plugin-protocol-v0-s1"></a>
 ## 1. 边界与代价
 
 插件只通过宿主提供的注册上下文获得能力，不能直接写住户状态、读凭证库或绕过权限闸。
@@ -21,6 +22,7 @@ v0 支持四类插件：`channel_adapter`、`frontend`、`tool_capability`、`br
 经 `PluginPrepareContext` 登记的资源，但无法检测插件绕过 context 直接调用 Node 原生 API
 制造的计时器、文件句柄或网络连接。此类未登记资源违反作者约定，却不在 v0 的机制保证内。
 
+<a id="plugin-protocol-v0-s2"></a>
 ## 2. Manifest 是安装前唯一入口
 
 每个插件包根目录必须有纯数据文件 `mist-plugin.json`。宿主在加载插件代码前解析它；
@@ -102,7 +104,7 @@ interface EnvironmentBinding {
 操作可以用同一 id 的新版本进入第 7 节事务，不能靠后装覆盖前装。
 
 `contextInjections` 是所有插件来源非工具文本的完整清单。宿主在 import 前读取 `source`，
-路径校验与 entrypoint 相同；正文随包版本冻结并带 plugin id、注入 id、源路径和 scope 的
+路径校验与 entrypoint 相同；正文随包版本冻结并带 plugin id、注入 manifest `id`、源路径和 scope 的
 来源标记。MCP `instructions` 或其他运行期文本只有与已声明源文件逐字一致时才能采用；
 未声明或漂移的文本必须显式拒绝并返回 `CONTEXT_INJECTION_MISMATCH`，不得静默采用或静默
 丢弃。`resident` scope 可以随住户重建再次装配，`session` scope 只属于当前会话；两者都
@@ -110,10 +112,19 @@ interface EnvironmentBinding {
 的容量策略，不适用于上下文注入正文；插件 active 时，已声明正文按 scope 装配，不允许实现
 自行猜测 lazy/eager 语义。
 
-`operations` 必须是宿主能力契约中已登记的操作名。带副作用的操作如果存在可收窄参数，
-manifest 必须把允许值声明到字面量级；例如只能触发换窗的桥接应声明
-`literals: { text: ["/new"] }`，不能申请任意 `terminal_send`。宿主拒绝未声明的操作、
-参数和值；空数组不代表通配。
+升级比较使用的有效注入声明是经路径校验后、从各自 v1/v2 包内读取的 canonical 四元组
+`{ id, source, scope, body }`。manifest 字段 `id` 是该四元组的唯一键；协议不得定义、接受
+或推导第二键或别名。`source` 是规范化的包内相对路径，`body` 是该 `source` 的
+精确 UTF-8 正文。宿主必须保存可审计的 v1/v2 四元组差集，逐字比较正文；不得以插件自报的
+`description`、运行期文本、历史确认或版本号替代此比较。
+
+`operations` 必须是宿主能力契约中已登记的操作名；合法 lane 集合和可收窄的操作参数也由同一
+份宿主能力契约唯一决定。当前契约里的 `primary`、`coding` 只是示例，不是协议硬编码的
+完整集合。插件只能在宿主已登记的 schema 明确支持时声明 literal 子集；例如只能触发换窗的
+桥接可以声明 `literals: { text: ["/new"] }`，不能申请任意 `terminal_send`。宿主拒绝未登记
+的操作、参数、值或 literal；空数组不代表通配。lane 名大小写敏感，绑定和 dispatch 前不得
+trim、套别名或模糊纠错，也不得从 adapter、credential 或 role 推导；未知 lane 以现有
+`CONFIG_INVALID` fail-closed，不能进入绑定或 dispatch。
 
 `env` 只声明需求，不携带值。`secret: true` 的值不得进入插件配置快照、诊断、错误文本或
 事件正文。凭证比普通 secret env 更严格：manifest 只声明槽位与可接受类型，实际绑定只
@@ -126,6 +137,7 @@ manifest 必须把允许值声明到字面量级；例如只能触发换窗的�
 代价：字面量权限会让动态命令类插件需要更细的宿主能力或显式人工授权，不能用一个
 “terminal=true”偷懒换取万能键盘。
 
+<a id="plugin-protocol-v0-s3"></a>
 ## 3. 注册是事务，不是一串回调
 
 宿主按 `discover → validate → prepare → activate → active` 推进。只有 `active` 状态的能力
@@ -184,7 +196,16 @@ discovered → validated → prepared → active → disposing → disposed
                                                           │
                                  显式清理重试成功 ─────────┘→ disposed
                                  显式清理重试失败 ───────────→ quarantined
+
+blocked ─显式修复或用户重试→ discovered（重新走完整新生命周期）
+blocked ─显式停用并清理→ disposing → disposed / quarantined
 ```
+
+`DisposableHandle.revoke` 是**单个资源**的撤销，`PreparedPlugin.rollback` 是**整次 prepare** 的
+逆操作，`ActivePlugin.dispose` 是**整插件卸载**；三者各自幂等，不能泛称为同一个 disposer。
+任一阶段进入 `blocked` 后不得自动回到 `ready`，也不得直达 `active`：只能由显式修复或用户重试
+重新从 `discovered` 走完整生命周期，或由显式停用进入清理。`dispose` 不完整进入
+`quarantined`，其唯一出边仍是宿主显式清理重试。
 
 `prepare` 期间的每次 `register` 都先写入宿主拥有的注册日志，并返回宿主同样持有的
 `DisposableHandle`。协议合规插件应当只经 context 创建对外资源；v0 对宿主管理资源提供
@@ -206,7 +227,8 @@ plugin id、`operationId`、`enabled: true` 的启用意图、配置与绑定，
 中途的操作保持不可达，从最后一笔撤销回执继续清理；失败则进入 quarantined。
 `quarantined`、剩余资源 id、reason code 与操作日志都必须跨重启保留；不得因重启清空内存态
 而把孤儿中间态投影为 ready。协调结束前，该插件以 `LIFECYCLE_RECOVERY_PENDING` 显式
-blocked，不允许自动执行普通 prepare/activate/call 路径。
+blocked，不允许自动执行普通 prepare/activate/call 路径。这是 C10 的**启动时日志协调**，
+不是用户重试；协调结束后若为 `blocked`，仍须等待上文的显式修复/用户重试或显式停用。
 
 `quarantined` 的恢复只能由宿主提供的显式清理重试触发，不属于启动协调，也不重新经过
 prepare/activate/call。重试从持久化的剩余资源清单和撤销回执继续：全部资源撤销成功后进入
@@ -228,11 +250,16 @@ prepare/activate/call。重试从持久化的剩余资源清单和撤销回执�
 作者把 import-time 副作用改造进 prepare/activate 生命周期，但 v0 的同进程信任边界不能
 机械拦截故意绕开的 Node 原生调用。
 
+<a id="plugin-protocol-v0-s4"></a>
 ## 4. 故障只影响插件，不拖死地基
 
 宿主在生命周期钩子和每次能力调用外建立错误边界。同步抛错、异步拒绝、超时和无效返回
 都只把当前插件或当前调用标记失败；其他插件、住户存储和 boot-time 不变量继续可用。
 失败插件不会自动无限重试。恢复必须是显式重试、重新启用或新版本安装。
+
+一次 active 插件 `call` 因抛错或超时返回 `PLUGIN_RUNTIME_FAILED` 后，宿主不得自行重试该次
+调用，也不得让调度器重新进入 prepare 或 activate。C09 的可验证观察使用 fixture 时钟或 scheduler
+tick 推进至少一个失败后的周期并排空队列；它不使用真实 sleep，也不为生产系统定义 TTL。
 
 `readiness` 至少区分：
 
@@ -250,6 +277,7 @@ prepare/activate/call。重试从持久化的剩余资源清单和撤销回执�
 代价：隔离会把一部分错误从崩溃变成显式降级，运维面必须展示 blocked/quarantined，
 否则故障只会从停机变成静默缺能力。
 
+<a id="plugin-protocol-v0-s5"></a>
 ## 5. 凭证、适配器与用途车道
 
 凭证独立存储，登录委托执行通道完成；本协议不设计 OAuth 登录或刷新流程。配置和绑定的
@@ -266,7 +294,7 @@ type AgentRole = "main" | "subagent";
 
 interface LaneBinding {
   readonly residentId: string;
-  readonly lane: string;       // 至少支持 primary、coding
+  readonly lane: string;       // 合法集合由宿主能力契约登记；primary/coding 仅为示例
   readonly adapterId: string;
   readonly credentialRef: CredentialRef;
   readonly adapterConfig?: {
@@ -283,8 +311,12 @@ interface DispatchRequest {
 }
 ```
 
-绑定的键是 `residentId × lane`。`main` / `subagent` 是运行角色；宿主不得从 lane 名、适配器
-或凭证类型推导角色，角色只取自已经过授权的 `DispatchRequest.role`。
+绑定的键是 `residentId × lane`。合法 lane 集合只认宿主能力契约登记的当前集合；协议示例中的
+`primary`、`coding` 不构成额外的固定集合。lane 比较大小写敏感，宿主不得 trim、接受别名或
+模糊纠错，也不得从 adapter、credential 或 role 推导 lane。绑定保存和 dispatch 前若 lane
+不在契约集合内，必须以现有 `CONFIG_INVALID` fail-closed，不加载凭证、不调用 adapter，也不
+覆盖上一份有效绑定。`main` / `subagent` 是运行角色；宿主不得从 lane 名、适配器或凭证类型
+推导角色，角色只取自已经过授权的 `DispatchRequest.role`。
 主 agent 挂住户生命周期和记忆，默认工具集精简；subagent 不挂住户记忆，工具按当前任务
 显式开放。subagent 未指定车道时继承主请求的车道；显式换道时必须重新过绑定、权限和
 工具策略校验。
@@ -296,7 +328,9 @@ Claude 协议的网关；token 仍由凭证引用提供，不得内联。
 
 凭证类型是 wire type，不等于宿主一定能签发。宿主只展示当前 active credential issuer
 明确提供的获取类型，创建 `CredentialRef` 时记录 `issuerId`；issuer 不存在时，TUI/API
-不得展示对应登录入口，外部导入的 ref 也必须能回指现役 issuer。RFC 起草时的
+不得展示对应登录入口，外部导入的 ref 也必须能回指现役 issuer。v0 不决定 issuer 删除后
+现役 ref 的删除、处置或迁移语义；它只禁止新建悬空 ref 和 secret 落入协议载体，详见第 10 节。
+RFC 起草时的
 [pi provider 表](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md)
 已列出 Claude、OpenAI Codex 与 xAI/Grok subscription OAuth；未来类型或外部流程仍按同一
 issuer 规则接入，本协议不把登录步骤写进地基。
@@ -305,8 +339,12 @@ issuer 规则接入，本协议不把登录步骤写进地基。
 列出受影响绑定并先解除或迁移，不能制造悬空引用。
 
 代价：严格的凭证类型约束会拒绝一些技术上“也许能跑”的组合；这是用显式可审计的通道
-语义换取少踩计费和身份边界的坑。
+语义换取少踩计费和身份边界的坑。2026-08-17 的动机是 `claude_oauth → Claude SDK`
+必须保留订阅身份与计费边界；同时 `baseUrl + tokenCredentialRef` 支持兼容 Claude 网关，
+又不把 token 内联进配置、绑定或诊断。代价是适配器兼容性不能用一个通用 token 形状偷换
+订阅身份或计费归属，网关还必须在执行边界解析其独立凭证引用。
 
+<a id="plugin-protocol-v0-s6"></a>
 ## 6. skill 与 MCP 都是工具能力
 
 skill 和 MCP 统一归 `tool_capability` 插件，manifest 必须声明提供的能力、操作和副作用
@@ -336,6 +374,7 @@ verified scope，翻译输出的工具与已授权源操作必须逐项可逆映
 lazy 模式增加一次 schema 取回，并要求适配器维护可发现目录；显式上下文注入则牺牲运行期
 随服务端即时改 instruction 的便利，换取安装前可读、升级可 diff、出事可追溯。
 
+<a id="plugin-protocol-v0-s7"></a>
 ## 7. 版本兼容与升级迁移
 
 安装前依次校验 `manifestSchemaVersion`、`requiresMist`、插件版本和配置 schema。
@@ -343,21 +382,29 @@ lazy 模式增加一次 schema 取回，并要求适配器维护可发现目录�
 active 前保持可恢复，新版本不得原地改写旧配置。
 
 升级时，宿主必须在目标 schema 校验完成后、v2 `activate` 之前，取得现役 v1 的有效
-`PermissionGrant` 集合并与 v2 manifest 逐项比较。比较以 `capabilityId` 为键；`effect` 的
-风险顺序固定为 `read < reversible < irreversible`，`operations` 和 `literals` 的允许值按
-集合包含关系比较。v2 出现 v1 没有的 capability、提高 effect、增加 operation、增加 literal
-值，或移除 v1 原有的 literal 限制，均属于扩权。比较必须基于宿主能力契约归一化后的授权结果，
-不能用插件自报描述、版本号或配置文件差异替代权限比较。
+`PermissionGrant` 集合及第 2 节的有效注入四元组，并与 v2 逐项比较。每个注入只以 manifest
+字段 `id` 作为唯一键，比较的固定形状为 `{ id, source, scope, body }`：`source` 是规范化的包内
+相对路径，`body` 是精确 UTF-8 正文；不得使用第二键或别名。权限比较以
+`capabilityId` 为键；`effect` 的风险顺序固定为 `read < reversible < irreversible`，`operations`
+和 `literals` 的允许值按集合包含关系比较。v2 出现 v1 没有的 capability、提高 effect、增加
+operation、增加 literal 值，或移除 v1 原有的 literal 限制，均属于扩权。注入方面，新增 `id`、
+只改变 `body`、只改变 `source`，或 scope 从 `session` 升为 `resident`，均属于扩权；删除 `id`，
+或 `resident → session`，属于收窄。比较必须基于宿主能力契约归一化后的授权结果和包内 canonical
+正文，不能用插件自报描述、版本号、配置文件差异或历史确认替代。
 
-没有扩权时，升级继续走原有流程，不增加额外确认。出现扩权时，宿主必须展示 v1/v2 的权限
-差集，并针对本次升级取得显式人工确认；确认之前不得激活或公开 v2，v1 的插件、绑定、路由和
-原 verified scope 继续保持 ready。没有确认时，升级事务返回 `UPGRADE_PERMISSION_CONFIRMATION_REQUIRED`
-并保持 blocked；不得把配置写入、启动重试或过去的确认记录当作本次确认。确认后才可继续
+没有扩权时，升级继续走原有流程，不增加额外确认。出现任一权限或注入扩权时，宿主必须展示
+可审计的 v1/v2 差集（含授权项和注入 `{id, source, scope, body}` 差异），并针对本次升级取得
+显式人工确认；确认之前不得激活或公开 v2，也不得公开新注入，v1 的插件、绑定、路由和原
+verified scope 继续保持 ready。没有确认时，升级事务返回
+`UPGRADE_PERMISSION_CONFIRMATION_REQUIRED` 并保持 blocked；不得把配置写入、启动重试或过去的
+确认记录当作本次确认。确认后才可继续
 copy-on-write 的 prepare/activate 和原子切换，后续失败仍按本节既有回滚路径处理。
 
 `UPGRADE_PERMISSION_CONFIRMATION_REQUIRED` 不属于启动协调可恢复的 activate/dispose 操作；宿主
-重启后，待确认的 v2 升级副本和本次确认资格一并作废，v1 继续保持 ready，用户必须重新发起升级、
-重新计算权限差集并取得本次显式确认。
+重启、显式取消或发起另一升级后，待确认的 v2 升级副本和本次确认资格一并作废，v1 继续保持
+ready，用户必须重新发起升级、重新计算差集并取得本次显式确认。v0 不定义任意数字 TTL：待确认
+副本只存活于本次未结束升级的生命周期，代价是中断后需重新 prepare/比较，而不是保留一份无法
+审计其时效的候选版本。
 
 ```ts
 interface MigrationRequest {
@@ -377,6 +424,7 @@ scope 的 ready。
 
 代价：升级期间会短暂保留两份插件与配置，占用更多磁盘和资源；这是可回滚的成本。
 
+<a id="plugin-protocol-v0-s8"></a>
 ## 8. 稳定失败语义
 
 所有拒绝与失败至少给出以下稳定 reason code，错误详情可以追加但不能替代 code：
@@ -394,7 +442,7 @@ scope 的 ready。
 | `PREPARE_FAILED` | prepare 抛错、超时或返回无效 | 全量 rollback，未公开 |
 | `ACTIVATE_FAILED` | activate 失败或其中断恢复完成 | 全量 rollback，blocked 且未公开；保留启用意图，等待显式重试或停用 |
 | `MIGRATION_FAILED` | 迁移或目标 schema 校验失败 | 旧版本保持 ready |
-| `UPGRADE_PERMISSION_CONFIRMATION_REQUIRED` | v2 `PermissionGrant` 相对 v1 扩权且本次升级未获显式人工确认 | 升级事务 blocked；v1 保持 ready，v2 未激活 |
+| `UPGRADE_PERMISSION_CONFIRMATION_REQUIRED` | v2 有相对 v1 的 `PermissionGrant` 或 canonical context injection 扩权，且本次升级未获显式人工确认 | 升级事务 blocked；v1 保持 ready，v2 未激活、未公开新注入 |
 | `DISPOSE_INCOMPLETE` | 任一资源撤销失败 | quarantined，对外入口关闭；只能由显式清理重试进入 disposed，重试失败继续隔离并保留案底 |
 | `LIFECYCLE_RECOVERY_PENDING` | 检出未完成的 activate/dispose 操作日志 | blocked 且入口关闭；启动协调完成后才进入确定终态 |
 | `PLUGIN_RUNTIME_FAILED` | active 插件调用抛错或超时 | 当前调用失败；按策略降级或 blocked |
@@ -407,6 +455,7 @@ scope 的 ready。
 翻译产物在进入模型可见上下文前还必须经过敏感值闸：命中当前执行边界已解析的 secret 值
 时以 `SENSITIVE_OUTPUT_BLOCKED` 拒绝，不能指望后续摘要或记忆层替插件擦除。
 
+<a id="plugin-protocol-v0-s9"></a>
 ## 9. 规范到判卷的对应
 
 | RFC 规范面 | 验收区 | 主要红灯 |
@@ -415,9 +464,10 @@ scope 的 ready。
 | 权限、secret、skill/MCP 翻译与上下文注入 | B | 越权、secret 进上下文、翻译扩权、未声明或卸载后残留注入 |
 | 生命周期、事务注册、故障隔离 | C | 半注册、公开早于权威提交、重复清理、注销留活线、拖死地基 |
 | 住户×车道、角色、凭证约束 | D | 串房、角色混维、错凭证覆盖好绑定 |
-| 版本升级、配置迁移、回滚 | E | 原地改配置、失败后 v1 不可用 |
+| 版本升级、配置迁移、回滚与注入扩权确认 | E | 原地改配置、失败后 v1 不可用、未确认新守则公开 |
 | readiness scope、不变量与变异验证 | F | 假 ready、无稳定原因码、约束删掉仍全绿 |
 
+<a id="plugin-protocol-v0-s10"></a>
 ## 10. 非目标
 
 - 不实现任何具体插件或适配器；
@@ -425,4 +475,7 @@ scope 的 ready。
 - 不以可用性探针冒充二进制身份、签名或供应链认证；
 - 不承诺第三方插件代码是可信沙箱；
 - 不把住户人格、记忆或聊天内容放进插件包；
+- 不定义 `secretRef` 的存储后端、加密、轮换，或 issuer 删除后现役 ref 的产品处置与迁移策略；
+  协议只保留不透明 ref，不落 secret。没有 active issuer 时不得展示对应入口、不得新建或导入
+  无法回指现役 issuer 的 ref，也不得制造悬空 ref；现役 ref 的删除语义由产品另行决定；
 - 不允许插件协议改写已决的通道政策、住户连续性或权限审批点。

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -63,6 +63,8 @@
 它不是普通工具返回值，也不是人格文件：正文必须在插件包内随 manifest 声明、可 diff、
 可追溯来源；运行期服务端不得用未声明或漂移的文本静默改写住户上下文。停用或卸载插件时，
 对应注入必须同时从现役上下文、启动包和后续重建输入撤下，不能留下“卸不掉的守则”。
+升级比较的唯一 canonical 形状是 `{id, source, scope, body}`：manifest `id` 是唯一键，不得另设、
+接受或推导第二键或别名；`source` 是规范化的包内相对路径，`body` 是精确 UTF-8 正文。
 
 **注入模式（injection mode）**
 工具能力 schema 的容量策略。`eager` 在能力 active 时装入完整 schema；`lazy` 只装入可发现的
@@ -79,28 +81,49 @@ reason code 跨重启保留；重启不能把它洗成 ready。显式清理重�
 所有剩余资源撤销成功时才能进入 `disposed`；重试失败继续留在 `quarantined`，并保留操作记录
 和人工处理清单。
 
+**blocked**
+插件因校验、权限、迁移或 activate 失败而不能提供能力的持久状态，不是可自动恢复的 ready
+前置态。它只能由显式修复或用户重试重新从 `discovered` 走完整生命周期，或由显式停用进入
+清理；不得自动回 ready 或直达 active。启动时的未完成 activate/dispose 日志协调属于 C10 恢复，
+不是用户重试；`quarantined` 只有独立的 `retryCleanup` 显式清理重试可出，重复 `dispose` 不算。
+
 **升级扩权闸**
-升级时宿主将 v2 manifest 的 `PermissionGrant` 与现役 v1 的有效授权集合逐项比较的控制点。
-新增 capability、提高 effect、增加 operation、增加 literal 值或移除原有 literal 限制都算扩权；
-扩权必须展示差集并取得本次升级的显式人工确认，确认前 v1 保持 ready，v2 不得激活。没有扩权
-时沿用原升级流程，不额外打扰人类。
+升级时宿主将 v2 manifest 的 `PermissionGrant` 和包内 canonical context injection 四元组
+`{id, source, scope, body}` 与现役 v1 有效集合逐项比较的控制点；`id` 是唯一键。新增 capability、
+提高 effect、增加 operation、增加 literal 值、移除原有 literal 限制，以及新增 `id`、只改变
+`body`、只改变 `source`、`session → resident` 都算扩权；删除 `id` 或 `resident → session` 是收窄。扩权必须展示
+可审计差集并取得本次升级的显式人工确认，确认前 v1 保持 ready，v2 不得激活、公开或注入新正文；
+不得使用插件 description、历史确认或任意 TTL 取代本次包内比较。重启、显式取消或新升级会丢弃
+未确认 v2 副本；没有扩权时沿用原升级流程，不额外打扰人类。
 
 **适配器（adapter）**
 把 mist 的统一调用形状翻译给某个执行通道的插件。适配器只负责协议翻译和执行，
 不拥有住户身份、记忆或生命周期；通道可以换，住户不换。
 
 **用途车道（lane）**
-住户选择执行通道时的用途槽，例如 `primary`、`coding`。绑定以
-「住户 × 用途车道」为键，指向适配器和凭证引用。主 agent / subagent 是运行角色，
-不是车道；两者是正交维度。
+住户选择执行通道时的用途槽，例如 `primary`、`coding`。lane 值必须来自宿主 capability contract，
+并按大小写精确比较；未知、错拼、大小写不同或带空白的 lane 在绑定/dispatch 前返回
+`CONFIG_INVALID` 并 fail-closed，且无效新绑定不得覆盖旧绑定。绑定以「住户 × 用途车道」为键，
+指向适配器和凭证引用。role 不声明 lane，也不得推导 lane；主 agent / subagent 只来自已授权
+`DispatchRequest.role`，role 与 lane 是正交维度。
 
 **凭证引用（credential reference）**
-指向独立凭证库记录的不透明 id。配置、绑定、日志和插件 manifest 只能携带引用与类型，
-不能携带密钥值。登录流程不属于插件协议。
+指向独立凭证库记录的不透明 id，不能携带密钥值。manifest 只声明 credential slot 与可接受类型；
+实例配置和绑定携带 opaque credential ref。没有 active issuer 时不展示入口、不得新建或导入无法
+回指该 issuer 的 ref，也不得制造悬空引用。v0 不定义 secretRef 后端、加密、轮换或 issuer 删除后
+现役 ref 的产品处置/迁移语义；登录流程不属于插件协议。
 
-**disposer**
-注册成功后用于撤销该次注册所产生资源的幂等句柄。宿主先撤销可达性再清理资源；
-重复调用必须安全，清理失败必须显式留下隔离记录，不能留下无人认领的活线。
+**DisposableHandle.revoke**
+宿主注册日志持有的**单个资源**撤销句柄。它幂等；宿主先撤销可达性再清理资源，失败留下
+资源级隔离记录，不能留下无人认领的活线。
+
+**PreparedPlugin.rollback**
+一次 prepare 的**整次逆操作**。它幂等，用于 activate 失败或中断前撤销本次 prepare 的资源；
+它不是单资源 `revoke`，也不是整插件 `dispose`。
+
+**ActivePlugin.dispose**
+active 插件的**整插件卸载**操作。它幂等；撤销不完整时进入 `quarantined`，而非把失败当作
+`disposed`。它不是 `retryCleanup`：quarantined 下重复 dispose 只返回同一隔离态。
 
 **许愿区 / 决定区**
 设计文档的两个分区。写得出代价的进决定区，写不出的进愿望区。


### PR DESCRIPTION
## 这次收了什么

完成 Issue #67 的协议文档与验收规范收口：

- `contextInjections` 的新增、正文变化、source 变化、`session → resident` 全部进入统一升级确认闸。
- 统一 canonical 口径为 `{ id, source, scope, body }`，并把 E07 拆成 9 个独立可判分支，避免“正文或 source”这种漏测小门缝。
- 补齐 lane、宿主能力契约、`secretRef`/issuer、blocked 出边、`DisposableHandle` 三层职责、C09、C10/C12 和 RFC 锚点映射。
- 保护原有 RFC 改动，未触碰 H1/H2、运行时代码、安装器、webui 或无关文件。

## 验证证据

- `npm run lint`：通过；仅有两个既有 broken symlink 警告。
- `npm run typecheck`：通过。
- `npm test`：26 files / 216 tests 通过。
- `npm run acceptance`：6/6 通过。
- `npm run acceptance:strict`：6/6 通过。
- `git diff --check`：通过。

仓库没有 plugin mutation runner，因此本次 mutation 未执行；acceptance 绿灯不冒充运行时或 mutation 实证。门牌已经挂好，屋里是否真的按协议运转，留给后续运行时实现验证。🙂

## 请主笔审查

@sakisakisa-design 请审查这个 draft PR 的完整 diff。确认设计、验收和术语三处一致后，请将其转为 Ready for review 并合并；如有修改意见，我会按同一 PR 收口。

Closes #67

- 宝儿
