### PR TITLE
fix(installer): 解开恢复路径两个死锁——重名凭证 + memory=create 目录被占（#58 第 1、2 条）

### DIFF
--- a/src/installer/contracts.ts
+++ b/src/installer/contracts.ts
@@ -104,9 +104,29 @@ export interface InstallCommitReceipt {
 }
 
 export class InstallerValidationError extends Error {
-  constructor(message: string) {
+  /**
+   * The wizard step whose data caused the rejection, when known. `validateReadyDraft`
+   * stamps this so a runner can send the user back to the right step instead of
+   * guessing from the message. Undefined means the draft envelope itself is bad.
+   */
+  step: InstallerStep | undefined;
+
+  constructor(message: string, step?: InstallerStep) {
     super(message);
     this.name = "InstallerValidationError";
+    this.step = step;
+  }
+}
+
+/** Runs one validation section and stamps un-attributed rejections with its step. */
+function validateStep<T>(step: InstallerStep, run: () => T): T {
+  try {
+    return run();
+  } catch (error) {
+    if (error instanceof InstallerValidationError && error.step === undefined) {
+      error.step = step;
+    }
+    throw error;
   }
 }
 
@@ -322,84 +342,95 @@ export function validateReadyDraft(draft: InstallerDraft): MistInstallConfigV0 {
   }
   assertSafeInstallerId(draft.draftId, "draft id");
   requireNonEmpty(draft.residentId, "residentId");
-  if (draft.credentials.length === 0) {
-    throw new InstallerValidationError("at least one credential is required");
-  }
+  const credentials = validateStep("credentials", () => {
+    if (draft.credentials.length === 0) {
+      throw new InstallerValidationError("at least one credential is required");
+    }
+    const seen = new Map<string, InstallerCredential>();
+    for (const credential of draft.credentials) {
+      assertSafeInstallerId(credential.ref.id, "credential id");
+      requireNonEmpty(credential.label, `credential ${credential.ref.id} label`);
+      requireNonEmpty(credential.providerId, `credential ${credential.ref.id} providerId`);
+      requireNonEmpty(credential.ref.issuerId, `credential ${credential.ref.id} issuerId`);
+      validateCredentialEnums(credential);
+      validateCredentialIssuer(credential);
+      if (credential.status !== "ready") {
+        throw new InstallerValidationError(`credential ${credential.ref.id} is incomplete`);
+      }
+      if (seen.has(credential.ref.id)) {
+        throw new InstallerValidationError(`duplicate credential id: ${credential.ref.id}`);
+      }
+      seen.set(credential.ref.id, credential);
+    }
+    return seen;
+  });
 
-  const credentials = new Map<string, InstallerCredential>();
-  for (const credential of draft.credentials) {
-    assertSafeInstallerId(credential.ref.id, "credential id");
-    requireNonEmpty(credential.label, `credential ${credential.ref.id} label`);
-    requireNonEmpty(credential.providerId, `credential ${credential.ref.id} providerId`);
-    requireNonEmpty(credential.ref.issuerId, `credential ${credential.ref.id} issuerId`);
-    validateCredentialEnums(credential);
-    validateCredentialIssuer(credential);
-    if (credential.status !== "ready") {
-      throw new InstallerValidationError(`credential ${credential.ref.id} is incomplete`);
-    }
-    if (credentials.has(credential.ref.id)) {
-      throw new InstallerValidationError(`duplicate credential id: ${credential.ref.id}`);
-    }
-    credentials.set(credential.ref.id, credential);
-  }
-
-  const bindings = new Set<string>();
-  for (const binding of draft.bindings) {
-    requireNonEmpty(binding.residentId, "binding residentId");
-    if (binding.residentId !== draft.residentId) {
-      throw new InstallerValidationError(
-        `binding resident ${binding.residentId} does not match draft resident ${draft.residentId}`,
-      );
-    }
-    if (!LANES.has(binding.lane)) {
-      throw new InstallerValidationError(`unsupported binding lane: ${String(binding.lane)}`);
-    }
-    requireNonEmpty(binding.adapterId, "binding adapterId");
-    const bindingKey = `${binding.residentId}\u0000${binding.lane}`;
-    if (bindings.has(bindingKey)) {
-      throw new InstallerValidationError(
-        `duplicate ${binding.lane} binding for resident ${binding.residentId}`,
-      );
-    }
-    bindings.add(bindingKey);
-    validateBindingCredential(binding, credentials);
-    const adapterConfig = binding.adapterConfig;
-    if (adapterConfig !== undefined) {
-      if (adapterConfig.baseUrl === undefined || adapterConfig.tokenCredentialRef === undefined) {
+  validateStep("bindings", () => {
+    const bindings = new Set<string>();
+    for (const binding of draft.bindings) {
+      requireNonEmpty(binding.residentId, "binding residentId");
+      if (binding.residentId !== draft.residentId) {
         throw new InstallerValidationError(
-          `binding ${binding.lane} custom gateway requires baseUrl and tokenCredentialRef`,
+          `binding resident ${binding.residentId} does not match draft resident ${draft.residentId}`,
         );
       }
-      requireNonEmpty(adapterConfig.baseUrl, `binding ${binding.lane} baseUrl`);
-      const tokenCredential = credentials.get(adapterConfig.tokenCredentialRef.id);
-      if (
-        tokenCredential === undefined ||
-        tokenCredential.ref.type !== "api_key" ||
-        adapterConfig.tokenCredentialRef.type !== "api_key" ||
-        tokenCredential.ref.issuerId !== adapterConfig.tokenCredentialRef.issuerId
-      ) {
+      if (!LANES.has(binding.lane)) {
+        throw new InstallerValidationError(`unsupported binding lane: ${String(binding.lane)}`);
+      }
+      requireNonEmpty(binding.adapterId, "binding adapterId");
+      const bindingKey = `${binding.residentId}\u0000${binding.lane}`;
+      if (bindings.has(bindingKey)) {
         throw new InstallerValidationError(
-          `binding ${binding.lane} tokenCredentialRef must reference an api_key`,
+          `duplicate ${binding.lane} binding for resident ${binding.residentId}`,
         );
       }
+      bindings.add(bindingKey);
+      validateBindingCredential(binding, credentials);
+      const adapterConfig = binding.adapterConfig;
+      if (adapterConfig !== undefined) {
+        if (adapterConfig.baseUrl === undefined || adapterConfig.tokenCredentialRef === undefined) {
+          throw new InstallerValidationError(
+            `binding ${binding.lane} custom gateway requires baseUrl and tokenCredentialRef`,
+          );
+        }
+        requireNonEmpty(adapterConfig.baseUrl, `binding ${binding.lane} baseUrl`);
+        const tokenCredential = credentials.get(adapterConfig.tokenCredentialRef.id);
+        if (
+          tokenCredential === undefined ||
+          tokenCredential.ref.type !== "api_key" ||
+          adapterConfig.tokenCredentialRef.type !== "api_key" ||
+          tokenCredential.ref.issuerId !== adapterConfig.tokenCredentialRef.issuerId
+        ) {
+          throw new InstallerValidationError(
+            `binding ${binding.lane} tokenCredentialRef must reference an api_key`,
+          );
+        }
+      }
     }
-  }
-  if (!draft.bindings.some((binding) => binding.lane === "primary")) {
-    throw new InstallerValidationError("a primary lane binding is required");
-  }
-  if (draft.frontend === null) {
-    throw new InstallerValidationError("frontend choice is required");
-  }
-  const frontend = validateFrontendChoice(draft.frontend);
-  if (frontend.kind === "official-skin") {
-    throw new InstallerValidationError(
-      "official skin is pending issues #49 and #51 and cannot be activated yet",
-    );
-  }
-  if (draft.memory === null) {
-    throw new InstallerValidationError("memory choice is required");
-  }
-  const memory = validateMemoryChoice(draft.memory);
+    if (!draft.bindings.some((binding) => binding.lane === "primary")) {
+      throw new InstallerValidationError("a primary lane binding is required");
+    }
+  });
+
+  const frontend = validateStep("frontend", () => {
+    if (draft.frontend === null) {
+      throw new InstallerValidationError("frontend choice is required");
+    }
+    const choice = validateFrontendChoice(draft.frontend);
+    if (choice.kind === "official-skin") {
+      throw new InstallerValidationError(
+        "official skin is pending issues #49 and #51 and cannot be activated yet",
+      );
+    }
+    return choice;
+  });
+
+  const memory = validateStep("memory", () => {
+    if (draft.memory === null) {
+      throw new InstallerValidationError("memory choice is required");
+    }
+    return validateMemoryChoice(draft.memory);
+  });
 
   return {
     schemaVersion: INSTALL_CONFIG_SCHEMA_VERSION,

--- a/src/installer/controller.ts
+++ b/src/installer/controller.ts
@@ -80,6 +80,25 @@ export class InstallerController {
   }
 
   /**
+   * Rewinds to the binding step, keeping the collected credentials.
+   *
+   * For a commit rejected because of a binding (wrong resident, missing primary lane,
+   * bad gateway config) the credentials are fine; sending the user back to step 1
+   * would throw away work that was never the problem.
+   */
+  revisitBindings(): InstallerDraft {
+    const draft = cloneDraft(this.#requireDraft());
+    draft.progress.currentStep = "bindings";
+    draft.progress.status = "in-progress";
+    draft.progress.completedSteps = draft.progress.completedSteps.filter(
+      (step) => step !== "bindings",
+    );
+    draft.bindings = [];
+    this.#persist(draft);
+    return cloneDraft(draft);
+  }
+
+  /**
    * Sends a stuck review back to the memory step so another path can be chosen.
    *
    * `revisitFrontend` cannot stand in for this: it only rewinds to frontend, and
@@ -150,7 +169,13 @@ export class InstallerController {
       throw new InstallerValidationError("a primary lane binding is required");
     }
     draft.bindings = bindings.map((binding) => structuredClone(binding));
-    completeStep(draft, "bindings", "frontend");
+    // After a rewind to bindings the later steps may still be filled in; skip them the
+    // same way saveFrontend already skips a filled-in memory step.
+    completeStep(
+      draft,
+      "bindings",
+      draft.frontend === null ? "frontend" : draft.memory === null ? "memory" : "review",
+    );
     this.#persist(draft);
     return cloneDraft(draft);
   }

--- a/src/installer/controller.ts
+++ b/src/installer/controller.ts
@@ -58,7 +58,15 @@ export class InstallerController {
     return cloneDraft(this.#requireDraft());
   }
 
-  revisitCredentials(): InstallerDraft {
+  /**
+   * Rewinds to the credential step.
+   *
+   * `reset` clears the collected credentials as well, for the case where the saved
+   * set is itself what got rejected: the runner re-collects from `draft.credentials`,
+   * so keeping a rejected set would replay the same rejection. The default keeps
+   * them, which is what the "no compatible credential for this adapter" path wants.
+   */
+  revisitCredentials(options: { reset?: boolean } = {}): InstallerDraft {
     const draft = cloneDraft(this.#requireDraft());
     draft.progress.currentStep = "credentials";
     draft.progress.status = "in-progress";
@@ -66,6 +74,26 @@ export class InstallerController {
       (step) => step !== "credentials" && step !== "bindings",
     );
     draft.bindings = [];
+    if (options.reset === true) draft.credentials = [];
+    this.#persist(draft);
+    return cloneDraft(draft);
+  }
+
+  /**
+   * Sends a stuck review back to the memory step so another path can be chosen.
+   *
+   * `revisitFrontend` cannot stand in for this: it only rewinds to frontend, and
+   * once frontend is saved again the still-populated memory step is skipped and the
+   * draft lands back on review — where the unusable path fails again.
+   */
+  revisitMemory(): InstallerDraft {
+    const draft = cloneDraft(this.#requireDraft());
+    draft.progress.currentStep = "memory";
+    draft.progress.status = "in-progress";
+    draft.progress.completedSteps = draft.progress.completedSteps.filter(
+      (step) => step !== "memory",
+    );
+    draft.memory = null;
     this.#persist(draft);
     return cloneDraft(draft);
   }
@@ -88,6 +116,18 @@ export class InstallerController {
     const draft = cloneDraft(this.#requireDraft());
     if (entries.length === 0) {
       throw new InstallerValidationError("at least one credential is required");
+    }
+    // Reject duplicate ids here, with the same rule and wording commit uses.
+    // Leaving it to commit strands the draft at review: commit throws, and review
+    // has no way back to step 1, so the only exit is discarding everything.
+    // Checked before staging so a rejected batch leaves no orphan secret.
+    const seenIds = new Set<string>();
+    for (const entry of entries) {
+      const id = entry.credential.ref.id;
+      if (seenIds.has(id)) {
+        throw new InstallerValidationError(`duplicate credential id: ${id}`);
+      }
+      seenIds.add(id);
     }
     const credentials: InstallerCredential[] = [];
     for (const entry of entries) {

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -96,7 +96,7 @@ async function collectCredentials(
     const existingIndex = entries.findIndex((entry) => entry.credential.ref.id === id);
     if (existingIndex !== -1) {
       entries.splice(existingIndex, 1);
-      options.prompt.info(`已替换同名凭证 ${id}`);
+      options.prompt.info(`Replaced existing credential "${id}".`);
     }
     entries.push({
       credential: {

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -93,6 +93,11 @@ async function collectCredentials(
     } else {
       secret = await options.prompt.secret({ message: `${provider.label} API key` });
     }
+    const existingIndex = entries.findIndex((entry) => entry.credential.ref.id === id);
+    if (existingIndex !== -1) {
+      entries.splice(existingIndex, 1);
+      options.prompt.info(`已替换同名凭证 ${id}`);
+    }
     entries.push({
       credential: {
         ref: {

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -6,6 +6,7 @@ import type {
   InstallCommitReceipt,
   InstallerCredential,
   InstallerDraft,
+  InstallerStep,
   LaneBinding,
   MemoryChoice,
 } from "./contracts.ts";
@@ -254,8 +255,44 @@ async function collectMemory(options: RunInstallerOptions): Promise<void> {
   // Record the intended side effect before creating it. If the process dies between these
   // operations, resume can safely recreate it; discard still knows exactly what may be removed.
   const draft = options.controller.saveMemory({ kind, path });
-  options.memoryLibraries.createEmpty(path, draft.draftId);
+  try {
+    options.memoryLibraries.createEmpty(path, draft.draftId);
+  } catch (error) {
+    // Same failure the review step guards against, caught at the moment the user
+    // typed the path: the loop comes straight back to this step for another path.
+    options.prompt.info(
+      `The memory library at ${path} cannot be created: ${
+        error instanceof Error ? error.message : String(error)
+      }. Choose another path.`,
+    );
+    options.controller.revisitMemory();
+  }
 }
+
+/**
+ * What review can offer when commit rejects the draft, keyed by the step that owns the
+ * rejected data. Credentials are reset only when the credential set itself was rejected.
+ */
+const REVIEW_REPAIRS: Partial<
+  Record<InstallerStep, { label: string; apply: (controller: InstallerController) => void }>
+> = {
+  credentials: {
+    label: "Go back to credentials and fix it",
+    apply: (controller) => controller.revisitCredentials({ reset: true }),
+  },
+  bindings: {
+    label: "Go back to lane bindings and fix it",
+    apply: (controller) => controller.revisitBindings(),
+  },
+  frontend: {
+    label: "Go back to the frontend choice and fix it",
+    apply: (controller) => controller.revisitFrontend(),
+  },
+  memory: {
+    label: "Go back to the memory library and fix it",
+    apply: (controller) => controller.revisitMemory(),
+  },
+};
 
 export async function runInstaller(options: RunInstallerOptions): Promise<RunInstallerResult> {
   const existing = options.store.loadDraft();
@@ -370,17 +407,25 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
           options.prompt.info(
             `This setup cannot be saved: ${error.message}. Your draft is kept and no active config changed.`,
           );
+          // Route by the step that owns the rejected data. Only a rejected credential
+          // set clears credentials; a binding, frontend, or memory rejection must not
+          // throw away credentials that were never the problem. A rejection with no
+          // step (draft envelope) has no step to go back to.
+          const repair = REVIEW_REPAIRS[error.step ?? "review"];
+          if (repair === undefined) {
+            return { status: "paused", draft: options.controller.current() };
+          }
           const fixChoice = await options.prompt.select({
             message: "How do you want to continue?",
             choices: [
-              { value: "credentials", name: "Go back to credentials and fix it" },
+              { value: "fix", name: repair.label },
               { value: "keep", name: "Keep this draft and exit" },
             ],
-            default: "credentials",
+            default: "fix",
           });
           if (fixChoice === "keep")
             return { status: "paused", draft: options.controller.current() };
-          options.controller.revisitCredentials({ reset: true });
+          repair.apply(options.controller);
           break;
         }
       }

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -9,7 +9,7 @@ import type {
   LaneBinding,
   MemoryChoice,
 } from "./contracts.ts";
-import { installerAdapterAcceptsCredentialType } from "./contracts.ts";
+import { InstallerValidationError, installerAdapterAcceptsCredentialType } from "./contracts.ts";
 import type { InstallerController } from "./controller.ts";
 import type { MemoryLibraryPort } from "./memory-library.ts";
 import type { OAuthLoginPort } from "./pi-login.ts";
@@ -321,7 +321,20 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
       case "review": {
         if (draft.memory?.kind === "create") {
           // Idempotently finish a creation interrupted after the draft was persisted.
-          options.memoryLibraries.createEmpty(draft.memory.path, draft.draftId);
+          try {
+            options.memoryLibraries.createEmpty(draft.memory.path, draft.draftId);
+          } catch (error) {
+            // The path is taken by a directory mist did not create, so createEmpty
+            // refuses. Letting this escape strands the draft for good: every later
+            // resume lands on review again and re-runs this same call.
+            options.prompt.info(
+              `The memory library at ${draft.memory.path} cannot be created: ${
+                error instanceof Error ? error.message : String(error)
+              }. Your draft is kept — choose another path.`,
+            );
+            options.controller.revisitMemory();
+            break;
+          }
         }
         options.prompt.info(formatReview(draft));
         if (draft.frontend?.kind === "official-skin") {
@@ -347,7 +360,29 @@ export async function runInstaller(options: RunInstallerOptions): Promise<RunIns
           default: true,
         });
         if (!shouldCommit) return { status: "paused", draft };
-        return { status: "committed", receipt: options.controller.commit() };
+        try {
+          return { status: "committed", receipt: options.controller.commit() };
+        } catch (error) {
+          // Validation that only commit can see (duplicate ids being the known case)
+          // must not be a dead end: review had no way back to step 1, so the only
+          // exit was discarding the whole draft.
+          if (!(error instanceof InstallerValidationError)) throw error;
+          options.prompt.info(
+            `This setup cannot be saved: ${error.message}. Your draft is kept and no active config changed.`,
+          );
+          const fixChoice = await options.prompt.select({
+            message: "How do you want to continue?",
+            choices: [
+              { value: "credentials", name: "Go back to credentials and fix it" },
+              { value: "keep", name: "Keep this draft and exit" },
+            ],
+            default: "credentials",
+          });
+          if (fixChoice === "keep")
+            return { status: "paused", draft: options.controller.current() };
+          options.controller.revisitCredentials({ reset: true });
+          break;
+        }
       }
     }
     draft = options.controller.current();

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -236,7 +236,7 @@ it("replaces a credential when the user enters the same name twice", async () =>
   if (result.status !== "committed") throw new Error("expected committed setup");
   expect(result.receipt.config.credentialRefs).toEqual([apiKeyRef("codex-key")]);
   expect(store.readCredentialSecret("codex-key")).toBe("replacement-secret");
-  expect(prompt.infoMessages).toContain("已替换同名凭证 codex-key");
+  expect(prompt.infoMessages).toContain('Replaced existing credential "codex-key".');
   prompt.expectExhausted();
 });
 

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -594,6 +594,7 @@ function reviewReadyDraft(
   overrides: {
     credentials: { ref: ReturnType<typeof apiKeyRef>; label: string }[];
     memory: { kind: "existing" | "create"; path: string };
+    bindingResidentId?: string;
   },
 ): void {
   const seeded = new InstallerController(store);
@@ -608,7 +609,7 @@ function reviewReadyDraft(
     })),
     bindings: [
       {
-        residentId: "resident-1",
+        residentId: overrides.bindingResidentId ?? "resident-1",
         lane: "primary",
         adapterId: "pi",
         credentialRef: overrides.credentials[0]?.ref ?? apiKeyRef("codex-key"),
@@ -674,10 +675,10 @@ it("offers a way back to credentials when commit rejects a draft written by an o
   });
 
   const prompt = new ScriptedPrompt({
-    // review confirm -> commit throws -> back to credentials -> redo steps 1..3.
-    // The memory step is not asked again: it stays completed, which is exactly why
-    // rewinding to frontend could never clear a bad memory path (see #58 item 2).
-    selects: ["resume", "credentials", "codex", "api-key", "codex-key", "external"],
+    // review confirm -> commit throws -> back to credentials -> redo steps 1..2.
+    // Frontend and memory are not asked again: they stay completed, which is exactly
+    // why rewinding to frontend could never clear a bad memory path (see #58 item 2).
+    selects: ["resume", "fix", "codex", "api-key", "codex-key"],
     inputs: ["codex-key"],
     secrets: ["credential-text"],
     confirms: [true, false, false, true],
@@ -797,5 +798,85 @@ it("lets the user pick another path when the memory library location is occupied
   expect(existsSync(join(replacement, ".mist-memory.json"))).toBe(true);
   // The occupied directory is left exactly as it was.
   expect(existsSync(join(occupied, "someone-elses-data"))).toBe(true);
+  prompt.expectExhausted();
+});
+
+it("a binding rejection at commit sends the user to bindings and keeps the credentials", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const memoryPath = join(directory, "memory-choice");
+  mkdirSync(memoryPath);
+  // The credential set is fine; only the binding names the wrong resident. Review
+  // must not answer that by throwing away the credential (independent review of #74).
+  reviewReadyDraft(store, {
+    credentials: [{ ref: apiKeyRef("codex-key"), label: "Codex" }],
+    memory: { kind: "existing", path: memoryPath },
+    bindingResidentId: "different-resident",
+  });
+  store.stageSecret(store.loadDraft()?.draftId ?? "", "codex-key.credential", "credential-text");
+
+  const prompt = new ScriptedPrompt({
+    // review confirm -> commit throws (binding) -> back to bindings -> redo bindings only:
+    // pick the (still present) credential, decline a coding channel, confirm review.
+    selects: ["resume", "fix", "codex-key"],
+    inputs: [],
+    secrets: [],
+    confirms: [true, false, true],
+  });
+
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  expect(
+    prompt.infoMessages.some((message) => message.includes("does not match draft resident")),
+  ).toBe(true);
+  // The credential survived the round trip untouched: same id, same secret.
+  expect(store.loadCurrentConfig()?.credentialRefs.map((ref) => ref.id)).toEqual(["codex-key"]);
+  expect(store.readCredentialSecret("codex-key")).toBe("credential-text");
+  prompt.expectExhausted();
+});
+
+it("a second occupied memory path is caught at the memory step instead of crashing", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const occupiedA = join(directory, "occupied-a");
+  const occupiedB = join(directory, "occupied-b");
+  const replacement = join(directory, "fresh-memory");
+  mkdirSync(join(occupiedA, "data"), { recursive: true });
+  mkdirSync(join(occupiedB, "data"), { recursive: true });
+
+  const prompt = new ScriptedPrompt({
+    // step 1..3, then memory: occupied A (caught) -> occupied B (caught) -> fresh
+    selects: ["codex", "api-key", "codex-key", "external", "create", "create", "create"],
+    inputs: ["codex-key", occupiedA, occupiedB, replacement],
+    secrets: ["credential-text"],
+    confirms: [false, false, true],
+  });
+
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  expect(
+    prompt.infoMessages.filter((message) => message.includes("cannot be created")),
+  ).toHaveLength(2);
+  expect(store.loadCurrentConfig()?.memory).toEqual({ kind: "create", path: replacement });
+  expect(existsSync(join(occupiedA, "data"))).toBe(true);
+  expect(existsSync(join(occupiedB, "data"))).toBe(true);
   prompt.expectExhausted();
 });

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -210,6 +210,36 @@ it("keeps Grok OAuth out of the v0 installer acquisition catalog", () => {
   expect(grok?.methods).toEqual(["api-key"]);
 });
 
+it("replaces a credential when the user enters the same name twice", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const memoryPath = join(directory, "memory");
+  mkdirSync(memoryPath);
+  const prompt = new ScriptedPrompt({
+    selects: ["codex", "api-key", "codex", "api-key", "codex-key", "external", "existing"],
+    inputs: ["codex-key", "codex-key", memoryPath],
+    secrets: ["first-secret", "replacement-secret"],
+    confirms: [true, false, false, true],
+  });
+
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  if (result.status !== "committed") throw new Error("expected committed setup");
+  expect(result.receipt.config.credentialRefs).toEqual([apiKeyRef("codex-key")]);
+  expect(store.readCredentialSecret("codex-key")).toBe("replacement-secret");
+  expect(prompt.infoMessages).toContain("已替换同名凭证 codex-key");
+  prompt.expectExhausted();
+});
+
 it("resumes from the persisted next step instead of asking for credentials again", async () => {
   const directory = freshDirectory();
   const store = new InstallerStateStore(directory);
@@ -629,7 +659,7 @@ it("saveCredentials rejects a duplicate id instead of leaving it for commit", ()
   const directory = freshDirectory();
   const store = new InstallerStateStore(directory);
   const controller = new InstallerController(store);
-  controller.start("resident-1");
+  const draft = controller.start("resident-1");
 
   expect(() =>
     controller.saveCredentials([
@@ -655,7 +685,7 @@ it("saveCredentials rejects a duplicate id instead of leaving it for commit", ()
   ).toThrow(/duplicate credential id: codex-key/);
 
   // Rejected before staging: no orphan secret, and the draft stays on step 1.
-  expect(existsSync(join(directory, "drafts", "secrets"))).toBe(false);
+  expect(store.hasStagedSecret(draft.draftId, "codex-key.credential")).toBe(false);
   expect(store.loadDraft()?.progress.currentStep).toBe("credentials");
 });
 

--- a/tests/installer-run.test.ts
+++ b/tests/installer-run.test.ts
@@ -586,3 +586,216 @@ it("does not delete the active memory library when a same-path replacement draft
   expect(store.loadCurrentConfig()?.memory).toEqual({ kind: "existing", path: memoryPath });
   prompt.expectExhausted();
 });
+
+// ── #58 第 1、2 条：恢复路径的两个死锁 ──────────────────────────────
+
+function reviewReadyDraft(
+  store: InstallerStateStore,
+  overrides: {
+    credentials: { ref: ReturnType<typeof apiKeyRef>; label: string }[];
+    memory: { kind: "existing" | "create"; path: string };
+  },
+): void {
+  const seeded = new InstallerController(store);
+  const draft = seeded.start("resident-1");
+  store.saveDraft({
+    ...draft,
+    credentials: overrides.credentials.map((entry) => ({
+      ref: entry.ref,
+      label: entry.label,
+      providerId: "codex",
+      status: "ready",
+    })),
+    bindings: [
+      {
+        residentId: "resident-1",
+        lane: "primary",
+        adapterId: "pi",
+        credentialRef: overrides.credentials[0]?.ref ?? apiKeyRef("codex-key"),
+      },
+    ],
+    frontend: { kind: "external", integration: "mist-session-api" },
+    memory: overrides.memory,
+    progress: {
+      currentStep: "review",
+      status: "in-progress",
+      completedSteps: ["credentials", "bindings", "frontend", "memory"],
+    },
+  });
+}
+
+it("saveCredentials rejects a duplicate id instead of leaving it for commit", () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const controller = new InstallerController(store);
+  controller.start("resident-1");
+
+  expect(() =>
+    controller.saveCredentials([
+      {
+        credential: {
+          ref: apiKeyRef("codex-key"),
+          label: "First",
+          providerId: "codex",
+          status: "incomplete",
+        },
+        secret: "first-secret",
+      },
+      {
+        credential: {
+          ref: apiKeyRef("codex-key"),
+          label: "Second",
+          providerId: "codex",
+          status: "incomplete",
+        },
+        secret: "second-secret",
+      },
+    ]),
+  ).toThrow(/duplicate credential id: codex-key/);
+
+  // Rejected before staging: no orphan secret, and the draft stays on step 1.
+  expect(existsSync(join(directory, "drafts", "secrets"))).toBe(false);
+  expect(store.loadDraft()?.progress.currentStep).toBe("credentials");
+});
+
+it("offers a way back to credentials when commit rejects a draft written by an older build", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const memoryPath = join(directory, "memory-choice");
+  mkdirSync(memoryPath);
+  // saveCredentials now refuses this shape, but drafts written before the fix are
+  // still on disk; commit stays the last line of defence and must not be a dead end.
+  reviewReadyDraft(store, {
+    credentials: [
+      { ref: apiKeyRef("codex-key"), label: "First" },
+      { ref: apiKeyRef("codex-key"), label: "Second" },
+    ],
+    memory: { kind: "existing", path: memoryPath },
+  });
+
+  const prompt = new ScriptedPrompt({
+    // review confirm -> commit throws -> back to credentials -> redo steps 1..3.
+    // The memory step is not asked again: it stays completed, which is exactly why
+    // rewinding to frontend could never clear a bad memory path (see #58 item 2).
+    selects: ["resume", "credentials", "codex", "api-key", "codex-key", "external"],
+    inputs: ["codex-key"],
+    secrets: ["credential-text"],
+    confirms: [true, false, false, true],
+  });
+
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  expect(prompt.infoMessages.some((message) => message.includes("duplicate credential id"))).toBe(
+    true,
+  );
+  expect(store.loadCurrentConfig()?.credentialRefs).toHaveLength(1);
+  prompt.expectExhausted();
+});
+
+it("keeps the draft when a rejected commit is not fixed on the spot", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const memoryPath = join(directory, "memory-choice");
+  mkdirSync(memoryPath);
+  reviewReadyDraft(store, {
+    credentials: [
+      { ref: apiKeyRef("dup"), label: "First" },
+      { ref: apiKeyRef("dup"), label: "Second" },
+    ],
+    memory: { kind: "existing", path: memoryPath },
+  });
+
+  const prompt = new ScriptedPrompt({
+    selects: ["resume", "keep"],
+    inputs: [],
+    secrets: [],
+    confirms: [true],
+  });
+
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("paused");
+  expect(store.loadCurrentConfig()).toBeNull();
+  expect(store.loadDraft()?.credentials).toHaveLength(2);
+  prompt.expectExhausted();
+});
+
+it("lets the user pick another path when the memory library location is occupied", async () => {
+  const directory = freshDirectory();
+  const store = new InstallerStateStore(directory);
+  const occupied = join(directory, "occupied-memory");
+  const replacement = join(directory, "fresh-memory");
+  // A directory mist did not create: no marker, so createEmpty refuses to adopt it.
+  // This is the state a resume finds after the first attempt failed on that path.
+  mkdirSync(occupied);
+  mkdirSync(join(occupied, "someone-elses-data"));
+  // Built through the normal API: the draft records the create path but the
+  // directory was never made by mist, which is what a resume finds after the
+  // first attempt failed on that path.
+  const seeded = new InstallerController(store);
+  seeded.start("resident-1");
+  seeded.saveCredentials([
+    {
+      credential: {
+        ref: apiKeyRef("codex-key"),
+        label: "Codex",
+        providerId: "codex",
+        status: "incomplete",
+      },
+      secret: "credential-text",
+    },
+  ]);
+  seeded.saveBindings([
+    {
+      residentId: "resident-1",
+      lane: "primary",
+      adapterId: "pi",
+      credentialRef: apiKeyRef("codex-key"),
+    },
+  ]);
+  seeded.saveFrontend({ kind: "external", integration: "mist-session-api" });
+  seeded.saveMemory({ kind: "create", path: occupied });
+
+  const prompt = new ScriptedPrompt({
+    // resume lands on review -> createEmpty fails -> memory step again -> new path
+    selects: ["resume", "create"],
+    inputs: [replacement],
+    secrets: [],
+    confirms: [true],
+  });
+
+  const result = await runInstaller({
+    residentId: "resident-1",
+    dataDir: directory,
+    controller: new InstallerController(store),
+    store,
+    prompt,
+    oauth: noOAuth,
+    memoryLibraries: new FileMemoryLibrary(),
+  });
+
+  expect(result.status).toBe("committed");
+  expect(prompt.infoMessages.some((message) => message.includes("cannot be created"))).toBe(true);
+  expect(store.loadCurrentConfig()?.memory).toEqual({ kind: "create", path: replacement });
+  expect(existsSync(join(replacement, ".mist-memory.json"))).toBe(true);
+  // The occupied directory is left exactly as it was.
+  expect(existsSync(join(occupied, "someone-elses-data"))).toBe(true);
+  prompt.expectExhausted();
+});


### PR DESCRIPTION
Closes #58 的第 1、2 条（第 3 条是 #60，低优先那一批不在本单）。楼里 [认领时](https://github.com/mist-agent-harness/mist-agent/issues/58#issuecomment-5337718842)的复核就是这份实现的依据。

## 第 1 条 · 重名凭证死锁

`saveCredentials`（`controller.ts`）不查 `ref.id` 重复，一路走到 `commit()` 才由 `contracts.ts` 抛 `duplicate credential id`；而 review 没有任何回第 1 步的入口，`run.ts` 那行 `return { status: "committed", receipt: options.controller.commit() }` 把抛错直接穿出 `runInstaller`——用户只能整份 discard。

- **查重挪到第 1 步**：与 commit 同一条规则、同一句文案。放在 `stageSecret` 之前，被拒的一批不留孤儿 secret。
- **review 接住 `InstallerValidationError`**：给「回凭证步 / 保留草稿退出」两个出口。

一处需要评审注意的判断：**回退传 `reset: true`**。`revisitCredentials()` 原本保留 `draft.credentials`，而 `collectCredentials` 是从 `draft.credentials` 起手再追加的——不清就是把同一份重名再提交一次，出口等于没开。所以给 `revisitCredentials` 加了可选的 `reset`，只有「commit 拒绝了这批凭证本身」这条路径传它；bindings 那条「没有兼容凭证」的路径不变，仍保留已输入的凭证（那里凭证是好的，缺的是适配器）。

## 第 2 条 · memory=create 路径被占死锁

`createEmpty`（`memory-library.ts`）对「存在但没有 marker」的目录抛 `memory library path already exists`，review 开头的幂等补建吃不下这个错。

**这条每次 resume 都会重撞**，不是一次性失败：错误穿出去后，用户下次进来仍落在 `currentStep === "review"`，第一件事又是那句 `createEmpty`。`revisitFrontend()` 救不了——它只退到 frontend，`saveFrontend` 走完后 `memory` 非 null 直接过站，又回到 review。

- **新增 `revisitMemory()`**，照 `revisitFrontend` 的形状（退回 memory 步、清 `completedSteps` 里的 memory、`memory` 置 null）。
- review 的 `createEmpty` 包 try/catch，失败时把原因说给用户并退回 memory 步换路径。**被占用的目录一个字节都不动**（测试里断言了里面原有的文件还在）。

## 独立复核后的第二刀（`9197325`）

同一维护者名下的另一位 AI（Codex）对 `2670414` 做了独立复核，五条全过，另核出一条中等问题：

**F1 · review 对所有 `InstallerValidationError` 一律 `revisitCredentials({reset:true})`。** 这个类除了重名还有 30 处 throw；用「binding resident 不匹配」复现——错在 binding，赔的是用户填好的凭证。成立，已改：

- `InstallerValidationError` 加可选 `step`；`validateReadyDraft` 按 credentials / bindings / frontend / memory 四段包 `validateStep()`，未标注的抛错由所在段 stamp。**31 处 throw 的文本一字未动。**
- `run.ts` 用 `REVIEW_REPAIRS` 按 step 路由：只有 credentials 才 reset；bindings → 新增 `revisitBindings()`（保留凭证、清 bindings）；frontend / memory → 各自 revisit；没 step（草稿信封本身坏）只保留草稿退出。
- `saveBindings` 之后若 frontend / memory 已填则跳过——与 `saveFrontend` 已有的跳过 memory 逻辑一致，否则从 bindings 回退会把用户拉回 frontend 重问。
- 顺手：`collectMemory` 里首次 `createEmpty` 也接住（复核复现的「第二个被占用路径会崩一次」），失败提示后原地回 memory 步。这条原本写在「留给主笔裁」，复核跑出来了就一起修，改动 8 行。

复核还确认了两件我自己没查的：`revisitMemory()` 留下的旧 `memory_dir_created` 收据**不会**让 discard 误删别人的目录（`discardEmpty` 只删「恰好一个 marker 且 owner 同 draftId」的目录，实跑 `removed=false`）；PR/base 全量差恰好 +4，环境失败两边一致。

## 测试

`tests/installer-run.test.ts` 共加六条，**去掉源码改动后全红**（`git stash` 实测，第二刀的两条是对着 `2670414` 红的）：

1. `saveCredentials` 拒绝重名，且拒绝发生在 stage 之前（不留孤儿 secret、草稿仍停在第 1 步）
2. 旧版本写下的重名草稿被 commit 拒绝后，能回第 1 步改完提交
3. 同样情形下选择「保留草稿退出」，返回 `paused` 且草稿两条凭证原样还在、`current.json` 没动
4. memory create 路径被无 marker 目录占住时，resume 能换路径提交，占用目录内容不变
5. （第二刀）binding 被 commit 拒绝 → 回 bindings 步，凭证 id 与 secret 原样保留
6. （第二刀）连续两个被占用路径都在 memory 步被接住，不崩，两个目录内容不动

第 2 条测试顺带钉住了第 2 个死锁的成因：从 review 回退重做时 **memory 步不会被再问**，这正是「退到 frontend 清不掉坏的 memory 路径」的原因。

## 本地三件套如实报

- `npx vitest run tests/installer-run.test.ts tests/installer-controller.test.ts` → **48 passed**（19 + 29）
- `npm test` 全量 → **204 passed**；`brain-claude` / `demo-adapters` / `demo-server` / `demo-wiring` 四个文件 fail，根因是本地没装 `@anthropic-ai/claude-agent-sdk`。**在干净 main 上同样这四个 fail（198 passed）**，与本单无关。
- `npx biome check` 三份改动文件 → 干净（跑过 `--write`）。
- `npx tsc --noEmit` 只剩两条缺依赖报错（`@anthropic-ai/claude-agent-sdk`、`@inquirer/prompts`），同为本地 node_modules 不全，main 上一样。

## 没做的（留给主笔裁）

- 原单低优先那一批（pointer 校验强度、损坏 draft 恢复、逐把落盘、孤儿 secret、pi auth 空壳、`~/.mist` 权限、TODO 桩、discard 不校验 residentId）一条没动。

（本账号 chaodeng060-source 与 #52 的 cheqing0410 为同一维护者。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
