### PR TITLE
docs(glossary): 补 scopeId 独立词条、窗三元组与 scope × lane 正交（#96）

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -113,6 +113,17 @@ reason code 跨重启保留；重启不能把它洗成 ready。显式清理重�
 回指该 issuer 的 ref，也不得制造悬空引用。v0 不定义 secretRef 后端、加密、轮换或 issuer 删除后
 现役 ref 的产品处置/迁移语义；登录流程不属于插件协议。
 
+**scopeId（可见性作用域标识）**
+住户的可见性／隔离边界的标识：不是窗，也不是 context injection 的 `scope`。
+隔离只按 scope 划（论证见 issue #69），同一 scope 的多扇 viewport 共享同一份
+可见事实。开窗未显式给出 scopeId 时，只能落「私聊」，不得默认「全局」。
+scopeId 与 lane 是正交维度：lane 是选择执行通道时的用途槽，scopeId 划可见性边界；
+两者互不推导，任一方的合法值都不得从另一方猜出。
+
+**窗三元组（residentId, scopeId, windowId）**
+一扇窗的完整身份，三项缺一不可（图纸 `docs/design/multi-viewport.md` §1.1）。
+generation 不属于三元组：换气是窗内换代，generation + 1，三元组不变（§1.2）。
+
 **viewport（视窗）**
 住户 scope 的一面视野。D7 多活窗模型里，一位住户可同时有多个 viewport，各自独立
 代际；关掉即归档为只读日志／导出证据。viewport 不是隔离单位——同一 scope 下的多个


### PR DESCRIPTION
## 这个 PR 做什么

按 #96 楼里拍板的待补任务，给 glossary 补两个词条（净增 11 行，既有词条零改动）：

1. **scopeId（可见性作用域标识）**：可见性／隔离边界的标识（论证见 #69），与 context injection 的 `scope` 切开；scope × lane 正交明文落表——此前只有「role × lane 正交」有据，scope × lane 没有一句明文。
2. **窗三元组（residentId, scopeId, windowId）**：以图纸 `docs/design/multi-viewport.md` §1.1 为准落表；generation 不属于三元组，换代不改变三元组（§1.2）。

只写定义与边界，不复制图纸／验收里的行为规格（回执过滤、重开校验等仍以其原文为准），避免第二本账。位置在 lane／凭证引用之后、viewport 之前，让 scope 先于引用它的 viewport 出现。

## 判卷

- 纯文档增量，不变任何一盏验收灯的颜色。
- `npm run lint && typecheck && test` 未在本地跑：改动为一个 .md 文件，biome / tsc / vitest 均不覆盖；CI 若红照修。
