### PR TITLE
fix(session): persist window archives across restart

### DIFF
--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -70,7 +70,7 @@ class MistDriver implements HarnessDriver {
     this.#messageTree = new MessageTreeService(
       this.#messageTreeStore,
       {
-        getHead: (windowId) => this.#sessions.get(windowId)?.headId ?? null,
+        getHead: (windowId) => this.#sessions.getHead(windowId),
         setHead: (windowId, headId) => this.#sessions.setHead(windowId, headId),
       } satisfies SessionHeadPort,
       { assistantReply: options.reply ?? ((_residentId, message) => `收到：${message}`) },

--- a/src/message-tree/service.ts
+++ b/src/message-tree/service.ts
@@ -71,6 +71,8 @@ export class MessageTreeService {
     newContent: string,
     windowId: string,
   ): Promise<HistoryNode> {
+    // 读侧先验证窗仍可写；归档窗不能先落一条 sibling 再在 setHead 时才失败。
+    this.#sessionHeads.getHead(windowId);
     const revised = this.#store.appendSibling(residentId, nodeId, newContent);
     // #14 二轮 + 认领人延伸裁定：改口即换枝，assistant/user 一视同仁，
     // active head 都切到新兄弟。若改的是 user 且未重新生成便继续 say，下一棵

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -1,3 +1,6 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+
 /**
  * 活窗（viewport）的临时状态。
  *
@@ -72,13 +75,99 @@ export interface OpenOptions<TContext> {
   windowId?: string;
 }
 
+export interface SessionRegistryOptions {
+  /**
+   * 窗归档的 append-only JSONL。只保存已归档窗，不保存或复活活窗。
+   * 不给路径时保持纯内存，供无持久化需求的嵌入方与单测使用。
+   */
+  archivePath?: string;
+}
+
+interface ArchivedWindowRecord {
+  schemaVersion: 1;
+  type: "window_archived";
+  window: ArchivedWindow;
+}
+
+function parseArchivedWindowRecord(line: string, lineNumber: number): ArchivedWindow {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    throw new Error(`invalid window archive JSONL at line ${lineNumber}`);
+  }
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`invalid window archive record at line ${lineNumber}`);
+  }
+  const record = value as Partial<ArchivedWindowRecord>;
+  if (record.schemaVersion !== 1 || record.type !== "window_archived") {
+    throw new Error(`unsupported window archive record at line ${lineNumber}`);
+  }
+  const window = record.window;
+  if (
+    typeof window !== "object" ||
+    window === null ||
+    typeof window.residentId !== "string" ||
+    window.residentId.length === 0 ||
+    typeof window.windowId !== "string" ||
+    window.windowId.length === 0 ||
+    typeof window.scopeId !== "string" ||
+    window.scopeId.length === 0 ||
+    !Number.isInteger(window.generation) ||
+    window.generation < 1 ||
+    (window.headId !== null && typeof window.headId !== "string") ||
+    window.archived !== true
+  ) {
+    throw new Error(`invalid window archive payload at line ${lineNumber}`);
+  }
+  return {
+    residentId: window.residentId,
+    windowId: window.windowId,
+    scopeId: window.scopeId,
+    generation: window.generation,
+    headId: window.headId,
+    archived: true,
+  };
+}
+
 export class SessionRegistry<TContext> {
   readonly #active = new Map<string, ActiveWindow<TContext>>();
   readonly #archived = new Map<string, ArchivedWindow>();
   /** 代际归窗：windowId -> 上一次用过的代际号。 */
   readonly #lastGeneration = new Map<string, number>();
+  readonly #archivePath: string | undefined;
   #windowSeq = 0;
   #dispatchSeq = 0;
+
+  constructor(options: SessionRegistryOptions = {}) {
+    this.#archivePath = options.archivePath;
+    if (this.#archivePath === undefined) return;
+    mkdirSync(dirname(this.#archivePath), { recursive: true });
+    if (!existsSync(this.#archivePath)) return;
+    const lines = readFileSync(this.#archivePath, "utf8").split("\n");
+    for (const [index, line] of lines.entries()) {
+      if (line.trim().length === 0) continue;
+      const archived = parseArchivedWindowRecord(line, index + 1);
+      const previousGeneration = this.#lastGeneration.get(archived.windowId) ?? 0;
+      if (archived.generation <= previousGeneration) {
+        throw new Error(
+          `window archive generation is not increasing at line ${index + 1}: ${archived.windowId}`,
+        );
+      }
+      this.#archived.set(archived.windowId, archived);
+      this.#lastGeneration.set(archived.windowId, archived.generation);
+    }
+  }
+
+  #appendArchive(archived: ArchivedWindow): void {
+    if (this.#archivePath === undefined) return;
+    const record: ArchivedWindowRecord = {
+      schemaVersion: 1,
+      type: "window_archived",
+      window: archived,
+    };
+    appendFileSync(this.#archivePath, `${JSON.stringify(record)}\n`, "utf8");
+  }
 
   #mintWindowId(): string {
     let candidate: string;
@@ -143,6 +232,10 @@ export class SessionRegistry<TContext> {
     return this.#archived.get(windowId);
   }
 
+  getHead(windowId: string): string | null {
+    return this.#requireLive(windowId).headId;
+  }
+
   isActive(windowId: string): boolean {
     return this.#active.has(windowId);
   }
@@ -199,7 +292,6 @@ export class SessionRegistry<TContext> {
   kill(windowId: string): ArchivedWindow | undefined {
     const window = this.#active.get(windowId);
     if (window === undefined) return this.#archived.get(windowId);
-    this.#active.delete(windowId);
     const archived: ArchivedWindow = {
       residentId: window.residentId,
       windowId: window.windowId,
@@ -208,6 +300,9 @@ export class SessionRegistry<TContext> {
       headId: window.headId,
       archived: true,
     };
+    // 先落耐久证据再改内存；追加失败时窗仍保持活态，不伪报已归档。
+    this.#appendArchive(archived);
+    this.#active.delete(windowId);
     this.#archived.set(windowId, archived);
     return archived;
   }

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -77,7 +77,8 @@ export interface OpenOptions<TContext> {
 
 export interface SessionRegistryOptions {
   /**
-   * 窗归档的 append-only JSONL。只保存已归档窗，不保存或复活活窗。
+   * 窗生命周期的 append-only JSONL。保存已发出的代际水位与归档证据，
+   * 不保存或复活活窗。
    * 不给路径时保持纯内存，供无持久化需求的嵌入方与单测使用。
    */
   archivePath?: string;
@@ -89,7 +90,15 @@ interface ArchivedWindowRecord {
   window: ArchivedWindow;
 }
 
-function parseArchivedWindowRecord(line: string, lineNumber: number): ArchivedWindow {
+interface WindowOpenedRecord {
+  schemaVersion: 1;
+  type: "window_opened";
+  window: Pick<ActiveWindow<unknown>, "residentId" | "windowId" | "scopeId" | "generation">;
+}
+
+type WindowJournalRecord = ArchivedWindowRecord | WindowOpenedRecord;
+
+function parseWindowJournalRecord(line: string, lineNumber: number): WindowJournalRecord {
   let value: unknown;
   try {
     value = JSON.parse(line);
@@ -99,8 +108,15 @@ function parseArchivedWindowRecord(line: string, lineNumber: number): ArchivedWi
   if (typeof value !== "object" || value === null) {
     throw new Error(`invalid window archive record at line ${lineNumber}`);
   }
-  const record = value as Partial<ArchivedWindowRecord>;
-  if (record.schemaVersion !== 1 || record.type !== "window_archived") {
+  const record = value as {
+    schemaVersion?: unknown;
+    type?: unknown;
+    window?: Partial<ArchivedWindow>;
+  };
+  if (
+    record.schemaVersion !== 1 ||
+    (record.type !== "window_archived" && record.type !== "window_opened")
+  ) {
     throw new Error(`unsupported window archive record at line ${lineNumber}`);
   }
   const window = record.window;
@@ -113,26 +129,42 @@ function parseArchivedWindowRecord(line: string, lineNumber: number): ArchivedWi
     window.windowId.length === 0 ||
     typeof window.scopeId !== "string" ||
     window.scopeId.length === 0 ||
+    typeof window.generation !== "number" ||
     !Number.isInteger(window.generation) ||
     window.generation < 1 ||
-    (window.headId !== null && typeof window.headId !== "string") ||
-    window.archived !== true
+    (record.type === "window_archived" &&
+      ((window.headId !== null && typeof window.headId !== "string") || window.archived !== true))
   ) {
     throw new Error(`invalid window archive payload at line ${lineNumber}`);
   }
+  const common = {
+    residentId: window.residentId as string,
+    windowId: window.windowId as string,
+    scopeId: window.scopeId as string,
+    generation: window.generation as number,
+  };
+  if (record.type === "window_opened") {
+    return {
+      schemaVersion: 1,
+      type: "window_opened",
+      window: common,
+    };
+  }
   return {
-    residentId: window.residentId,
-    windowId: window.windowId,
-    scopeId: window.scopeId,
-    generation: window.generation,
-    headId: window.headId,
-    archived: true,
+    schemaVersion: 1,
+    type: "window_archived",
+    window: {
+      ...common,
+      headId: window.headId as string | null,
+      archived: true,
+    },
   };
 }
 
 export class SessionRegistry<TContext> {
   readonly #active = new Map<string, ActiveWindow<TContext>>();
   readonly #archived = new Map<string, ArchivedWindow>();
+  readonly #windowIdentity = new Map<string, { residentId: string; scopeId: string }>();
   /** 代际归窗：windowId -> 上一次用过的代际号。 */
   readonly #lastGeneration = new Map<string, number>();
   readonly #archivePath: string | undefined;
@@ -147,16 +179,54 @@ export class SessionRegistry<TContext> {
     const lines = readFileSync(this.#archivePath, "utf8").split("\n");
     for (const [index, line] of lines.entries()) {
       if (line.trim().length === 0) continue;
-      const archived = parseArchivedWindowRecord(line, index + 1);
-      const previousGeneration = this.#lastGeneration.get(archived.windowId) ?? 0;
-      if (archived.generation <= previousGeneration) {
+      const record = parseWindowJournalRecord(line, index + 1);
+      const window = record.window;
+      const identity = this.#windowIdentity.get(window.windowId);
+      if (
+        identity !== undefined &&
+        (identity.residentId !== window.residentId || identity.scopeId !== window.scopeId)
+      ) {
+        throw new Error(`window identity changed at line ${index + 1}: ${window.windowId}`);
+      }
+      this.#windowIdentity.set(window.windowId, {
+        residentId: window.residentId,
+        scopeId: window.scopeId,
+      });
+      const previousGeneration = this.#lastGeneration.get(window.windowId) ?? 0;
+      if (record.type === "window_opened" && window.generation <= previousGeneration) {
         throw new Error(
-          `window archive generation is not increasing at line ${index + 1}: ${archived.windowId}`,
+          `window generation is not increasing at line ${index + 1}: ${window.windowId}`,
         );
       }
-      this.#archived.set(archived.windowId, archived);
-      this.#lastGeneration.set(archived.windowId, archived.generation);
+      if (record.type === "window_archived") {
+        const previousArchiveGeneration = this.#archived.get(window.windowId)?.generation ?? 0;
+        if (
+          window.generation < previousGeneration ||
+          window.generation <= previousArchiveGeneration
+        ) {
+          throw new Error(
+            `window archive generation is not increasing at line ${index + 1}: ${window.windowId}`,
+          );
+        }
+        this.#archived.set(window.windowId, record.window);
+      }
+      this.#lastGeneration.set(window.windowId, Math.max(previousGeneration, window.generation));
     }
+  }
+
+  #appendOpened(window: ActiveWindow<TContext>): void {
+    if (this.#archivePath === undefined) return;
+    const record: WindowOpenedRecord = {
+      schemaVersion: 1,
+      type: "window_opened",
+      window: {
+        residentId: window.residentId,
+        windowId: window.windowId,
+        scopeId: window.scopeId,
+        generation: window.generation,
+      },
+    };
+    appendFileSync(this.#archivePath, `${JSON.stringify(record)}\n`, "utf8");
   }
 
   #appendArchive(archived: ArchivedWindow): void {
@@ -174,7 +244,11 @@ export class SessionRegistry<TContext> {
     do {
       this.#windowSeq += 1;
       candidate = `window-${this.#windowSeq.toString(36).padStart(6, "0")}`;
-    } while (this.#active.has(candidate) || this.#archived.has(candidate));
+    } while (
+      this.#active.has(candidate) ||
+      this.#archived.has(candidate) ||
+      this.#lastGeneration.has(candidate)
+    );
     return candidate;
   }
 
@@ -210,8 +284,6 @@ export class SessionRegistry<TContext> {
       this.#requireArchivedForReopen(residentId, scopeId, windowId);
     }
     const generation = (this.#lastGeneration.get(windowId) ?? 0) + 1;
-    this.#lastGeneration.set(windowId, generation);
-    this.#archived.delete(windowId);
     const window: ActiveWindow<TContext> = {
       residentId,
       windowId,
@@ -220,6 +292,11 @@ export class SessionRegistry<TContext> {
       headId: options.headId ?? null,
       context: options.context,
     };
+    // 代际一经发出就先落盘；否则活窗在未归档时停机，重启后会重复发出同一代际。
+    this.#appendOpened(window);
+    this.#lastGeneration.set(windowId, generation);
+    this.#windowIdentity.set(windowId, { residentId, scopeId });
+    this.#archived.delete(windowId);
     this.#active.set(windowId, window);
     return window;
   }

--- a/tests/fixtures/session-registry-host.ts
+++ b/tests/fixtures/session-registry-host.ts
@@ -1,6 +1,7 @@
 import { SessionRegistry } from "../../src/session/session-registry.ts";
 
-const sessions = new SessionRegistry<null>();
+const archivePath = process.env.MIST_WINDOW_ARCHIVE_PATH;
+const sessions = new SessionRegistry<null>(archivePath === undefined ? {} : { archivePath });
 
 type HostCommand = {
   requestId: string;

--- a/tests/message-tree-service.test.ts
+++ b/tests/message-tree-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { MessageTreeService, MessageTreeStore } from "../src/message-tree/index.ts";
 import type { SessionHeadPort } from "../src/message-tree/index.ts";
+import { SessionRegistry, WINDOW_ARCHIVED } from "../src/session/session-registry.ts";
 
 class TestSessionHeads implements SessionHeadPort {
   readonly #heads = new Map<string, string>();
@@ -146,6 +147,28 @@ describe("MessageTreeService.say", () => {
     expect(store.history("resident-a")).toEqual([]);
     expect(heads.getHead("resident-a")).toBe("missing-parent");
     expect(heads.writes).toEqual([]);
+  });
+
+  it("归档窗在读 head 时先 fail-closed，say/revise 都不会留下孤儿节点", async () => {
+    const store = deterministicStore();
+    store.createRoom("resident-a");
+    const sessions = new SessionRegistry<null>();
+    const window = sessions.open("resident-a", { context: null });
+    const service = new MessageTreeService(store, {
+      getHead: (windowId) => sessions.getHead(windowId),
+      setHead: (windowId, headId) => sessions.setHead(windowId, headId),
+    });
+    const reply = await service.say("resident-a", "归档前", window.windowId);
+    const before = store.history("resident-a");
+    sessions.kill(window.windowId);
+
+    await expect(service.say("resident-a", "不应落树", window.windowId)).rejects.toThrow(
+      WINDOW_ARCHIVED,
+    );
+    await expect(
+      service.reviseNode("resident-a", reply.id, "也不应落树", window.windowId),
+    ).rejects.toThrow(WINDOW_ARCHIVED);
+    expect(store.history("resident-a")).toEqual(before);
   });
 
   it("相同正文的两轮仍各自落完整节点，不按内容去重", async () => {

--- a/tests/multi-viewport-host.test.ts
+++ b/tests/multi-viewport-host.test.ts
@@ -1,4 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -27,10 +30,15 @@ type Receipt = {
 };
 
 const children: ChildProcess[] = [];
+const directories: string[] = [];
 const fixture = fileURLToPath(new URL("./fixtures/session-registry-host.ts", import.meta.url));
 
-function startHost(): ChildProcess {
+function startHost(archivePath?: string): ChildProcess {
   const child = spawn(process.execPath, ["--import", "tsx", fixture], {
+    env: {
+      ...process.env,
+      ...(archivePath === undefined ? {} : { MIST_WINDOW_ARCHIVE_PATH: archivePath }),
+    },
     stdio: ["ignore", "pipe", "pipe", "ipc"],
   });
   children.push(child);
@@ -117,11 +125,17 @@ afterEach(async () => {
       }
     }),
   );
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 describe("multi-viewport real host subprocess", () => {
   it("opens two windows, kills and reopens one generation, and keeps the other live", async () => {
-    const child = startHost();
+    const directory = mkdtempSync(join(tmpdir(), "mist-viewport-host-"));
+    directories.push(directory);
+    const archivePath = join(directory, "windows.jsonl");
+    const child = startHost(archivePath);
     const pid = await waitForReady(child);
     expect(pid).toBe(child.pid);
 
@@ -155,22 +169,30 @@ describe("multi-viewport real host subprocess", () => {
       },
     );
 
-    const reopened = await callHost<WindowRecord>(child, {
+    const killed = await callHost<WindowRecord[]>(child, {
+      op: "killResident",
+      residentId: "resident-a",
+    });
+    expect(killed.map((window) => window.windowId)).toEqual([w2.windowId]);
+    await stopHost(child);
+
+    const restarted = startHost(archivePath);
+    await waitForReady(restarted);
+    expect(
+      await callHost<WindowRecord>(restarted, { op: "getArchived", windowId: w1.windowId }),
+    ).toMatchObject({ generation: 1, headId: "node-w1" });
+    expect(
+      await callHost<WindowRecord>(restarted, { op: "getArchived", windowId: w2.windowId }),
+    ).toMatchObject({ generation: 1, headId: "node-w2" });
+
+    const reopened = await callHost<WindowRecord>(restarted, {
       op: "open",
       residentId: "resident-a",
       scopeId: "room-1",
       windowId: w1.windowId,
     });
     expect(reopened.generation).toBe(2);
-    expect(await callHost(child, { op: "belongs", receipt: r1 })).toBe(false);
-
-    const killed = await callHost<WindowRecord[]>(child, {
-      op: "killResident",
-      residentId: "resident-a",
-    });
-    expect(killed.map((window) => window.windowId).sort()).toEqual(
-      [w1.windowId, w2.windowId].sort(),
-    );
-    await stopHost(child);
+    expect(await callHost(restarted, { op: "belongs", receipt: r1 })).toBe(false);
+    await stopHost(restarted);
   });
 });

--- a/tests/multi-viewport-host.test.ts
+++ b/tests/multi-viewport-host.test.ts
@@ -193,6 +193,26 @@ describe("multi-viewport real host subprocess", () => {
     });
     expect(reopened.generation).toBe(2);
     expect(await callHost(restarted, { op: "belongs", receipt: r1 })).toBe(false);
+    const generation2Receipt = await callHost<Receipt>(restarted, {
+      op: "issueDispatch",
+      windowId: w1.windowId,
+    });
     await stopHost(restarted);
+
+    // 活窗在未归档时正常停机；第三个进程必须从发号水位继续到 generation 3，
+    // 不能重复发 generation 2，让上一化身的迟到回执复活。
+    const restartedAgain = startHost(archivePath);
+    await waitForReady(restartedAgain);
+    const reopenedAgain = await callHost<WindowRecord>(restartedAgain, {
+      op: "open",
+      residentId: "resident-a",
+      scopeId: "room-1",
+      windowId: w1.windowId,
+    });
+    expect(reopenedAgain.generation).toBe(3);
+    expect(await callHost(restartedAgain, { op: "belongs", receipt: generation2Receipt })).toBe(
+      false,
+    );
+    await stopHost(restartedAgain);
   });
 });

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   PRIVATE_SCOPE,
@@ -118,6 +121,61 @@ describe("SessionRegistry：多窗语义", () => {
       sessions.open("resident-a", { windowId: archived.windowId, context: null }),
     ).toThrow(/scope mismatch/);
     expect(sessions.isArchived(archived.windowId)).toBe(true);
+  });
+
+  it("MV-A03 归档 append 到 JSONL，重启后仍可查询并按下一代重开", () => {
+    const directory = mkdtempSync(join(tmpdir(), "mist-window-archive-"));
+    const archivePath = join(directory, "windows.jsonl");
+    try {
+      const first = new SessionRegistry<null>({ archivePath });
+      const window = first.open("resident-a", {
+        scopeId: "room-1",
+        headId: "node-1",
+        context: null,
+      });
+      first.kill(window.windowId);
+
+      const lines = readFileSync(archivePath, "utf8").trim().split("\n");
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0] ?? "null")).toMatchObject({
+        schemaVersion: 1,
+        type: "window_archived",
+        window: { windowId: window.windowId, generation: 1, headId: "node-1" },
+      });
+
+      const second = new SessionRegistry<null>({ archivePath });
+      expect(second.getArchived(window.windowId)).toMatchObject({
+        residentId: "resident-a",
+        scopeId: "room-1",
+        generation: 1,
+        headId: "node-1",
+      });
+      const reopened = second.open("resident-a", {
+        windowId: window.windowId,
+        scopeId: "room-1",
+        context: null,
+      });
+      expect(reopened.generation).toBe(2);
+      second.kill(reopened.windowId);
+
+      const third = new SessionRegistry<null>({ archivePath });
+      expect(third.getArchived(window.windowId)?.generation).toBe(2);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("损坏的归档 JSONL 在启动时 fail loud", () => {
+    const directory = mkdtempSync(join(tmpdir(), "mist-window-archive-corrupt-"));
+    const archivePath = join(directory, "windows.jsonl");
+    try {
+      writeFileSync(archivePath, "not-json\n");
+      expect(() => new SessionRegistry<null>({ archivePath })).toThrow(
+        /invalid window archive JSONL at line 1/,
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it("会话态归零不动住户留下的东西", () => {

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -136,8 +136,13 @@ describe("SessionRegistry：多窗语义", () => {
       first.kill(window.windowId);
 
       const lines = readFileSync(archivePath, "utf8").trim().split("\n");
-      expect(lines).toHaveLength(1);
+      expect(lines).toHaveLength(2);
       expect(JSON.parse(lines[0] ?? "null")).toMatchObject({
+        schemaVersion: 1,
+        type: "window_opened",
+        window: { windowId: window.windowId, generation: 1 },
+      });
+      expect(JSON.parse(lines[1] ?? "null")).toMatchObject({
         schemaVersion: 1,
         type: "window_archived",
         window: { windowId: window.windowId, generation: 1, headId: "node-1" },


### PR DESCRIPTION
## Why this follow-up exists

#86 merged at `f72fde8` while the final independent review and its fixes were racing. The two accepted gaps were fixed on the old feature branch afterward, so they were not part of merge commit `02e3949`.

This PR is a clean cherry-pick of only that follow-up fix onto current `main` (which already contains #85 and #86).

## Fixes

1. **MV-A03 durable archive**
   - `SessionRegistry({ archivePath })` appends versioned `window_archived` JSONL before mutating in-memory state;
   - startup restores archived windows and per-window generation watermarks;
   - corrupt JSONL and non-increasing generations fail loud;
   - active windows are intentionally not resurrected.

2. **Archived-window head fail-closed**
   - `SessionRegistry.getHead(windowId)` uses the live-window guard;
   - the acceptance-driver head port no longer maps archived/unknown windows to `null`;
   - `MessageTreeService.reviseNode` validates the window before appending a sibling;
   - regression coverage proves archived-window `say` and `reviseNode` do not leave orphan nodes.

3. **Cross-process evidence**
   - the real Node subprocess test archives two windows, exits, restarts against the same JSONL path, reads both archives, and reopens one as generation 2.

## Verification on current main

At `1dcff08`:

- `npx vitest run` → 28 files, 294 tests passed
- `npx tsc --noEmit -p tsconfig.json` → passed
- `npx biome check .` → 66 files checked, 0 errors
- `git diff --check origin/main...HEAD` → passed

Tracks the remaining MV-A03 correction from #79. B03 remains in #79 for the later dispatch-chain wiring and is not changed here.
