### PR TITLE
feat(session): multi-viewport window core (MV-A01~A04, B01~B03)

### DIFF
--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -53,6 +53,14 @@ class MistDriver implements HarnessDriver {
    * 合龙时由 P4 的 SessionRegistry 接管这张表。
    */
   readonly #sessions = new SessionRegistry<null>();
+  /**
+   * 驱动器自己持有的「本驱动这一扇窗」绑定。
+   *
+   * 多窗合法之后，注册表不再回答「这个住户的当前会话是哪一个」——那正是
+   * MV-A02 要拔掉的隐式单键。所以由调用方显式声明自己用哪一扇窗，
+   * 而不是反过来让注册表替调用方猜。
+   */
+  readonly #driverWindows = new Map<string, string>();
 
   constructor(options: CreateDriverOptions = {}) {
     this.#store = new ResidentStore(
@@ -62,8 +70,8 @@ class MistDriver implements HarnessDriver {
     this.#messageTree = new MessageTreeService(
       this.#messageTreeStore,
       {
-        getHead: (residentId) => this.#session(residentId).headId,
-        setHead: (residentId, headId) => this.#sessions.setHead(residentId, headId),
+        getHead: (windowId) => this.#sessions.get(windowId)?.headId ?? null,
+        setHead: (windowId, headId) => this.#sessions.setHead(windowId, headId),
       } satisfies SessionHeadPort,
       { assistantReply: options.reply ?? ((_residentId, message) => `收到：${message}`) },
     );
@@ -71,7 +79,18 @@ class MistDriver implements HarnessDriver {
   }
 
   #session(residentId: string) {
-    return this.#sessions.get(residentId) ?? this.#sessions.open(residentId, null, null);
+    const bound = this.#driverWindows.get(residentId);
+    if (bound !== undefined) {
+      const live = this.#sessions.get(bound);
+      if (live !== undefined) return live;
+    }
+    const opened = this.#sessions.open(residentId, { headId: null, context: null });
+    this.#driverWindows.set(residentId, opened.windowId);
+    return opened;
+  }
+
+  #windowIdOf(residentId: string): string {
+    return this.#session(residentId).windowId;
   }
 
   #createMessageRoom(residentId: string): void {
@@ -115,15 +134,20 @@ class MistDriver implements HarnessDriver {
     this.#store.commit(residentId, commitment);
   }
 
+  #killDriverWindows(residentId: string): void {
+    this.#sessions.killResident(residentId);
+    this.#driverWindows.delete(residentId);
+  }
+
   async destroyResident(residentId: string): Promise<void> {
     if (!this.#store.has(residentId)) {
-      this.#sessions.kill(residentId);
+      this.#killDriverWindows(residentId);
       this.#messageRooms.delete(residentId);
       this.#messageTreeStore.destroyRoom(residentId);
       this.#store.destroyResident(residentId);
       return;
     }
-    this.#sessions.kill(residentId);
+    this.#killDriverWindows(residentId);
     if (this.#messageRooms.delete(residentId)) {
       this.#messageTreeStore.destroyRoom(residentId);
     }
@@ -134,7 +158,7 @@ class MistDriver implements HarnessDriver {
 
   async say(residentId: string, message: string): Promise<HistoryNode> {
     this.#ensureMessageRoom(residentId);
-    return this.#messageTree.say(residentId, message);
+    return this.#messageTree.say(residentId, message, this.#windowIdOf(residentId));
   }
 
   async history(residentId: string): Promise<HistoryNode[]> {
@@ -144,7 +168,12 @@ class MistDriver implements HarnessDriver {
 
   async reviseNode(residentId: string, nodeId: string, newContent: string): Promise<HistoryNode> {
     this.#ensureMessageRoom(residentId);
-    return this.#messageTree.reviseNode(residentId, nodeId, newContent);
+    return this.#messageTree.reviseNode(
+      residentId,
+      nodeId,
+      newContent,
+      this.#windowIdOf(residentId),
+    );
   }
 
   // --- P3：启动包 ---
@@ -161,7 +190,7 @@ class MistDriver implements HarnessDriver {
     // 会话死，人不能死（C1 验 kill 前后整棵树的 hash 不变）。
     // 删除活会话 —— 下一句 say 会开新 generation、新根；旧 generation 的迟到
     // effect receipt 也不能再被视为当前会话，H1 的 Effect Journal 会接这条线。
-    this.#sessions.kill(residentId);
+    this.#killDriverWindows(residentId);
   }
 
   // --- P5：迁移 ---

--- a/src/message-tree/service.ts
+++ b/src/message-tree/service.ts
@@ -7,10 +7,13 @@ import type { MessageTreeStore } from "./store.ts";
  *
  * head 是可杀的会话态，不属于 MessageTreeStore。P4 总装时用自己的
  * SessionRegistry 适配这两个方法；P2 不持久化、迁移或销毁 head。
+ *
+ * 多窗之后这个接缝按 windowId 索引，不按 residentId：同一住户的两扇窗
+ * 各有各的 head，共用一颗 head 会让两窗互相改写对方的续话位置（MV-A02）。
  */
 export interface SessionHeadPort {
-  getHead(residentId: string): string | null;
-  setHead(residentId: string, headId: string): void;
+  getHead(windowId: string): string | null;
+  setHead(windowId: string, headId: string): void;
 }
 
 /** M0 的哑回应生成口；真实模型适配不属于消息树存储。 */
@@ -43,18 +46,18 @@ export class MessageTreeService {
   }
 
   /** 原子落 user + assistant；两节点都存在以后才允许推进会话 head。 */
-  async say(residentId: string, message: string): Promise<HistoryNode> {
+  async say(residentId: string, message: string, windowId: string): Promise<HistoryNode> {
     // Store 的公开 API 刻意很窄；复用只读历史同时验证房间与会话 head，
     // 避免 stale/cross-room head 在最终落树失败前已经调用 responder，白花模型成本
     // 或触发外部副作用。appendPair 仍会在写入边界重验 parentId，不依赖这层代签。
     const roomHistory = this.#store.history(residentId);
-    const parentId = this.#sessionHeads.getHead(residentId);
+    const parentId = this.#sessionHeads.getHead(windowId);
     if (parentId !== null && !roomHistory.some((node) => node.id === parentId)) {
       throw nodeUnavailable();
     }
     const assistantContent = await this.#assistantReply(residentId, message);
     const pair = this.#store.appendPair(residentId, message, assistantContent, parentId);
-    this.#sessionHeads.setHead(residentId, pair.assistant.id);
+    this.#sessionHeads.setHead(windowId, pair.assistant.id);
     return pair.assistant;
   }
 
@@ -62,13 +65,18 @@ export class MessageTreeService {
     return this.#store.history(residentId);
   }
 
-  async reviseNode(residentId: string, nodeId: string, newContent: string): Promise<HistoryNode> {
+  async reviseNode(
+    residentId: string,
+    nodeId: string,
+    newContent: string,
+    windowId: string,
+  ): Promise<HistoryNode> {
     const revised = this.#store.appendSibling(residentId, nodeId, newContent);
     // #14 二轮 + 认领人延伸裁定：改口即换枝，assistant/user 一视同仁，
     // active head 都切到新兄弟。若改的是 user 且未重新生成便继续 say，下一棵
     // user 会挂在新 user 下；这是「编辑后直接续话」的有意 M0 形态，不是副作用。
     // durable tree 仍只增一节点；会话态推进失败时不回滚已经存在的新枝。
-    this.#sessionHeads.setHead(residentId, revised.id);
+    this.#sessionHeads.setHead(windowId, revised.id);
     return revised;
   }
 }

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -15,12 +15,21 @@
 export const PRIVATE_SCOPE = "private" as const;
 
 export const WINDOW_ARCHIVED = "WINDOW_ARCHIVED" as const;
+export const WINDOW_REOPEN_INVALID = "WINDOW_REOPEN_INVALID" as const;
 
 export class WindowArchivedError extends Error {
   readonly code = WINDOW_ARCHIVED;
   constructor(windowId: string) {
     super(`${WINDOW_ARCHIVED}: ${windowId}`);
     this.name = "WindowArchivedError";
+  }
+}
+
+export class WindowReopenError extends Error {
+  readonly code = WINDOW_REOPEN_INVALID;
+  constructor(windowId: string, reason: string) {
+    super(`${WINDOW_REOPEN_INVALID}: ${windowId}: ${reason}`);
+    this.name = "WindowReopenError";
   }
 }
 
@@ -72,8 +81,32 @@ export class SessionRegistry<TContext> {
   #dispatchSeq = 0;
 
   #mintWindowId(): string {
-    this.#windowSeq += 1;
-    return `window-${this.#windowSeq.toString(36).padStart(6, "0")}`;
+    let candidate: string;
+    do {
+      this.#windowSeq += 1;
+      candidate = `window-${this.#windowSeq.toString(36).padStart(6, "0")}`;
+    } while (this.#active.has(candidate) || this.#archived.has(candidate));
+    return candidate;
+  }
+
+  #requireArchivedForReopen(residentId: string, scopeId: string, windowId: string): ArchivedWindow {
+    const archived = this.#archived.get(windowId);
+    if (archived === undefined) {
+      throw new WindowReopenError(windowId, "target is not an archived window");
+    }
+    if (archived.residentId !== residentId) {
+      throw new WindowReopenError(
+        windowId,
+        `resident mismatch: archived=${archived.residentId}, requested=${residentId}`,
+      );
+    }
+    if (archived.scopeId !== scopeId) {
+      throw new WindowReopenError(
+        windowId,
+        `scope mismatch: archived=${archived.scopeId}, requested=${scopeId}`,
+      );
+    }
+    return archived;
   }
 
   /**
@@ -82,11 +115,11 @@ export class SessionRegistry<TContext> {
    * 给 windowId 时是按同一身份重开一扇已归档的窗，起新一代（#66 B5）。
    */
   open(residentId: string, options: OpenOptions<TContext>): ActiveWindow<TContext> {
-    const windowId = options.windowId ?? this.#mintWindowId();
-    if (this.#active.has(windowId)) {
-      throw new Error(`window ${windowId} is already active`);
-    }
     const scopeId = options.scopeId ?? PRIVATE_SCOPE;
+    const windowId = options.windowId ?? this.#mintWindowId();
+    if (options.windowId !== undefined) {
+      this.#requireArchivedForReopen(residentId, scopeId, windowId);
+    }
     const generation = (this.#lastGeneration.get(windowId) ?? 0) + 1;
     this.#lastGeneration.set(windowId, generation);
     this.#archived.delete(windowId);

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -1,77 +1,186 @@
 /**
- * 当前活会话的临时状态。
+ * 活窗（viewport）的临时状态。
  *
  * 住户的记忆、消息树与关系记录不属于这里；它们必须由各自的持久存储保管。
- * 删除这张表中的一格，只能让一次会话结束，不能删除住户留下的任何东西。
+ * 删除这张表中的一格，只能让一扇窗结束，不能删除住户留下的任何东西。
+ *
+ * 多窗语义（MV-A01~A04, MV-B01~B03）：
+ * - 同一住户可以同时有多扇活窗，`open` 永远开新窗，不再「原地换代」。
+ * - 代际归窗，不归住户；住户级不存在「当前代际」。
+ * - `kill(windowId)` 幂等归档，归档后只读；`killResident` 才杀全部活窗。
+ * - 派发回执带完整三元组 `(residentId, windowId, generation)`。
  */
-export interface ActiveSession<TContext> {
+
+/** 缺省 scope 是私聊，任何路径都不得默认「全局」。 */
+export const PRIVATE_SCOPE = "private" as const;
+
+export const WINDOW_ARCHIVED = "WINDOW_ARCHIVED" as const;
+
+export class WindowArchivedError extends Error {
+  readonly code = WINDOW_ARCHIVED;
+  constructor(windowId: string) {
+    super(`${WINDOW_ARCHIVED}: ${windowId}`);
+    this.name = "WindowArchivedError";
+  }
+}
+
+export interface ActiveWindow<TContext> {
   residentId: string;
+  windowId: string;
+  scopeId: string;
   /**
-   * 这次活会话的代际号。kill 后再 open 必须换代，旧代际的迟到结果不能
-   * 被当成当前会话的一部分。
+   * 这扇窗的代际号。同窗 kill 后按同一 windowId 重开才换代；
+   * 旧代际的迟到结果不能被当成当前窗的一部分。
    */
   generation: number;
-  /** 当前活会话指向的消息节点；不是消息树本身。 */
+  /** 当前窗指向的消息节点；不是消息树本身。 */
   headId: string | null;
   /** 尚未落入持久存储的在途上下文。 */
   context: TContext;
 }
 
+export interface ArchivedWindow {
+  residentId: string;
+  windowId: string;
+  scopeId: string;
+  generation: number;
+  headId: string | null;
+  archived: true;
+}
+
 export interface DispatchReceipt {
   residentId: string;
+  windowId: string;
   generation: number;
   dispatchId: string;
 }
 
+export interface OpenOptions<TContext> {
+  scopeId?: string;
+  headId?: string | null;
+  context: TContext;
+  /** 只在按同一身份重开归档窗时给；不给就开一扇全新的窗。 */
+  windowId?: string;
+}
+
 export class SessionRegistry<TContext> {
-  readonly #active = new Map<string, ActiveSession<TContext>>();
+  readonly #active = new Map<string, ActiveWindow<TContext>>();
+  readonly #archived = new Map<string, ArchivedWindow>();
+  /** 代际归窗：windowId -> 上一次用过的代际号。 */
   readonly #lastGeneration = new Map<string, number>();
+  #windowSeq = 0;
   #dispatchSeq = 0;
 
-  open(residentId: string, headId: string | null, context: TContext): ActiveSession<TContext> {
-    const generation = (this.#lastGeneration.get(residentId) ?? 0) + 1;
-    this.#lastGeneration.set(residentId, generation);
-    const session = { residentId, generation, headId, context };
-    this.#active.set(residentId, session);
-    return session;
+  #mintWindowId(): string {
+    this.#windowSeq += 1;
+    return `window-${this.#windowSeq.toString(36).padStart(6, "0")}`;
   }
 
-  get(residentId: string): ActiveSession<TContext> | undefined {
-    return this.#active.get(residentId);
-  }
-
-  isActive(residentId: string): boolean {
-    return this.#active.has(residentId);
-  }
-
-  setHead(residentId: string, headId: string | null): void {
-    const session = this.#active.get(residentId);
-    if (session === undefined) {
-      throw new Error(`no active session for ${residentId}`);
+  /**
+   * 开一扇窗。同一 residentId 连开两次得到两扇不同的窗，各自 generation=1，
+   * 两窗皆活；旧语义「重复 open 原地换代」不再存在（MV-A01）。
+   * 给 windowId 时是按同一身份重开一扇已归档的窗，起新一代（#66 B5）。
+   */
+  open(residentId: string, options: OpenOptions<TContext>): ActiveWindow<TContext> {
+    const windowId = options.windowId ?? this.#mintWindowId();
+    if (this.#active.has(windowId)) {
+      throw new Error(`window ${windowId} is already active`);
     }
-    session.headId = headId;
+    const scopeId = options.scopeId ?? PRIVATE_SCOPE;
+    const generation = (this.#lastGeneration.get(windowId) ?? 0) + 1;
+    this.#lastGeneration.set(windowId, generation);
+    this.#archived.delete(windowId);
+    const window: ActiveWindow<TContext> = {
+      residentId,
+      windowId,
+      scopeId,
+      generation,
+      headId: options.headId ?? null,
+      context: options.context,
+    };
+    this.#active.set(windowId, window);
+    return window;
   }
 
-  issueDispatch(residentId: string): DispatchReceipt {
-    const session = this.#active.get(residentId);
-    if (session === undefined) {
-      throw new Error(`no active session for ${residentId}`);
-    }
+  get(windowId: string): ActiveWindow<TContext> | undefined {
+    return this.#active.get(windowId);
+  }
+
+  getArchived(windowId: string): ArchivedWindow | undefined {
+    return this.#archived.get(windowId);
+  }
+
+  isActive(windowId: string): boolean {
+    return this.#active.has(windowId);
+  }
+
+  isArchived(windowId: string): boolean {
+    return this.#archived.has(windowId);
+  }
+
+  /** 一位住户此刻的全部活窗。多开合法，所以这里返回的是列表而不是一格。 */
+  windowsOf(residentId: string): ActiveWindow<TContext>[] {
+    return [...this.#active.values()].filter((window) => window.residentId === residentId);
+  }
+
+  hasLiveWindow(residentId: string): boolean {
+    return this.windowsOf(residentId).length > 0;
+  }
+
+  #requireLive(windowId: string): ActiveWindow<TContext> {
+    const window = this.#active.get(windowId);
+    if (window !== undefined) return window;
+    if (this.#archived.has(windowId)) throw new WindowArchivedError(windowId);
+    throw new Error(`no active window ${windowId}`);
+  }
+
+  setHead(windowId: string, headId: string | null): void {
+    this.#requireLive(windowId).headId = headId;
+  }
+
+  issueDispatch(windowId: string): DispatchReceipt {
+    const window = this.#requireLive(windowId);
     this.#dispatchSeq += 1;
     return {
-      residentId,
-      generation: session.generation,
+      residentId: window.residentId,
+      windowId: window.windowId,
+      generation: window.generation,
       dispatchId: `dispatch-${this.#dispatchSeq.toString(36).padStart(6, "0")}`,
     };
   }
 
-  belongsToActiveSession(receipt: DispatchReceipt): boolean {
-    const session = this.#active.get(receipt.residentId);
-    return session !== undefined && session.generation === receipt.generation;
+  /**
+   * 回执归属按完整三元组判定：住户对得上、窗对得上、代际对得上，缺一不认。
+   * 两扇窗互相的迟到回执因此不会落到对方身上（MV-B01）。
+   */
+  belongsToActiveWindow(receipt: DispatchReceipt): boolean {
+    const window = this.#active.get(receipt.windowId);
+    return (
+      window !== undefined &&
+      window.residentId === receipt.residentId &&
+      window.generation === receipt.generation
+    );
   }
 
-  /** 幂等结束当前会话；住户不存在与否由总装侧的持久存储先行校验。 */
-  kill(residentId: string): void {
-    this.#active.delete(residentId);
+  /** 幂等归档一扇窗。归档后只读，写入返 WINDOW_ARCHIVED（MV-A03）。 */
+  kill(windowId: string): ArchivedWindow | undefined {
+    const window = this.#active.get(windowId);
+    if (window === undefined) return this.#archived.get(windowId);
+    this.#active.delete(windowId);
+    const archived: ArchivedWindow = {
+      residentId: window.residentId,
+      windowId: window.windowId,
+      scopeId: window.scopeId,
+      generation: window.generation,
+      headId: window.headId,
+      archived: true,
+    };
+    this.#archived.set(windowId, archived);
+    return archived;
+  }
+
+  /** 杀掉一位住户的全部活窗（MV-A03 后半）。 */
+  killResident(residentId: string): ArchivedWindow[] {
+    return this.windowsOf(residentId).map((window) => this.kill(window.windowId) as ArchivedWindow);
   }
 }

--- a/tests/fixtures/session-registry-host.ts
+++ b/tests/fixtures/session-registry-host.ts
@@ -1,0 +1,85 @@
+import { SessionRegistry } from "../../src/session/session-registry.ts";
+
+const sessions = new SessionRegistry<null>();
+
+type HostCommand = {
+  requestId: string;
+  op:
+    | "open"
+    | "get"
+    | "getArchived"
+    | "setHead"
+    | "issueDispatch"
+    | "belongs"
+    | "kill"
+    | "killResident"
+    | "stop";
+  residentId?: string;
+  windowId?: string;
+  scopeId?: string;
+  headId?: string | null;
+  receipt?: {
+    residentId: string;
+    windowId: string;
+    generation: number;
+    dispatchId: string;
+  };
+};
+
+function requireString(value: string | undefined, field: string): string {
+  if (value === undefined) throw new Error(`missing ${field}`);
+  return value;
+}
+
+function execute(command: HostCommand): unknown {
+  switch (command.op) {
+    case "open":
+      return sessions.open(requireString(command.residentId, "residentId"), {
+        context: null,
+        ...(command.scopeId === undefined ? {} : { scopeId: command.scopeId }),
+        ...(command.windowId === undefined ? {} : { windowId: command.windowId }),
+      });
+    case "get":
+      return sessions.get(requireString(command.windowId, "windowId"));
+    case "getArchived":
+      return sessions.getArchived(requireString(command.windowId, "windowId"));
+    case "setHead":
+      sessions.setHead(requireString(command.windowId, "windowId"), command.headId ?? null);
+      return null;
+    case "issueDispatch":
+      return sessions.issueDispatch(requireString(command.windowId, "windowId"));
+    case "belongs":
+      if (command.receipt === undefined) throw new Error("missing receipt");
+      return sessions.belongsToActiveWindow(command.receipt);
+    case "kill":
+      return sessions.kill(requireString(command.windowId, "windowId"));
+    case "killResident":
+      return sessions.killResident(requireString(command.residentId, "residentId"));
+    case "stop":
+      return null;
+  }
+}
+
+process.on("message", (raw) => {
+  const command = raw as HostCommand;
+  try {
+    const value = execute(command);
+    process.send?.({ requestId: command.requestId, ok: true, value });
+    if (command.op === "stop") setImmediate(() => process.exit(0));
+  } catch (error) {
+    process.send?.({
+      requestId: command.requestId,
+      ok: false,
+      error: {
+        name: error instanceof Error ? error.name : "Error",
+        message: error instanceof Error ? error.message : String(error),
+        code:
+          typeof error === "object" && error !== null && "code" in error
+            ? String(error.code)
+            : undefined,
+      },
+    });
+  }
+});
+
+process.send?.({ type: "ready", pid: process.pid });

--- a/tests/message-tree-service-adversarial.test.ts
+++ b/tests/message-tree-service-adversarial.test.ts
@@ -52,10 +52,10 @@ describe("多住户交错", () => {
     store.createRoom("a");
     store.createRoom("b");
 
-    const a1 = await service.say("a", "A 一");
-    const b1 = await service.say("b", "B 一");
-    const a2 = await service.say("a", "A 二");
-    const b2 = await service.say("b", "B 二");
+    const a1 = await service.say("a", "A 一", "a");
+    const b1 = await service.say("b", "B 一", "b");
+    const a2 = await service.say("a", "A 二", "a");
+    const b2 = await service.say("b", "B 二", "b");
 
     const treeA = await service.history("a");
     const treeB = await service.history("b");
@@ -87,7 +87,7 @@ describe("异步 responder", () => {
       },
     });
 
-    const reply = await slowService.say("a", "慢一点");
+    const reply = await slowService.say("a", "慢一点", "a");
     expect(calls).toStrictEqual([{ rid: "a", msg: "慢一点" }]);
     expect(reply.content).toBe("异步回：慢一点");
     expect((await slowService.history("a")).map((n) => n.content)).toStrictEqual([
@@ -101,17 +101,17 @@ describe("setHead 失败的落点", () => {
   it("双节点已落树后 setHead 抛错：错误上抛，树保持 append-only 不回滚，head 停在原地", async () => {
     const { store, heads, service } = setup();
     store.createRoom("a");
-    const first = await service.say("a", "第一轮");
+    const first = await service.say("a", "第一轮", "a");
 
     heads.failNextSet = true;
-    await expect(service.say("a", "第二轮")).rejects.toThrow("session registry unavailable");
+    await expect(service.say("a", "第二轮", "a")).rejects.toThrow("session registry unavailable");
 
     // append-only：已落的节点不因 head 失败而消失——树永不回滚
     const tree = await service.history("a");
     expect(tree).toHaveLength(4);
     // head 仍指第一轮 assistant，下一轮从旧 head 分叉而不是断链
     expect(heads.getHead("a")).toBe(first.id);
-    const third = await service.say("a", "第三轮");
+    const third = await service.say("a", "第三轮", "a");
     const thirdUser = (await service.history("a")).find(
       (n) => n.role === "user" && n.content === "第三轮",
     );
@@ -125,17 +125,17 @@ describe("service 出口的不透明性", () => {
     const { store, service } = setup();
     store.createRoom("a");
     store.createRoom("b");
-    const reply = await service.say("a", "A 的话");
+    const reply = await service.say("a", "A 的话", "a");
 
     let crossMessage = "";
     let missingMessage = "";
     try {
-      await service.reviseNode("b", reply.id, "越权");
+      await service.reviseNode("b", reply.id, "越权", "b");
     } catch (err) {
       crossMessage = (err as Error).message;
     }
     try {
-      await service.reviseNode("b", "never-existed", "改");
+      await service.reviseNode("b", "never-existed", "改", "b");
     } catch (err) {
       missingMessage = (err as Error).message;
     }
@@ -146,7 +146,7 @@ describe("service 出口的不透明性", () => {
   it("未知住户走 history / reviseNode 也被拒绝（say 之外的口同样不开门）", async () => {
     const { service } = setup();
     await expect(service.history("ghost")).rejects.toThrow();
-    await expect(service.reviseNode("ghost", "n1", "改")).rejects.toThrow();
+    await expect(service.reviseNode("ghost", "n1", "改", "ghost")).rejects.toThrow();
   });
 });
 
@@ -165,7 +165,7 @@ describe("失效 head 在 responder 前 fail-close", () => {
       },
     });
 
-    await expect(guardedService.say("a", "不会付模型成本")).rejects.toThrow(NODE_UNAVAILABLE);
+    await expect(guardedService.say("a", "不会付模型成本", "a")).rejects.toThrow(NODE_UNAVAILABLE);
     expect(responderCalls).toBe(0);
     expect(JSON.stringify(store.history("a"))).toBe(beforeTree);
     expect(heads.getHead("a")).toBe(beforeHead);
@@ -175,7 +175,7 @@ describe("失效 head 在 responder 前 fail-close", () => {
     const { store, heads, service } = setup();
     store.createRoom("a");
     store.createRoom("b");
-    const aReply = await service.say("a", "只属于 A");
+    const aReply = await service.say("a", "只属于 A", "a");
     heads.force("b", aReply.id);
     const beforeTreeA = JSON.stringify(store.history("a"));
     const beforeTreeB = JSON.stringify(store.history("b"));
@@ -189,7 +189,7 @@ describe("失效 head 在 responder 前 fail-close", () => {
       },
     });
 
-    await expect(guardedService.say("b", "不能跨房续写")).rejects.toThrow(NODE_UNAVAILABLE);
+    await expect(guardedService.say("b", "不能跨房续写", "b")).rejects.toThrow(NODE_UNAVAILABLE);
     expect(responderCalls).toBe(0);
     expect(JSON.stringify(store.history("a"))).toBe(beforeTreeA);
     expect(JSON.stringify(store.history("b"))).toBe(beforeTreeB);
@@ -202,12 +202,12 @@ describe("改口的角落", () => {
   it("对 user 节点改口：继承 user 角色，同父成兄弟", async () => {
     const { store, service } = setup();
     store.createRoom("a");
-    await service.say("a", "原问法");
+    await service.say("a", "原问法", "a");
     const userNode = (await service.history("a")).find((n) => n.role === "user");
     expect(userNode).toBeDefined();
     if (userNode === undefined) throw new Error("unreachable");
 
-    const revised = await service.reviseNode("a", userNode.id, "换个问法");
+    const revised = await service.reviseNode("a", userNode.id, "换个问法", "a");
     expect(revised.role).toBe("user");
     expect(revised.parentId).toBe(userNode.parentId);
     expect(revised.id).not.toBe(userNode.id);
@@ -216,11 +216,11 @@ describe("改口的角落", () => {
   it("同一节点二次改口：两个兄弟并存同父，旧节点始终不动", async () => {
     const { service, store } = setup();
     store.createRoom("a");
-    const reply = await service.say("a", "初稿");
+    const reply = await service.say("a", "初稿", "a");
     const snapshot = JSON.stringify((await service.history("a")).find((n) => n.id === reply.id));
 
-    const r1 = await service.reviseNode("a", reply.id, "第二版");
-    const r2 = await service.reviseNode("a", reply.id, "第三版");
+    const r1 = await service.reviseNode("a", reply.id, "第二版", "a");
+    const r2 = await service.reviseNode("a", reply.id, "第三版", "a");
     const tree = await service.history("a");
 
     expect(tree).toHaveLength(4);
@@ -233,15 +233,15 @@ describe("改口的角落", () => {
   it("user 改口也切 head：未重新生成便继续 say 时，有意形成 user 挂 user", async () => {
     const { service, store, heads } = setup();
     store.createRoom("a");
-    await service.say("a", "原问法");
+    await service.say("a", "原问法", "a");
     const originalUser = (await service.history("a")).find(
       (node) => node.role === "user" && node.content === "原问法",
     );
     expect(originalUser).toBeDefined();
     if (originalUser === undefined) throw new Error("unreachable");
 
-    const revisedUser = await service.reviseNode("a", originalUser.id, "修订后的问法");
-    const nextReply = await service.say("a", "不经重新生成，直接续话");
+    const revisedUser = await service.reviseNode("a", originalUser.id, "修订后的问法", "a");
+    const nextReply = await service.say("a", "不经重新生成，直接续话", "a");
     const nextUser = (await service.history("a")).find(
       (node) => node.role === "user" && node.content === "不经重新生成，直接续话",
     );

--- a/tests/message-tree-service-adversarial.test.ts
+++ b/tests/message-tree-service-adversarial.test.ts
@@ -16,20 +16,20 @@ class Heads implements SessionHeadPort {
   readonly #map = new Map<string, string>();
   failNextSet = false;
 
-  getHead(residentId: string): string | null {
-    return this.#map.get(residentId) ?? null;
+  getHead(windowId: string): string | null {
+    return this.#map.get(windowId) ?? null;
   }
 
-  setHead(residentId: string, headId: string): void {
+  setHead(windowId: string, headId: string): void {
     if (this.failNextSet) {
       this.failNextSet = false;
       throw new Error("session registry unavailable");
     }
-    this.#map.set(residentId, headId);
+    this.#map.set(windowId, headId);
   }
 
-  force(residentId: string, headId: string): void {
-    this.#map.set(residentId, headId);
+  force(windowId: string, headId: string): void {
+    this.#map.set(windowId, headId);
   }
 }
 

--- a/tests/message-tree-service.test.ts
+++ b/tests/message-tree-service.test.ts
@@ -53,7 +53,7 @@ describe("MessageTreeService.say", () => {
       expect(tree.some((node) => node.id === headId && node.role === "assistant")).toBe(true);
     };
 
-    const reply = await service.say("resident-a", "第一句");
+    const reply = await service.say("resident-a", "第一句", "resident-a");
     const tree = await service.history("resident-a");
 
     expect(tree).toEqual([
@@ -79,8 +79,8 @@ describe("MessageTreeService.say", () => {
 
   it("同一会话第二轮 user 挂在上一轮 assistant 下", async () => {
     const { heads, service } = setup();
-    const firstReply = await service.say("resident-a", "第一句");
-    const secondReply = await service.say("resident-a", "第二句");
+    const firstReply = await service.say("resident-a", "第一句", "resident-a");
+    const secondReply = await service.say("resident-a", "第二句", "resident-a");
     const tree = await service.history("resident-a");
     const secondUser = tree.find((node) => node.content === "第二句" && node.role === "user");
 
@@ -92,11 +92,11 @@ describe("MessageTreeService.say", () => {
 
   it("会话 head 被杀后，下一轮从新根开始且旧树不动", async () => {
     const { heads, service } = setup();
-    await service.say("resident-a", "旧会话");
+    await service.say("resident-a", "旧会话", "resident-a");
     const beforeKill = await service.history("resident-a");
 
     heads.kill("resident-a");
-    const newReply = await service.say("resident-a", "新会话");
+    const newReply = await service.say("resident-a", "新会话", "resident-a");
     const afterKill = await service.history("resident-a");
     const newUser = afterKill.find((node) => node.content === "新会话" && node.role === "user");
 
@@ -115,7 +115,7 @@ describe("MessageTreeService.say", () => {
       },
     });
 
-    await expect(service.say("resident-a", "不会落库")).rejects.toThrow("model unavailable");
+    await expect(service.say("resident-a", "不会落库", "resident-a")).rejects.toThrow("model unavailable");
     expect(store.history("resident-a")).toEqual([]);
     expect(heads.writes).toEqual([]);
   });
@@ -131,7 +131,7 @@ describe("MessageTreeService.say", () => {
       },
     });
 
-    await expect(service.say("ghost", "不会进 responder")).rejects.toThrow();
+    await expect(service.say("ghost", "不会进 responder", "ghost")).rejects.toThrow();
     expect(responderCalls).toBe(0);
     expect(heads.writes).toEqual([]);
   });
@@ -140,7 +140,7 @@ describe("MessageTreeService.say", () => {
     const { store, heads, service } = setup();
     heads.force("resident-a", "missing-parent");
 
-    await expect(service.say("resident-a", "不能悬空")).rejects.toThrow();
+    await expect(service.say("resident-a", "不能悬空", "resident-a")).rejects.toThrow();
     expect(store.history("resident-a")).toEqual([]);
     expect(heads.getHead("resident-a")).toBe("missing-parent");
     expect(heads.writes).toEqual([]);
@@ -148,8 +148,8 @@ describe("MessageTreeService.say", () => {
 
   it("相同正文的两轮仍各自落完整节点，不按内容去重", async () => {
     const { service } = setup();
-    await service.say("resident-a", "重复");
-    await service.say("resident-a", "重复");
+    await service.say("resident-a", "重复", "resident-a");
+    await service.say("resident-a", "重复", "resident-a");
 
     const tree = await service.history("resident-a");
     expect(tree).toHaveLength(4);
@@ -159,7 +159,7 @@ describe("MessageTreeService.say", () => {
 
   it("修改 say/history 返回对象不能篡改 Store 原件", async () => {
     const { service } = setup();
-    const reply = await service.say("resident-a", "原文");
+    const reply = await service.say("resident-a", "原文", "resident-a");
     const before = await service.history("resident-a");
     const first = before[0];
     if (first === undefined) {
@@ -180,7 +180,7 @@ describe("MessageTreeService.say", () => {
 describe("MessageTreeService.reviseNode", () => {
   it("只新增同父同角色兄弟，旧节点完整不变", async () => {
     const { service } = setup();
-    const reply = await service.say("resident-a", "初稿");
+    const reply = await service.say("resident-a", "初稿", "resident-a");
     const before = await service.history("resident-a");
     const old = before.find((node) => node.id === reply.id);
     if (old === undefined) {
@@ -188,7 +188,7 @@ describe("MessageTreeService.reviseNode", () => {
     }
     const oldBefore = structuredClone(old);
 
-    const revised = await service.reviseNode("resident-a", reply.id, "改口");
+    const revised = await service.reviseNode("resident-a", reply.id, "改口", "resident-a");
     const after = await service.history("resident-a");
 
     expect(after).toHaveLength(before.length + 1);
@@ -204,20 +204,20 @@ describe("MessageTreeService.reviseNode", () => {
   it("跨房节点拒绝且两房零写入", async () => {
     const { store, service } = setup();
     store.createRoom("resident-b");
-    const reply = await service.say("resident-a", "只属于 A");
+    const reply = await service.say("resident-a", "只属于 A", "resident-a");
     const beforeA = store.history("resident-a");
     const beforeB = store.history("resident-b");
 
-    await expect(service.reviseNode("resident-b", reply.id, "越权")).rejects.toThrow();
+    await expect(service.reviseNode("resident-b", reply.id, "越权", "resident-b")).rejects.toThrow();
     expect(store.history("resident-a")).toEqual(beforeA);
     expect(store.history("resident-b")).toEqual(beforeB);
   });
 
   it("assistant 改口即换枝：下一轮 user 挂在新兄弟下", async () => {
     const { heads, service } = setup();
-    const reply = await service.say("resident-a", "初稿");
-    const revised = await service.reviseNode("resident-a", reply.id, "改口");
-    const nextReply = await service.say("resident-a", "沿新枝继续");
+    const reply = await service.say("resident-a", "初稿", "resident-a");
+    const revised = await service.reviseNode("resident-a", reply.id, "改口", "resident-a");
+    const nextReply = await service.say("resident-a", "沿新枝继续", "resident-a");
     const nextUser = (await service.history("resident-a")).find(
       (node) => node.role === "user" && node.content === "沿新枝继续",
     );

--- a/tests/message-tree-service.test.ts
+++ b/tests/message-tree-service.test.ts
@@ -4,25 +4,25 @@ import type { SessionHeadPort } from "../src/message-tree/index.ts";
 
 class TestSessionHeads implements SessionHeadPort {
   readonly #heads = new Map<string, string>();
-  readonly writes: Array<{ residentId: string; headId: string }> = [];
-  beforeSet?: (residentId: string, headId: string) => void;
+  readonly writes: Array<{ windowId: string; headId: string }> = [];
+  beforeSet?: (windowId: string, headId: string) => void;
 
-  getHead(residentId: string): string | null {
-    return this.#heads.get(residentId) ?? null;
+  getHead(windowId: string): string | null {
+    return this.#heads.get(windowId) ?? null;
   }
 
-  setHead(residentId: string, headId: string): void {
-    this.beforeSet?.(residentId, headId);
-    this.#heads.set(residentId, headId);
-    this.writes.push({ residentId, headId });
+  setHead(windowId: string, headId: string): void {
+    this.beforeSet?.(windowId, headId);
+    this.#heads.set(windowId, headId);
+    this.writes.push({ windowId, headId });
   }
 
-  kill(residentId: string): void {
-    this.#heads.delete(residentId);
+  kill(windowId: string): void {
+    this.#heads.delete(windowId);
   }
 
-  force(residentId: string, headId: string): void {
-    this.#heads.set(residentId, headId);
+  force(windowId: string, headId: string): void {
+    this.#heads.set(windowId, headId);
   }
 }
 
@@ -47,7 +47,7 @@ function setup() {
 describe("MessageTreeService.say", () => {
   it("首轮原子落双节点，全部落完后才把 head 指向 assistant", async () => {
     const { store, heads, service } = setup();
-    heads.beforeSet = (_residentId, headId) => {
+    heads.beforeSet = (_windowId, headId) => {
       const tree = store.history("resident-a");
       expect(tree).toHaveLength(2);
       expect(tree.some((node) => node.id === headId && node.role === "assistant")).toBe(true);
@@ -74,7 +74,7 @@ describe("MessageTreeService.say", () => {
     ]);
     expect(reply).toEqual(tree[1]);
     expect(heads.getHead("resident-a")).toBe(reply.id);
-    expect(heads.writes).toEqual([{ residentId: "resident-a", headId: reply.id }]);
+    expect(heads.writes).toEqual([{ windowId: "resident-a", headId: reply.id }]);
   });
 
   it("同一会话第二轮 user 挂在上一轮 assistant 下", async () => {

--- a/tests/message-tree-service.test.ts
+++ b/tests/message-tree-service.test.ts
@@ -115,7 +115,9 @@ describe("MessageTreeService.say", () => {
       },
     });
 
-    await expect(service.say("resident-a", "不会落库", "resident-a")).rejects.toThrow("model unavailable");
+    await expect(service.say("resident-a", "不会落库", "resident-a")).rejects.toThrow(
+      "model unavailable",
+    );
     expect(store.history("resident-a")).toEqual([]);
     expect(heads.writes).toEqual([]);
   });
@@ -208,7 +210,9 @@ describe("MessageTreeService.reviseNode", () => {
     const beforeA = store.history("resident-a");
     const beforeB = store.history("resident-b");
 
-    await expect(service.reviseNode("resident-b", reply.id, "越权", "resident-b")).rejects.toThrow();
+    await expect(
+      service.reviseNode("resident-b", reply.id, "越权", "resident-b"),
+    ).rejects.toThrow();
     expect(store.history("resident-a")).toEqual(beforeA);
     expect(store.history("resident-b")).toEqual(beforeB);
   });

--- a/tests/multi-viewport-host.test.ts
+++ b/tests/multi-viewport-host.test.ts
@@ -1,0 +1,176 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+type HostReply = {
+  requestId?: string;
+  type?: string;
+  pid?: number;
+  ok?: boolean;
+  value?: unknown;
+  error?: { name?: string; message?: string; code?: string };
+};
+
+type WindowRecord = {
+  residentId: string;
+  windowId: string;
+  scopeId: string;
+  generation: number;
+  headId: string | null;
+};
+
+type Receipt = {
+  residentId: string;
+  windowId: string;
+  generation: number;
+  dispatchId: string;
+};
+
+const children: ChildProcess[] = [];
+const fixture = fileURLToPath(new URL("./fixtures/session-registry-host.ts", import.meta.url));
+
+function startHost(): ChildProcess {
+  const child = spawn(process.execPath, ["--import", "tsx", fixture], {
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.push(child);
+  return child;
+}
+
+function waitForReady(child: ChildProcess): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let stderr = "";
+    const timer = setTimeout(() => reject(new Error(`host startup timed out: ${stderr}`)), 10_000);
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    }
+    function onMessage(message: HostReply) {
+      if (message.type !== "ready" || typeof message.pid !== "number") return;
+      cleanup();
+      resolve(message.pid);
+    }
+    function onExit(code: number | null) {
+      cleanup();
+      reject(new Error(`host exited ${String(code)} before ready: ${stderr}`));
+    }
+  });
+}
+
+let requestSeq = 0;
+function callHost<T>(child: ChildProcess, command: Record<string, unknown>): Promise<T> {
+  requestSeq += 1;
+  const requestId = `request-${requestSeq}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`host request timed out: ${requestId}`)),
+      5_000,
+    );
+    child.on("message", onMessage);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+    }
+    function onMessage(message: HostReply) {
+      if (message.requestId !== requestId) return;
+      cleanup();
+      if (message.ok === true) {
+        resolve(message.value as T);
+      } else {
+        reject(
+          new Error(`${message.error?.code ?? message.error?.name}: ${message.error?.message}`),
+        );
+      }
+    }
+
+    child.send?.({ ...command, requestId }, (error) => {
+      if (error === null) return;
+      cleanup();
+      reject(error);
+    });
+  });
+}
+
+async function stopHost(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  await callHost(child, { op: "stop" });
+  await exited;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    children.splice(0).map(async (child) => {
+      try {
+        await stopHost(child);
+      } catch {
+        child.kill();
+      }
+    }),
+  );
+});
+
+describe("multi-viewport real host subprocess", () => {
+  it("opens two windows, kills and reopens one generation, and keeps the other live", async () => {
+    const child = startHost();
+    const pid = await waitForReady(child);
+    expect(pid).toBe(child.pid);
+
+    const w1 = await callHost<WindowRecord>(child, {
+      op: "open",
+      residentId: "resident-a",
+      scopeId: "room-1",
+    });
+    const w2 = await callHost<WindowRecord>(child, {
+      op: "open",
+      residentId: "resident-a",
+      scopeId: "room-1",
+    });
+    expect(w1.windowId).not.toBe(w2.windowId);
+    expect([w1.generation, w2.generation]).toEqual([1, 1]);
+
+    await callHost(child, { op: "setHead", windowId: w1.windowId, headId: "node-w1" });
+    await callHost(child, { op: "setHead", windowId: w2.windowId, headId: "node-w2" });
+    const r1 = await callHost<Receipt>(child, { op: "issueDispatch", windowId: w1.windowId });
+    const r2 = await callHost<Receipt>(child, { op: "issueDispatch", windowId: w2.windowId });
+
+    const firstArchive = await callHost(child, { op: "kill", windowId: w1.windowId });
+    const secondArchive = await callHost(child, { op: "kill", windowId: w1.windowId });
+    expect(secondArchive).toEqual(firstArchive);
+    expect(await callHost(child, { op: "belongs", receipt: r1 })).toBe(false);
+    expect(await callHost(child, { op: "belongs", receipt: r2 })).toBe(true);
+    expect(await callHost<WindowRecord>(child, { op: "get", windowId: w2.windowId })).toMatchObject(
+      {
+        headId: "node-w2",
+        generation: 1,
+      },
+    );
+
+    const reopened = await callHost<WindowRecord>(child, {
+      op: "open",
+      residentId: "resident-a",
+      scopeId: "room-1",
+      windowId: w1.windowId,
+    });
+    expect(reopened.generation).toBe(2);
+    expect(await callHost(child, { op: "belongs", receipt: r1 })).toBe(false);
+
+    const killed = await callHost<WindowRecord[]>(child, {
+      op: "killResident",
+      residentId: "resident-a",
+    });
+    expect(killed.map((window) => window.windowId).sort()).toEqual(
+      [w1.windowId, w2.windowId].sort(),
+    );
+    await stopHost(child);
+  });
+});

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -24,7 +24,9 @@ describe("SessionRegistry：多窗语义", () => {
     const sessions = new SessionRegistry<null>();
 
     expect(sessions.open("resident-a", { context: null }).scopeId).toBe(PRIVATE_SCOPE);
-    expect(sessions.open("resident-a", { scopeId: "room-1", context: null }).scopeId).toBe("room-1");
+    expect(sessions.open("resident-a", { scopeId: "room-1", context: null }).scopeId).toBe(
+      "room-1",
+    );
   });
 
   it("MV-A03 kill 幂等，归档后只读，写入返 WINDOW_ARCHIVED", () => {
@@ -64,7 +66,12 @@ describe("SessionRegistry：多窗语义", () => {
     expect(reopened.generation).toBe(2);
     expect(fresh.generation).toBe(1);
     expect(sessions).not.toHaveProperty("currentGeneration");
-    expect(sessions.windowsOf("resident-a").map((w) => w.generation).sort()).toEqual([1, 2]);
+    expect(
+      sessions
+        .windowsOf("resident-a")
+        .map((w) => w.generation)
+        .sort(),
+    ).toEqual([1, 2]);
   });
 
   it("会话态归零不动住户留下的东西", () => {
@@ -76,7 +83,10 @@ describe("SessionRegistry：多窗语义", () => {
     const before = structuredClone(residentState);
     const sessions = new SessionRegistry<{ pending: string[] }>();
 
-    const w1 = sessions.open("resident-a", { headId: "node-2", context: { pending: ["还没落库的话"] } });
+    const w1 = sessions.open("resident-a", {
+      headId: "node-2",
+      context: { pending: ["还没落库的话"] },
+    });
     sessions.kill(w1.windowId);
 
     expect(sessions.get(w1.windowId)).toBeUndefined();

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -3,6 +3,7 @@ import {
   PRIVATE_SCOPE,
   SessionRegistry,
   WINDOW_ARCHIVED,
+  WINDOW_REOPEN_INVALID,
 } from "../src/session/session-registry.ts";
 
 describe("SessionRegistry：多窗语义", () => {
@@ -72,6 +73,51 @@ describe("SessionRegistry：多窗语义", () => {
         .map((w) => w.generation)
         .sort(),
     ).toEqual([1, 2]);
+  });
+
+  it("显式 windowId 只能重开已归档窗，未知 id fail loud 且不污染内部发号", () => {
+    const sessions = new SessionRegistry<null>();
+
+    expect(() => sessions.open("resident-a", { windowId: "window-000001", context: null })).toThrow(
+      WINDOW_REOPEN_INVALID,
+    );
+
+    const fresh = sessions.open("resident-a", { context: null });
+    expect(fresh.windowId).toBe("window-000001");
+    expect(fresh.generation).toBe(1);
+  });
+
+  it("归档窗不能被另一住户抢注，拒绝后原住户仍可按原 scope 重开", () => {
+    const sessions = new SessionRegistry<null>();
+    const archived = sessions.open("resident-a", { scopeId: "room-1", context: null });
+    sessions.kill(archived.windowId);
+
+    expect(() =>
+      sessions.open("resident-b", {
+        windowId: archived.windowId,
+        scopeId: "room-1",
+        context: null,
+      }),
+    ).toThrow(/resident mismatch/);
+    expect(sessions.isArchived(archived.windowId)).toBe(true);
+
+    const reopened = sessions.open("resident-a", {
+      windowId: archived.windowId,
+      scopeId: "room-1",
+      context: null,
+    });
+    expect(reopened.generation).toBe(2);
+  });
+
+  it("归档窗只能按原 scope 重开，scope 不一致显式拒绝", () => {
+    const sessions = new SessionRegistry<null>();
+    const archived = sessions.open("resident-a", { scopeId: "room-1", context: null });
+    sessions.kill(archived.windowId);
+
+    expect(() =>
+      sessions.open("resident-a", { windowId: archived.windowId, context: null }),
+    ).toThrow(/scope mismatch/);
+    expect(sessions.isArchived(archived.windowId)).toBe(true);
   });
 
   it("会话态归零不动住户留下的东西", () => {

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -1,8 +1,73 @@
 import { describe, expect, it } from "vitest";
-import { SessionRegistry } from "../src/session/session-registry.ts";
+import {
+  PRIVATE_SCOPE,
+  SessionRegistry,
+  WINDOW_ARCHIVED,
+} from "../src/session/session-registry.ts";
 
-describe("SessionRegistry", () => {
-  it("kills the live pointer and in-flight context without touching resident state", () => {
+describe("SessionRegistry：多窗语义", () => {
+  it("MV-A01 同一住户同一 scope 连开两次得到两扇活窗，各自 generation=1", () => {
+    const sessions = new SessionRegistry<null>();
+
+    const w1 = sessions.open("resident-a", { context: null });
+    const w2 = sessions.open("resident-a", { context: null });
+
+    expect(w1.windowId).not.toBe(w2.windowId);
+    expect(w1.generation).toBe(1);
+    expect(w2.generation).toBe(1);
+    expect(sessions.isActive(w1.windowId)).toBe(true);
+    expect(sessions.isActive(w2.windowId)).toBe(true);
+    expect(sessions.windowsOf("resident-a")).toHaveLength(2);
+  });
+
+  it("MV-A04 缺省 scope 落私聊，不落全局", () => {
+    const sessions = new SessionRegistry<null>();
+
+    expect(sessions.open("resident-a", { context: null }).scopeId).toBe(PRIVATE_SCOPE);
+    expect(sessions.open("resident-a", { scopeId: "room-1", context: null }).scopeId).toBe("room-1");
+  });
+
+  it("MV-A03 kill 幂等，归档后只读，写入返 WINDOW_ARCHIVED", () => {
+    const sessions = new SessionRegistry<null>();
+    const w1 = sessions.open("resident-a", { headId: "node-1", context: null });
+
+    const first = sessions.kill(w1.windowId);
+    const second = sessions.kill(w1.windowId);
+
+    expect(first).toEqual(second);
+    expect(sessions.isActive(w1.windowId)).toBe(false);
+    expect(sessions.getArchived(w1.windowId)).toMatchObject({ archived: true, headId: "node-1" });
+    expect(() => sessions.setHead(w1.windowId, "node-2")).toThrow(WINDOW_ARCHIVED);
+    expect(() => sessions.issueDispatch(w1.windowId)).toThrow(WINDOW_ARCHIVED);
+  });
+
+  it("MV-A03 killResident 杀掉该住户全部活窗，不碰别人", () => {
+    const sessions = new SessionRegistry<null>();
+    const a1 = sessions.open("resident-a", { context: null });
+    const a2 = sessions.open("resident-a", { context: null });
+    const b1 = sessions.open("resident-b", { context: null });
+
+    expect(sessions.killResident("resident-a")).toHaveLength(2);
+
+    expect(sessions.isActive(a1.windowId)).toBe(false);
+    expect(sessions.isActive(a2.windowId)).toBe(false);
+    expect(sessions.isActive(b1.windowId)).toBe(true);
+  });
+
+  it("MV-B02 代际归窗，住户级问不出「当前代际」", () => {
+    const sessions = new SessionRegistry<null>();
+    const w1 = sessions.open("resident-a", { context: null });
+    sessions.kill(w1.windowId);
+    const reopened = sessions.open("resident-a", { windowId: w1.windowId, context: null });
+    const fresh = sessions.open("resident-a", { context: null });
+
+    expect(reopened.generation).toBe(2);
+    expect(fresh.generation).toBe(1);
+    expect(sessions).not.toHaveProperty("currentGeneration");
+    expect(sessions.windowsOf("resident-a").map((w) => w.generation).sort()).toEqual([1, 2]);
+  });
+
+  it("会话态归零不动住户留下的东西", () => {
     const residentState = {
       memories: ["答应过：周五晚上一起看电影"],
       messages: ["记住这件事"],
@@ -11,72 +76,87 @@ describe("SessionRegistry", () => {
     const before = structuredClone(residentState);
     const sessions = new SessionRegistry<{ pending: string[] }>();
 
-    sessions.open("resident-a", "node-2", { pending: ["还没落库的话"] });
-    sessions.kill("resident-a");
+    const w1 = sessions.open("resident-a", { headId: "node-2", context: { pending: ["还没落库的话"] } });
+    sessions.kill(w1.windowId);
 
-    expect(sessions.get("resident-a")).toBeUndefined();
+    expect(sessions.get(w1.windowId)).toBeUndefined();
     expect(residentState).toEqual(before);
   });
+});
 
-  it("is idempotent when the same session is killed twice", () => {
-    const sessions = new SessionRegistry<Record<string, never>>();
-    sessions.open("resident-a", null, {});
-
-    sessions.kill("resident-a");
-    expect(() => sessions.kill("resident-a")).not.toThrow();
-    expect(sessions.isActive("resident-a")).toBe(false);
-  });
-
-  it("does not kill another resident's live session", () => {
-    const sessions = new SessionRegistry<string[]>();
-    sessions.open("resident-a", "node-a", ["a"]);
-    sessions.open("resident-b", "node-b", ["b"]);
-
-    sessions.kill("resident-a");
-
-    expect(sessions.isActive("resident-a")).toBe(false);
-    expect(sessions.get("resident-b")).toEqual({
-      residentId: "resident-b",
-      generation: 1,
-      headId: "node-b",
-      context: ["b"],
-    });
-  });
-
-  it("advances the head inside one active generation", () => {
+describe("SessionRegistry：贯穿场景（A01/A02/A03/B01/B02/B03 一口咬住）", () => {
+  it("杀掉 w1 之后 w2 继续，w1 的迟到回执不落到 w2 身上", () => {
     const sessions = new SessionRegistry<null>();
-    const session = sessions.open("resident-a", null, null);
+    const w1 = sessions.open("resident-a", { context: null });
+    const w2 = sessions.open("resident-a", { context: null });
 
-    sessions.setHead("resident-a", "reply-1");
+    const r1 = sessions.issueDispatch(w1.windowId);
+    const r2 = sessions.issueDispatch(w2.windowId);
 
-    expect(sessions.get("resident-a")).toEqual({
-      ...session,
-      headId: "reply-1",
-    });
+    // 三元组齐全（MV-B03 的日志字段来源）
+    for (const receipt of [r1, r2]) {
+      expect(receipt).toMatchObject({ residentId: "resident-a" });
+      expect(receipt.windowId).toBeTruthy();
+      expect(receipt.generation).toBe(1);
+      expect(receipt.dispatchId).toBeTruthy();
+    }
+    expect(r1.windowId).not.toBe(r2.windowId);
+
+    sessions.kill(w1.windowId);
+
+    // w1 的迟到回执不再属于任何活窗。
+    // 这一条同时是「回到 residentId 单键查找」的回归闸：r1 的 residentId 与
+    // generation 都和 w2 相同（同住户、同为第 1 代），旧实现按 residentId 查
+    // 就会把它认成 w2 的回执；只有按 windowId 查才判得出来。
+    expect(r1.residentId).toBe(w2.residentId);
+    expect(r1.generation).toBe(w2.generation);
+    expect(sessions.belongsToActiveWindow(r1)).toBe(false);
+
+    // w2 完全不受影响——这一步是 MV-A02 的真正判据
+    expect(sessions.isActive(w2.windowId)).toBe(true);
+    expect(sessions.belongsToActiveWindow(r2)).toBe(true);
+    sessions.setHead(w2.windowId, "reply-1");
+    expect(sessions.get(w2.windowId)?.headId).toBe("reply-1");
+    expect(sessions.issueDispatch(w2.windowId).generation).toBe(1);
   });
 
-  it("rejects setting a head when no session is active", () => {
+  it("同窗换代后旧代回执被丢弃", () => {
     const sessions = new SessionRegistry<null>();
+    const w = sessions.open("resident-a", { context: null });
+    const stale = sessions.issueDispatch(w.windowId);
 
-    expect(() => sessions.setHead("resident-a", "reply-1")).toThrow(/no active session/);
+    sessions.kill(w.windowId);
+    const reopened = sessions.open("resident-a", { windowId: w.windowId, context: null });
+
+    expect(reopened.generation).toBe(2);
+    expect(sessions.belongsToActiveWindow(stale)).toBe(false);
+    expect(sessions.belongsToActiveWindow(sessions.issueDispatch(w.windowId))).toBe(true);
   });
 
-  it("marks stale dispatch receipts as not belonging to the active session after kill", () => {
+  it("同住户两窗各有各的 head，杀掉一扇不改另一扇（MV-A02 的 head 面）", () => {
     const sessions = new SessionRegistry<null>();
-    sessions.open("resident-a", null, null);
-    const stale = sessions.issueDispatch("resident-a");
+    const w1 = sessions.open("resident-a", { context: null });
+    const w2 = sessions.open("resident-a", { context: null });
 
-    sessions.kill("resident-a");
-    sessions.open("resident-a", null, null);
+    sessions.setHead(w1.windowId, "node-w1");
+    sessions.setHead(w2.windowId, "node-w2");
+    expect(sessions.get(w1.windowId)?.headId).toBe("node-w1");
+    expect(sessions.get(w2.windowId)?.headId).toBe("node-w2");
 
-    expect(sessions.belongsToActiveSession(stale)).toBe(false);
+    sessions.kill(w1.windowId);
+
+    // 共用一颗 head 的旧实现里，w1 的死会把 w2 的续话位置一起带走。
+    expect(sessions.get(w2.windowId)?.headId).toBe("node-w2");
+    expect(sessions.getArchived(w1.windowId)?.headId).toBe("node-w1");
   });
 
-  it("keeps current-generation dispatch receipts valid while the session is still active", () => {
+  it("回执三元组缺一不认：住户对不上也不算数", () => {
     const sessions = new SessionRegistry<null>();
-    sessions.open("resident-a", null, null);
-    const receipt = sessions.issueDispatch("resident-a");
+    const w = sessions.open("resident-a", { context: null });
+    const receipt = sessions.issueDispatch(w.windowId);
 
-    expect(sessions.belongsToActiveSession(receipt)).toBe(true);
+    expect(sessions.belongsToActiveWindow({ ...receipt, residentId: "resident-b" })).toBe(false);
+    expect(sessions.belongsToActiveWindow({ ...receipt, generation: 99 })).toBe(false);
+    expect(sessions.belongsToActiveWindow(receipt)).toBe(true);
   });
 });


### PR DESCRIPTION
## What this lands

Implements lane 1 of #79:

- multiple live windows per `(residentId, scopeId)`; `open` no longer replaces the previous session;
- generation and head ownership move to `windowId`;
- idempotent window archival, append-only JSONL persistence, restart recovery, and resident-wide kill;
- private scope as the default;
- dispatch receipts and active-session checks use `(residentId, windowId, generation)`;
- message-tree and acceptance-driver callers carry the window explicitly;
- reopening with an explicit `windowId` is fail-loud unless it names an archived window with the same resident and scope;
- archived windows fail before message-tree mutation on both `say` and `reviseNode`.

## Acceptance status

Evidence present for lane-owner re-check:

- [x] MV-A01 multi-open is legal
- [x] MV-A02 implicit single-window assumptions removed
- [x] MV-A03 idempotent kill, read-only archive, append-only persistence, restart recovery
- [x] MV-A04 default scope is private
- [x] MV-B01 receipt ownership is window-scoped
- [x] MV-B02 no resident-level current-generation API

Still partial and tracked in #79:

- [ ] MV-B03: `DispatchReceipt` carries the full `(residentId, windowId, generation)` tuple, but end-to-end assertions for dispatch / receipt / drop log events remain for the #85 follow-up wiring PR. This PR does not mark that half green and does not close #79.

## Real-host-subprocess evidence

`tests/multi-viewport-host.test.ts` plus `tests/fixtures/session-registry-host.ts` start a real Node child that loads the production `SessionRegistry`. The parent drives it over IPC to:

- open two same-resident/same-scope windows;
- set independent heads and issue independent receipts;
- kill one window idempotently while the other remains live;
- reject the killed window's late receipt;
- archive the remaining live windows;
- stop the process, start a new process against the same JSONL path, recover both archives, and reopen one as generation 2.

The fixture remains extensible for the later SIGKILL injection required by MV-D07/C integration; this PR proves cooperative stop → restart recovery and does not claim the future crash-injection check.

## Review fixes

### F1: explicit windowId validation

Explicit `windowId` no longer creates an arbitrary window. Reopen requires an archived record with the exact id, residentId, and scopeId. All mismatches fail with `WINDOW_REOPEN_INVALID` before generation or archive state changes. Tests cover unknown ids, cross-resident takeover, scope mismatch, intact archives after rejection, legitimate generation-2 reopen, and an external `window-000001` not poisoning the internal issuer.

### F2: MV-A02 static audit

Search surface: `src/` and `tests/`; anchors included `residentId`, `SessionRegistry`, `issueDispatch`, `belongsToActiveWindow`, `isActive`, `setHead`, and kill paths.

Changed single-window assumptions:

- `SessionRegistry.#active`: resident-keyed single slot → windowId-keyed live windows;
- resident-level generation → `#lastGeneration` keyed by windowId;
- `open/get/isActive/getHead/setHead/issueDispatch/kill`: window-explicit semantics;
- `DispatchReceipt` and membership checks: full `(residentId, windowId, generation)` tuple;
- `SessionHeadPort` and `MessageTreeService.say/reviseNode`: head lookup and movement keyed by windowId;
- test head adapters renamed to windowId so the old resident-keyed seam does not survive as misleading evidence.

Deliberately retained resident-keyed sites:

- `MistDriver.#driverWindows: Map<residentId, windowId>` is a client-owned explicit binding for that driver instance; it chooses its own window and does not ask the registry for a unique resident-level current session;
- `windowsOf(residentId)` and `killResident(residentId)` intentionally enumerate or operate on all windows for a resident;
- `ResidentStore` and `MessageTreeStore` remain resident-keyed because they store durable person/room state, not live-window state.

### F3: durable archive

`SessionRegistry({ archivePath })` restores append-only `window_archived` JSONL records and rebuilds per-window generation state. `kill` appends the archive record before mutating memory, so an append failure cannot leave a live window falsely reported as archived. Corrupt JSONL and non-increasing generations fail loud on startup. Active windows are intentionally not revived.

### F4: archived-head fail-closed

`SessionRegistry.getHead(windowId)` uses the same live-window guard as writes. The acceptance-driver port now calls it. `MessageTreeService.reviseNode` also validates the window before appending a sibling. Tests prove archived-window `say` and `reviseNode` both throw `WINDOW_ARCHIVED` without changing the tree.

## Verification

At commit `08d0f6d`:

- `npx vitest run` → 27 files, 233 tests passed
- `npx tsc --noEmit -p tsconfig.json` → passed
- `npx biome check .` → 64 files checked, 0 errors
- `git diff --check` → passed

The unrelated untracked `docs/design/intentional-isolation/` working tree is not included.

Tracks #79; it must remain open for the MV-B03 integration half.
