### PR TITLE
feat(plugin): add scope-aware runtime readiness readback

### DIFF
--- a/acceptance/plugin-protocol-v0.md
+++ b/acceptance/plugin-protocol-v0.md
@@ -4,6 +4,10 @@
 不声称具体实现已经通过。实现落地时，每项必须成为确定性自动测试；测试违反约束后没有
 明确红灯的条目，不得勾选。
 
+F 系列运行态口径的增量见 [runtime-readiness.md](../docs/design/runtime-readiness.md)，
+对应实测位于 `tests/plugin-runtime-readiness.test.ts` 与
+`tests/pv0/pv0-f-readiness-semantics.test.ts`。
+
 每条测试记录四件事：fixture、动作、确定性断言、失败时的 reason code。含敏感值的
 fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置快照、日志、事件和
 错误输出；凡插件产物会进入模型，还要扫描带来源标记的住户上下文快照。
@@ -222,9 +226,9 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
 
 ## F. Readiness、投影与闭环
 
-- [ ] **[PV0-F01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) readiness 有 scope**：ready/degraded/blocked/quarantined 每种 fixture 都
+- [x] **[PV0-F01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) readiness 有 scope**：ready/degraded/blocked/quarantined 每种 fixture 都
   返回 resident、lane、operations 和验证时间；换住户或车道后不能沿用旧 ready。
-- [ ] **[PV0-F02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s8) 原因码稳定可判**：A–E 每条失败路径只以 RFC 第 8 节 reason code 之一
+- [x] **[PV0-F02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s8) 原因码稳定可判**：A–E 每条失败路径只以 RFC 第 8 节 reason code 之一
   作为机器判决，附加文本变化不影响断言。
 - [ ] **[PV0-F03](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s9) 每条约束都有指定红格**：逐项执行下表登记的 mutation；实测失败集合必须
   包含该 mutation 指定的 PV0 id，不能用“任意一格变红”代替。fixture 的宪法常量独立于
@@ -233,7 +237,7 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
   安装在 validate 阶段被拒，现有不变量仍可用。
 - [ ] **[PV0-F05](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s1) 壳共享魂私有**：插件包、manifest、配置导出和诊断中扫描住户人格、记忆、
   聊天 fixture 标记；均不得出现，插件只能经受控 capability 在当前 scope 临时访问。
-- [ ] **[PV0-F06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) ready 必须有当前 scope 的可用性收据**：分别用 initialize 握手、版本查询
+- [x] **[PV0-F06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) ready 必须有当前 scope 的可用性收据**：分别用 initialize 握手、版本查询
   和无副作用探针验证三类 capability；未运行探针、探针超时或返回身份不符时返回
   `CAPABILITY_UNVERIFIED` 且不进 ready 工具集。断言只证明可用性，不声称签名或供应链可信。
 

--- a/acceptance/plugin-protocol-v0.md
+++ b/acceptance/plugin-protocol-v0.md
@@ -244,7 +244,8 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
 本次 #101 只落地了确定性 evaluator/readback contract 与窄 fixture（缺运行证据、真实路径失败、
 scope/version/条件漂移和过期收据）；上述 F01/F02/F06 仍需完整的四状态、A–E 失败矩阵和三类
 provider-like readback fixture 后再勾选。`npm run acceptance` 的 C1–C6 六盏灯不替代 PV0 F
-系列验收，故此处保持未勾选。
+系列验收，故此处保持未勾选。`publishedResources` 仍是生命周期 projection，本切片不声称
+它受 readiness gate 控制；active 无收据时可能仍有已发布资源，但 readiness 必须为 unknown。
 
 ## 逐项 mutation 台账
 

--- a/acceptance/plugin-protocol-v0.md
+++ b/acceptance/plugin-protocol-v0.md
@@ -226,9 +226,9 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
 
 ## F. Readiness、投影与闭环
 
-- [x] **[PV0-F01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) readiness 有 scope**：ready/degraded/blocked/quarantined 每种 fixture 都
+- [ ] **[PV0-F01](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) readiness 有 scope**：ready/degraded/blocked/quarantined 每种 fixture 都
   返回 resident、lane、operations 和验证时间；换住户或车道后不能沿用旧 ready。
-- [x] **[PV0-F02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s8) 原因码稳定可判**：A–E 每条失败路径只以 RFC 第 8 节 reason code 之一
+- [ ] **[PV0-F02](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s8) 原因码稳定可判**：A–E 每条失败路径只以 RFC 第 8 节 reason code 之一
   作为机器判决，附加文本变化不影响断言。
 - [ ] **[PV0-F03](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s9) 每条约束都有指定红格**：逐项执行下表登记的 mutation；实测失败集合必须
   包含该 mutation 指定的 PV0 id，不能用“任意一格变红”代替。fixture 的宪法常量独立于
@@ -237,9 +237,14 @@ fixture 统一使用唯一标记 `SECRET_SHOULD_NEVER_APPEAR`，并扫描配置�
   安装在 validate 阶段被拒，现有不变量仍可用。
 - [ ] **[PV0-F05](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s1) 壳共享魂私有**：插件包、manifest、配置导出和诊断中扫描住户人格、记忆、
   聊天 fixture 标记；均不得出现，插件只能经受控 capability 在当前 scope 临时访问。
-- [x] **[PV0-F06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) ready 必须有当前 scope 的可用性收据**：分别用 initialize 握手、版本查询
+- [ ] **[PV0-F06](../docs/design/plugin-protocol-v0.md#plugin-protocol-v0-s4) ready 必须有当前 scope 的可用性收据**：分别用 initialize 握手、版本查询
   和无副作用探针验证三类 capability；未运行探针、探针超时或返回身份不符时返回
   `CAPABILITY_UNVERIFIED` 且不进 ready 工具集。断言只证明可用性，不声称签名或供应链可信。
+
+本次 #101 只落地了确定性 evaluator/readback contract 与窄 fixture（缺运行证据、真实路径失败、
+scope/version/条件漂移和过期收据）；上述 F01/F02/F06 仍需完整的四状态、A–E 失败矩阵和三类
+provider-like readback fixture 后再勾选。`npm run acceptance` 的 C1–C6 六盏灯不替代 PV0 F
+系列验收，故此处保持未勾选。
 
 ## 逐项 mutation 台账
 

--- a/docs/design/runtime-readiness.md
+++ b/docs/design/runtime-readiness.md
@@ -25,10 +25,11 @@
 `ReadinessScope` 至少绑定：
 
 ```text
-residentId, lane, operations, host, networkPath, version, lastVerifiedAt, verificationWindowMs
+residentId, lane, operations, host, networkPath, version
 ```
 
 `ReadinessReceipt` 还保存 definition、binding、authorization、证据清单和稳定 reason code。
+receipt 另保存 `lastVerifiedAt` 与 `verificationWindowMs`；它们不是 scope 字段。
 `verifiedScope` 与 `lastVerifiedAt` 始终成对出现；没有成功验证时 timestamp 为 null，状态明确为
 `unknown`，不能把空对象当作空 scope。ready 收据还必须持久化一个正的
 `verificationWindowMs`；宿主重启后按当前时间重新检查窗口，过期或没有窗口的旧收据都投影为
@@ -60,6 +61,12 @@ measurements 只能跟在同一证据行，不得脱离条件单独投影。本�
 
 任何非 `ready` 结果都不得进入 ready 工具集。`quarantined` 仍由 #97 资源撤销语义负责，投影时
 保持 fail-closed；readiness receipt 不会让它重新变绿。
+
+生产入口接收 `RuntimeReadinessRequest`（本次调用的 evaluator input 与三腿 probe），由当前宿主
+现场调用 `readRuntimeReadiness` 后才可持久化结果。旧的直接 receipt 输入只保留解析/诊断兼容，
+不能把手写 `ready` receipt 升格为权威 ready。`publishedResources` 是既有生命周期 projection，
+本切片不把 readiness 当作其 gate；active 且无收据时仍可能有已发布资源，但 readiness projection
+必须是 `unknown`，因此 F06 继续未勾选。
 
 ## 与 #97 的接线
 

--- a/docs/design/runtime-readiness.md
+++ b/docs/design/runtime-readiness.md
@@ -68,6 +68,10 @@ measurements 只能跟在同一证据行，不得脱离条件单独投影。本�
 本切片不把 readiness 当作其 gate；active 且无收据时仍可能有已发布资源，但 readiness projection
 必须是 `unknown`，因此 F06 继续未勾选。
 
+生产 enable path 会把 manifest 的 `version` 持久化为 authority 的 `runtimeVersion`；probe receipt
+的 definition、binding、verifiedScope 和每条 evidence 的 version 必须全部与它相等。旧 authority
+没有 `runtimeVersion` 时仍可被读取，但 probe-backed `ready` 会 fail-closed，不会从调用方输入补出版本。
+
 ## 与 #97 的接线
 
 `PluginAuthorityRecord.verifiedScope` 继续是 #97 的边界字段；运行态收据作为可选同代 receipt

--- a/docs/design/runtime-readiness.md
+++ b/docs/design/runtime-readiness.md
@@ -1,0 +1,83 @@
+# 运行态就绪验证（#101）
+
+本图纸只管 **runtime readiness / readback**，不新增 capability registry、调度器或持久化后端。
+能力协议 v0 的生命周期、`verifiedScope` 和 `CAPABILITY_UNVERIFIED` 口径以
+[plugin-protocol-v0.md](plugin-protocol-v0.md) 为基线；本图纸补足它留给后续实现的独立运行证据。
+
+## 边界
+
+五类事实各有唯一责任人，不能用一种事实替另一种事实背书：
+
+| 事实 | 回答的问题 | 运行态验证能否改它 |
+|---|---|---|
+| definition | 这是什么能力、哪个版本、哪个稳定 id | 不能 |
+| binding | 当前宿主/网络路径指向哪个实现 | 不能；只核对是否与目标一致 |
+| authorization | 哪个 resident、lane、operation 获准调用 | 不能；只核对覆盖关系 |
+| readiness | 这条 scope 的真实运行路径现在是否可用 | 只能产生带 scope/time/version 的收据 |
+| telemetry | 调用次数、延迟、失败率等观察读数 | 不能单独改变上述任何状态 |
+| projection | 启动包、目录或 UI 此刻展示什么 | 不能成为 readiness 证据 |
+
+`definition present + binding missing` 是诚实的 `readiness=unknown`，不是 active/ready。
+`enabled`、文件存在、导入成功、进程自报健康都不能越过运行态读回。
+
+## v0 contract
+
+`ReadinessScope` 至少绑定：
+
+```text
+residentId, lane, operations, host, networkPath, version, lastVerifiedAt
+```
+
+`ReadinessReceipt` 还保存 definition、binding、authorization、证据清单和稳定 reason code。
+`verifiedScope` 与 `lastVerifiedAt` 始终成对出现；没有成功验证时 timestamp 为 null，状态明确为
+`unknown`，不能把空对象当作空 scope。
+
+独立证据分三腿，三腿都需要才可为 `ready`：
+
+1. `existence`：从被测物外部确认目标存在；它不能证明进程运行。
+2. `running`：从外部确认运行态确实存活；它不能证明住户路径可达。
+3. `readback`：从目标运行路径取回真实操作的确定性结果（initialize、版本查询或无副作用探针）。
+
+证据必须来自 `external` probe，并逐条绑定 scope、runtime version、moduleRef、observedAt 和
+conditions。量化 measurements 只能跟在同一证据行，不得脱离条件单独投影。
+
+## 状态与失败语义
+
+| 观察 | 结果 | reason code |
+|---|---|---|
+| 三腿独立证据通过，scope/版本/条件完全相等 | `ready` | — |
+| 仅 definition 存在、缺 binding/证据/运行读回 | `unknown` | `CAPABILITY_UNVERIFIED` |
+| 自报证据、scope/host/network/lane/operation/version 不匹配 | `unknown` | `CAPABILITY_UNVERIFIED` |
+| 证据过期或条件不一致 | `unknown` | `CAPABILITY_UNVERIFIED` |
+| existence 或 running 明确失败 | `blocked` | `PLUGIN_RUNTIME_FAILED` |
+| 真实 readback 失败，操作子集仍通过 | `degraded` | `PLUGIN_RUNTIME_FAILED` |
+| 真实 readback 对请求操作均失败（即便 health=200） | `blocked` | `PLUGIN_RUNTIME_FAILED` |
+| authorization 不覆盖请求 scope | `blocked` | `PERMISSION_DENIED` |
+
+任何非 `ready` 结果都不得进入 ready 工具集。`quarantined` 仍由 #97 资源撤销语义负责，投影时
+保持 fail-closed；readiness receipt 不会让它重新变绿。
+
+## 与 #97 的接线
+
+`PluginAuthorityRecord.verifiedScope` 继续是 #97 的边界字段；运行态收据作为可选同代 receipt
+持久化。未提供收据的 active lifecycle 只能通过 host readiness projection 得到 `unknown`。
+停用、回滚、恢复隔离会删除旧收据，避免把上一代成功投影到当前运行态。#101 不引入新的
+canonical registry，也不把 receipt 当作 binding/authorization 的第二真相源。
+
+## 可判卷矩阵
+
+自动化验收位于 `tests/plugin-runtime-readiness.test.ts`，PV0 F 系列在
+`tests/pv0/pv0-f-readiness-semantics.test.ts` 保持映射：
+
+- 文件/定义存在但从未运行：缺 `running/readback` → `unknown`；
+- health 绿但真实路径不可达：readback fail → `blocked`，不被 health 覆盖；
+- 仓库、部署、运行时版本或 moduleRef 不一致：scope mismatch → `unknown`；
+- host/network/lane/operation/resident 不匹配：scope mismatch → `unknown`；
+- 自报、过期、条件漂移或探针不可回答：证据不足 → `unknown`；
+- 三腿外部证据、授权和 scope 全部一致：才生成 `lastVerifiedAt` 并返回 `ready`。
+
+### 代价
+
+真实路径读回会增加验证延迟、探针维护和故障可见性成本；某些能力无法被无副作用探测时，
+会更常停在 `unknown`，但这是避免假 ready 的诚实代价。收据是时间和 scope 的快照，过期后
+必须重新验证，不能用 telemetry 或 projection 续命。

--- a/docs/design/runtime-readiness.md
+++ b/docs/design/runtime-readiness.md
@@ -71,6 +71,8 @@ measurements 只能跟在同一证据行，不得脱离条件单独投影。本�
 生产 enable path 会把 manifest 的 `version` 持久化为 authority 的 `runtimeVersion`；probe receipt
 的 definition、binding、verifiedScope 和每条 evidence 的 version 必须全部与它相等。旧 authority
 没有 `runtimeVersion` 时仍可被读取，但 probe-backed `ready` 会 fail-closed，不会从调用方输入补出版本。
+active true→true 若发现新的 manifest version 与现役 authority 不同，会清除旧 readiness 并保持
+`active/unknown`；必须重新以匹配版本完成启用与现场探针，不能沿用上一代 ready。
 
 ## 与 #97 的接线
 

--- a/docs/design/runtime-readiness.md
+++ b/docs/design/runtime-readiness.md
@@ -25,12 +25,14 @@
 `ReadinessScope` 至少绑定：
 
 ```text
-residentId, lane, operations, host, networkPath, version, lastVerifiedAt
+residentId, lane, operations, host, networkPath, version, lastVerifiedAt, verificationWindowMs
 ```
 
 `ReadinessReceipt` 还保存 definition、binding、authorization、证据清单和稳定 reason code。
 `verifiedScope` 与 `lastVerifiedAt` 始终成对出现；没有成功验证时 timestamp 为 null，状态明确为
-`unknown`，不能把空对象当作空 scope。
+`unknown`，不能把空对象当作空 scope。ready 收据还必须持久化一个正的
+`verificationWindowMs`；宿主重启后按当前时间重新检查窗口，过期或没有窗口的旧收据都投影为
+`unknown/CAPABILITY_UNVERIFIED`。
 
 独立证据分三腿，三腿都需要才可为 `ready`：
 
@@ -39,7 +41,9 @@ residentId, lane, operations, host, networkPath, version, lastVerifiedAt
 3. `readback`：从目标运行路径取回真实操作的确定性结果（initialize、版本查询或无副作用探针）。
 
 证据必须来自 `external` probe，并逐条绑定 scope、runtime version、moduleRef、observedAt 和
-conditions。量化 measurements 只能跟在同一证据行，不得脱离条件单独投影。
+conditions；三条证据腿还必须使用不同的 `probeId`，避免同一观察冒充独立证明。量化
+measurements 只能跟在同一证据行，不得脱离条件单独投影。本切片不引入 provider registry 或
+跨宿主证明协议，独立性的边界止于可观察的 probe 身份和来源。
 
 ## 状态与失败语义
 
@@ -74,7 +78,12 @@ canonical registry，也不把 receipt 当作 binding/authorization 的第二真
 - 仓库、部署、运行时版本或 moduleRef 不一致：scope mismatch → `unknown`；
 - host/network/lane/operation/resident 不匹配：scope mismatch → `unknown`；
 - 自报、过期、条件漂移或探针不可回答：证据不足 → `unknown`；
-- 三腿外部证据、授权和 scope 全部一致：才生成 `lastVerifiedAt` 并返回 `ready`。
+- 三腿外部证据、授权和 scope 全部一致且显式提供正的验证窗口：才生成 `lastVerifiedAt` 并返回
+  `ready`。
+
+当前 PV0 F01/F02/F06 清单仍未勾选：本切片的 deterministic fixtures 覆盖失败语义和收据边界，
+尚未声称完整四状态、A–E 失败矩阵或三类 provider-like readback 已全部验收。`npm run acceptance`
+的 C1–C6 不替代 PV0 F 系列验收。
 
 ### 代价
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -74,6 +74,20 @@
 一次 capability 可用性验证实际覆盖的住户、车道、操作集合与时间点。ready 只在这组边界内
 成立，不能把某一车道、角色或旧时间点的成功投影成全局可用。
 
+**运行态就绪（runtime readiness）**
+某个 capability 在指定 `resident × lane × operation × host/network × version × time`
+边界内，经过独立运行证据和真实路径读回后得到的派生状态。它不改变 definition、binding
+或 authorization；证据不足时为 `unknown`，不能从文件存在、进程自报或全局 health 推成 ready。
+
+**运行态读回（runtime readback）**
+从运行中的目标外部取回的、与请求 scope 和条件绑定的事实，例如实际调用路径的无副作用探针、
+版本查询或 initialize 握手。health 只能是某一条证据，不能代替真实操作路径读回。
+
+**就绪收据（readiness receipt）**
+一次运行态就绪验证的可审计结果，必须把 `verifiedScope` 与 `lastVerifiedAt` 成对保存，
+并在同一证据行携带条件与量化读数。收据不是 definition、授权或 telemetry 的真相源，
+也不把某一次 scope 的成功投影到其他住户、车道、操作、主机、网络路径或版本。
+
 **quarantined**
 插件资源撤销不完整或运行时越界后的持久隔离态。全部对外入口保持关闭，剩余资源 id 与稳定
 reason code 跨重启保留；重启不能把它洗成 ready。显式清理重试是宿主独立操作，不等于重复

--- a/src/plugin/enable.ts
+++ b/src/plugin/enable.ts
@@ -12,6 +12,7 @@ import { type SecretResolver, resolveEnvironment } from "./environment.ts";
 import { type PluginManifestV0, validateBindings } from "./manifest.ts";
 import type { PluginOperationStore } from "./operation-store.ts";
 import { type PluginOperationOutcome, operationOutcome } from "./recovery-coordinator.ts";
+import type { ReadinessReceipt } from "./runtime-readiness.ts";
 import type { PluginTransactionHost } from "./transaction-host.ts";
 import type { PluginModuleV0, ReasonCode } from "./types.ts";
 
@@ -23,6 +24,8 @@ export interface EnabledChangeRequest {
   /** instance config 全量（含 enabled 目标值）；运行时形状由就绪门定型。 */
   readonly config: unknown;
   readonly resolveSecret: SecretResolver;
+  /** Optional external runtime receipt. Omission deliberately remains unknown. */
+  readonly readiness?: ReadinessReceipt;
 }
 
 export type EnabledChangeResult =
@@ -65,6 +68,10 @@ export async function applyEnabledChange(
 
   const existing = readIfPresent(store, request.pluginId);
   if (existing?.enabled && existing.lifecycleState === "active") {
+    if (request.readiness !== undefined) {
+      host.recordReadiness(request.pluginId, request.readiness);
+      return operationOutcome(store.read(request.pluginId));
+    }
     return operationOutcome(existing); // true→true：已在役 幂等返回 不重进事务
   }
   const assembled = resolveEnvironment(request.manifest, request.config, request.resolveSecret);
@@ -83,9 +90,10 @@ export async function applyEnabledChange(
     config: request.config,
     env: assembled.env,
     bindings: { environment: (request.config as { environment: unknown }).environment },
-    // PV0 占位：readiness gate（F01/F06）尚未实现，此空对象不是验证收据；
-    // 接线前不得将其投影为 ready——消费者应视为 unverified。
-    verifiedScope: {},
+    // Activation and runtime readiness are separate facts. Without an external receipt,
+    // the durable authority carries no verified scope and host projection remains unknown.
+    verifiedScope: request.readiness?.verifiedScope ?? null,
+    ...(request.readiness === undefined ? {} : { readiness: request.readiness }),
   });
 }
 

--- a/src/plugin/enable.ts
+++ b/src/plugin/enable.ts
@@ -12,7 +12,7 @@ import { type SecretResolver, resolveEnvironment } from "./environment.ts";
 import { type PluginManifestV0, validateBindings } from "./manifest.ts";
 import type { PluginOperationStore } from "./operation-store.ts";
 import { type PluginOperationOutcome, operationOutcome } from "./recovery-coordinator.ts";
-import type { ReadinessReceipt } from "./runtime-readiness.ts";
+import type { ReadinessReceipt, RuntimeReadinessRequest } from "./runtime-readiness.ts";
 import type { PluginTransactionHost } from "./transaction-host.ts";
 import type { PluginModuleV0, ReasonCode } from "./types.ts";
 
@@ -24,8 +24,10 @@ export interface EnabledChangeRequest {
   /** instance config 全量（含 enabled 目标值）；运行时形状由就绪门定型。 */
   readonly config: unknown;
   readonly resolveSecret: SecretResolver;
-  /** Optional external runtime receipt. Omission deliberately remains unknown. */
+  /** Legacy compatibility input; a ready receipt is rejected by the host. */
   readonly readiness?: ReadinessReceipt;
+  /** Current-process probe request; its generated receipt is the only new ready authority. */
+  readonly readinessRequest?: RuntimeReadinessRequest;
 }
 
 export type EnabledChangeResult =
@@ -68,6 +70,10 @@ export async function applyEnabledChange(
 
   const existing = readIfPresent(store, request.pluginId);
   if (existing?.enabled && existing.lifecycleState === "active") {
+    if (request.readinessRequest !== undefined) {
+      await host.recordReadinessFromProbe(request.pluginId, request.readinessRequest);
+      return operationOutcome(store.read(request.pluginId));
+    }
     if (request.readiness !== undefined) {
       host.recordReadiness(request.pluginId, request.readiness);
       return operationOutcome(store.read(request.pluginId));
@@ -92,8 +98,12 @@ export async function applyEnabledChange(
     bindings: { environment: (request.config as { environment: unknown }).environment },
     // Activation and runtime readiness are separate facts. Without an external receipt,
     // the durable authority carries no verified scope and host projection remains unknown.
-    verifiedScope: request.readiness?.verifiedScope ?? null,
+    verifiedScope:
+      request.readinessRequest === undefined ? (request.readiness?.verifiedScope ?? null) : null,
     ...(request.readiness === undefined ? {} : { readiness: request.readiness }),
+    ...(request.readinessRequest === undefined
+      ? {}
+      : { readinessRequest: request.readinessRequest }),
   });
 }
 

--- a/src/plugin/enable.ts
+++ b/src/plugin/enable.ts
@@ -70,6 +70,10 @@ export async function applyEnabledChange(
 
   const existing = readIfPresent(store, request.pluginId);
   if (existing?.enabled && existing.lifecycleState === "active") {
+    if (existing.runtimeVersion !== request.manifest.version) {
+      host.invalidateReadiness(request.pluginId);
+      return operationOutcome(store.read(request.pluginId));
+    }
     if (request.readinessRequest !== undefined) {
       await host.recordReadinessFromProbe(request.pluginId, request.readinessRequest);
       return operationOutcome(store.read(request.pluginId));

--- a/src/plugin/enable.ts
+++ b/src/plugin/enable.ts
@@ -75,11 +75,19 @@ export async function applyEnabledChange(
       return operationOutcome(store.read(request.pluginId));
     }
     if (request.readinessRequest !== undefined) {
-      await host.recordReadinessFromProbe(request.pluginId, request.readinessRequest);
+      try {
+        await host.recordReadinessFromProbe(request.pluginId, request.readinessRequest);
+      } catch {
+        return readinessRejectedOutcome(store, request.pluginId);
+      }
       return operationOutcome(store.read(request.pluginId));
     }
     if (request.readiness !== undefined) {
-      host.recordReadiness(request.pluginId, request.readiness);
+      try {
+        host.recordReadiness(request.pluginId, request.readiness);
+      } catch {
+        return readinessRejectedOutcome(store, request.pluginId);
+      }
       return operationOutcome(store.read(request.pluginId));
     }
     return operationOutcome(existing); // true→true：已在役 幂等返回 不重进事务
@@ -118,4 +126,14 @@ function readIfPresent(store: PluginOperationStore, pluginId: string) {
   } catch {
     return null;
   }
+}
+
+function readinessRejectedOutcome(
+  store: PluginOperationStore,
+  pluginId: string,
+): PluginOperationOutcome {
+  return {
+    ...operationOutcome(store.read(pluginId)),
+    reasonCode: "CAPABILITY_UNVERIFIED",
+  };
 }

--- a/src/plugin/enable.ts
+++ b/src/plugin/enable.ts
@@ -93,6 +93,7 @@ export async function applyEnabledChange(
     pluginId: request.pluginId,
     moduleRef: request.moduleRef,
     module: request.module,
+    runtimeVersion: request.manifest.version,
     config: request.config,
     env: assembled.env,
     bindings: { environment: (request.config as { environment: unknown }).environment },

--- a/src/plugin/operation-store.ts
+++ b/src/plugin/operation-store.ts
@@ -13,6 +13,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import type { LifecycleState } from "./lifecycle.ts";
+import { type ReadinessReceipt, isReadinessReceipt } from "./runtime-readiness.ts";
 import type { ReasonCode, ResourceKind } from "./types.ts";
 
 export const PLUGIN_OPERATION_SCHEMA_VERSION = 1 as const;
@@ -78,6 +79,8 @@ export interface PluginAuthorityRecord {
   readonly config: unknown;
   readonly bindings: unknown;
   readonly verifiedScope: unknown;
+  /** Optional runtime receipt; absent means an active lifecycle is not runtime-ready. */
+  readonly readiness?: ReadinessReceipt;
   reasonCode?: ReasonCode;
   readonly operation: PluginOperationRecord;
   quarantine?: PluginQuarantineRecord;
@@ -284,6 +287,10 @@ function parseAuthority(text: string, expectedPluginId: string): PluginAuthority
     throw new Error("plugin authority has an invalid reasonCode");
   }
   const reasonCode = reasonCodeValue as ReasonCode | undefined;
+  const readiness = value.readiness;
+  if (readiness !== undefined && !isReadinessReceipt(readiness)) {
+    throw new Error("plugin authority has an invalid readiness receipt");
+  }
   const quarantine = parseQuarantine(value.quarantine);
   return {
     schemaVersion: PLUGIN_OPERATION_SCHEMA_VERSION,
@@ -294,6 +301,7 @@ function parseAuthority(text: string, expectedPluginId: string): PluginAuthority
     config: value.config,
     bindings: value.bindings,
     verifiedScope: value.verifiedScope,
+    ...(readiness === undefined ? {} : { readiness }),
     operation: parseOperation(value.operation),
     ...(reasonCode === undefined ? {} : { reasonCode }),
     ...(quarantine === undefined ? {} : { quarantine }),

--- a/src/plugin/operation-store.ts
+++ b/src/plugin/operation-store.ts
@@ -76,6 +76,8 @@ export interface PluginAuthorityRecord {
   lifecycleState: LifecycleState;
   enabled: boolean;
   readonly moduleRef: string;
+  /** Manifest/runtime version captured by the production enable path; absent on legacy records. */
+  readonly runtimeVersion?: string;
   readonly config: unknown;
   readonly bindings: unknown;
   readonly verifiedScope: unknown;
@@ -287,6 +289,7 @@ function parseAuthority(text: string, expectedPluginId: string): PluginAuthority
     throw new Error("plugin authority has an invalid reasonCode");
   }
   const reasonCode = reasonCodeValue as ReasonCode | undefined;
+  const runtimeVersion = optionalString(value, "runtimeVersion");
   const readiness = value.readiness;
   if (readiness !== undefined && !isReadinessReceipt(readiness)) {
     throw new Error("plugin authority has an invalid readiness receipt");
@@ -298,6 +301,7 @@ function parseAuthority(text: string, expectedPluginId: string): PluginAuthority
     lifecycleState: lifecycleState as LifecycleState,
     enabled: value.enabled,
     moduleRef: requiredString(value, "moduleRef"),
+    ...(runtimeVersion === undefined ? {} : { runtimeVersion }),
     config: value.config,
     bindings: value.bindings,
     verifiedScope: value.verifiedScope,

--- a/src/plugin/recovery-coordinator.ts
+++ b/src/plugin/recovery-coordinator.ts
@@ -189,6 +189,7 @@ export class PluginRecoveryCoordinator {
   #finish(record: PluginAuthorityRecord, explicitCleanup: boolean): PluginOperationOutcome {
     record.operation.phase = "completed";
     Reflect.deleteProperty(record, "quarantine");
+    Reflect.deleteProperty(record, "readiness");
     if (explicitCleanup || record.operation.operation === "dispose") {
       record.lifecycleState = "disposed";
       if (record.operation.operation === "dispose") record.operation.disposeCompleted = true;
@@ -247,6 +248,7 @@ export class PluginRecoveryCoordinator {
     record.reasonCode = reasonCode;
     record.operation.phase = "quarantined";
     record.quarantine = { reasonCode, remainingResourceIds, manualActions };
+    Reflect.deleteProperty(record, "readiness");
     this.#store.save(record);
     return operationOutcome(record);
   }

--- a/src/plugin/runtime-readiness.ts
+++ b/src/plugin/runtime-readiness.ts
@@ -88,6 +88,13 @@ export interface ReadinessReceipt {
   readonly verifiedScope: ReadinessScope;
   /** Always present with verifiedScope; null means no successful verification exists. */
   readonly lastVerifiedAt: string | null;
+  /**
+   * Freshness window used to make this receipt. New ready receipts must persist it so a
+   * restarted host can reject the receipt after the same window. It is optional only for
+   * receipts written before #101 added the field; those legacy ready receipts parse but project
+   * unknown until a fresh time-bound receipt is recorded.
+   */
+  readonly verificationWindowMs?: number | null;
   readonly evidence: readonly RuntimeEvidence[];
   readonly reasonCode?: ReasonCode;
   readonly reason?: ReadinessReason;
@@ -143,6 +150,7 @@ export function evaluateRuntimeReadiness(input: ReadinessEvaluationInput): Readi
     authorization: input.authorization === null ? null : cloneAuthorization(input.authorization),
     verifiedScope: cloneScope(input.scope),
     lastVerifiedAt: null,
+    verificationWindowMs: input.maxAgeMs ?? null,
     evidence: cloneEvidence(evidence),
   } as const;
 
@@ -219,20 +227,39 @@ export function evaluateRuntimeReadiness(input: ReadinessEvaluationInput): Readi
   const now = input.now === undefined ? Date.now() : Date.parse(input.now);
   if (!Number.isFinite(now))
     return invalid("evidence-stale", "readiness clock is not a valid ISO timestamp");
-  if (input.maxAgeMs !== undefined && (!Number.isFinite(input.maxAgeMs) || input.maxAgeMs < 0)) {
-    return invalid("evidence-stale", "maxAgeMs must be a non-negative finite number");
+  if (input.maxAgeMs === undefined) {
+    return invalid(
+      "evidence-stale",
+      "a positive maxAgeMs is required to persist a time-bound readiness receipt",
+    );
+  }
+  if (!Number.isFinite(input.maxAgeMs) || input.maxAgeMs <= 0) {
+    return invalid("evidence-stale", "maxAgeMs must be a positive finite number");
   }
 
+  const probeIds = new Set<string>();
   for (const item of evidence) {
     const observed = Date.parse(item.observedAt);
+    if (!validEvidence(item)) {
+      return invalid(
+        "scope-mismatch",
+        "runtime evidence is malformed or outside the requested scope",
+      );
+    }
     if (item.source !== "external") {
       return invalid(
         "evidence-not-independent",
         "runtime evidence is self-reported and cannot prove readiness",
       );
     }
+    if (probeIds.has(item.probeId)) {
+      return invalid(
+        "evidence-not-independent",
+        "existence, running, and readback evidence must use distinct external probe ids",
+      );
+    }
+    probeIds.add(item.probeId);
     if (
-      !validEvidence(item) ||
       !sameIdentityScope(item.scope, input.scope) ||
       item.scope.residentId !== input.scope.residentId ||
       item.scope.lane !== input.scope.lane ||
@@ -326,6 +353,11 @@ export function evaluateRuntimeReadiness(input: ReadinessEvaluationInput): Readi
   };
 }
 
+/** Runtime type guard for the existing #97 verifiedScope authority field. */
+export function isReadinessScope(value: unknown): value is ReadinessScope {
+  return validScope(value);
+}
+
 /** Stable parser used by the durable authority store; malformed receipts cannot project ready. */
 export function isReadinessReceipt(value: unknown): value is ReadinessReceipt {
   if (!isRecord(value)) return false;
@@ -350,7 +382,25 @@ export function isReadinessReceipt(value: unknown): value is ReadinessReceipt {
     (typeof value.lastVerifiedAt !== "string" || !Number.isFinite(Date.parse(value.lastVerifiedAt)))
   )
     return false;
+  if (
+    value.verificationWindowMs !== undefined &&
+    value.verificationWindowMs !== null &&
+    (typeof value.verificationWindowMs !== "number" ||
+      !Number.isFinite(value.verificationWindowMs) ||
+      value.verificationWindowMs <= 0)
+  )
+    return false;
+  if (
+    value.status === "ready" &&
+    value.verificationWindowMs !== undefined &&
+    (typeof value.verificationWindowMs !== "number" ||
+      !Number.isFinite(value.verificationWindowMs) ||
+      value.verificationWindowMs <= 0)
+  )
+    return false;
   if (!Array.isArray(evidence) || !evidence.every(validEvidence)) return false;
+  if (!hasUniqueProbeIds(evidence)) return false;
+  if (value.status !== "ready" && value.lastVerifiedAt !== null) return false;
   if (value.status !== "unknown" && evidence.some((item) => item.source !== "external"))
     return false;
   if (
@@ -409,8 +459,16 @@ export function projectReadiness(
     | "validated"
     | "discovered",
   receipt: ReadinessReceipt | undefined,
+  now: string | number = Date.now(),
 ): ReadinessProjection {
   if (lifecycleState === "active" && receipt !== undefined && isReadinessReceipt(receipt)) {
+    if (receipt.status === "ready" && !isReceiptCurrent(receipt, now)) {
+      return {
+        status: "unknown",
+        reasonCode: "CAPABILITY_UNVERIFIED",
+        detail: "runtime readiness receipt is expired or has no persisted verification window",
+      };
+    }
     return {
       status: receipt.status,
       reasonCode: receipt.reasonCode ?? "CAPABILITY_UNVERIFIED",
@@ -449,6 +507,26 @@ function failedReceipt(
   status: ReadinessStatus = "blocked",
 ): ReadinessReceipt {
   return { ...base, status, reasonCode, reason, detail, lastVerifiedAt: null };
+}
+
+function isReceiptCurrent(receipt: ReadinessReceipt, now: string | number): boolean {
+  if (
+    receipt.status !== "ready" ||
+    receipt.lastVerifiedAt === null ||
+    typeof receipt.verificationWindowMs !== "number" ||
+    !Number.isFinite(receipt.verificationWindowMs) ||
+    receipt.verificationWindowMs <= 0
+  ) {
+    return false;
+  }
+  const verifiedAt = Date.parse(receipt.lastVerifiedAt);
+  const currentTime = typeof now === "number" ? now : Date.parse(now);
+  return (
+    Number.isFinite(verifiedAt) &&
+    Number.isFinite(currentTime) &&
+    verifiedAt <= currentTime &&
+    currentTime - verifiedAt <= receipt.verificationWindowMs
+  );
 }
 
 function latestObservedAt(evidence: readonly RuntimeEvidence[]): string {
@@ -621,6 +699,9 @@ function stringArray(value: unknown): value is readonly string[] {
 function containsAll(haystack: readonly string[], needles: readonly string[]): boolean {
   const values = new Set(haystack);
   return needles.every((value) => values.has(value));
+}
+function hasUniqueProbeIds(evidence: readonly RuntimeEvidence[]): boolean {
+  return new Set(evidence.map((item) => item.probeId)).size === evidence.length;
 }
 function sameDefinition(definition: ReadinessDefinition, binding: ReadinessBinding): boolean {
   return (

--- a/src/plugin/runtime-readiness.ts
+++ b/src/plugin/runtime-readiness.ts
@@ -120,6 +120,12 @@ export interface RuntimeReadbackProbe {
   readonly readback: (scope: ReadinessScope) => Promise<RuntimeEvidence>;
 }
 
+/** Input and an observer owned by the current host invocation; callers do not supply a receipt. */
+export interface RuntimeReadinessRequest {
+  readonly input: ReadinessEvaluationInput;
+  readonly probe: RuntimeReadbackProbe;
+}
+
 /**
  * Run an independent existence/running/readback probe and evaluate its receipt.
  * A probe that cannot answer is represented by missing evidence and therefore `unknown`;
@@ -453,12 +459,19 @@ export function isReadinessReceipt(value: unknown): value is ReadinessReceipt {
 }
 
 /** A projection used by the host: an active plugin without a receipt is explicitly unknown. */
-export interface ReadinessProjection {
-  readonly status: ReadinessStatus;
-  readonly reasonCode: ReasonCode;
-  readonly detail: string;
-  readonly receipt?: ReadinessReceipt;
-}
+export type ReadinessProjection =
+  | {
+      readonly status: "ready";
+      readonly detail: string;
+      readonly receipt: ReadinessReceipt;
+      readonly reasonCode?: never;
+    }
+  | {
+      readonly status: Exclude<ReadinessStatus, "ready">;
+      readonly reasonCode: ReasonCode;
+      readonly detail: string;
+      readonly receipt?: ReadinessReceipt;
+    };
 
 export function projectReadiness(
   lifecycleState:
@@ -479,6 +492,13 @@ export function projectReadiness(
         status: "unknown",
         reasonCode: "CAPABILITY_UNVERIFIED",
         detail: "runtime readiness receipt is expired or has no persisted verification window",
+      };
+    }
+    if (receipt.status === "ready") {
+      return {
+        status: "ready",
+        detail: receipt.detail,
+        receipt,
       };
     }
     return {

--- a/src/plugin/runtime-readiness.ts
+++ b/src/plugin/runtime-readiness.ts
@@ -403,6 +403,18 @@ export function isReadinessReceipt(value: unknown): value is ReadinessReceipt {
   if (value.status !== "ready" && value.lastVerifiedAt !== null) return false;
   if (value.status !== "unknown" && evidence.some((item) => item.source !== "external"))
     return false;
+  if (value.status === "ready") {
+    if (value.lastVerifiedAt === null) return false;
+    if (value.lastVerifiedAt !== latestObservedAt(evidence)) return false;
+    if (value.reason !== undefined || value.reasonCode !== undefined) return false;
+    if (
+      value.verificationWindowMs !== undefined &&
+      typeof value.verificationWindowMs === "number" &&
+      !evidenceWithinVerificationWindow(evidence, value.lastVerifiedAt, value.verificationWindowMs)
+    ) {
+      return false;
+    }
+  }
   if (
     value.status === "ready" &&
     (value.lastVerifiedAt === null ||
@@ -529,13 +541,32 @@ function isReceiptCurrent(receipt: ReadinessReceipt, now: string | number): bool
   );
 }
 
+function evidenceWithinVerificationWindow(
+  evidence: readonly RuntimeEvidence[],
+  lastVerifiedAt: string,
+  verificationWindowMs: number,
+): boolean {
+  const verifiedAt = Date.parse(lastVerifiedAt);
+  if (!Number.isFinite(verifiedAt)) return false;
+  return evidence.every((item) => {
+    const observedAt = Date.parse(item.observedAt);
+    return (
+      Number.isFinite(observedAt) &&
+      observedAt <= verifiedAt &&
+      verifiedAt - observedAt <= verificationWindowMs
+    );
+  });
+}
+
 function latestObservedAt(evidence: readonly RuntimeEvidence[]): string {
-  return (
-    evidence
-      .map((item) => item.observedAt)
-      .sort()
-      .at(-1) ?? new Date(0).toISOString()
-  );
+  return evidence.reduce((latest, item) => {
+    const latestAt = Date.parse(latest);
+    const itemAt = Date.parse(item.observedAt);
+    if (itemAt > latestAt || (itemAt === latestAt && item.observedAt > latest)) {
+      return item.observedAt;
+    }
+    return latest;
+  }, new Date(0).toISOString());
 }
 
 function cloneDefinition(value: ReadinessDefinition): ReadinessDefinition {

--- a/src/plugin/runtime-readiness.ts
+++ b/src/plugin/runtime-readiness.ts
@@ -1,0 +1,657 @@
+import type { ReasonCode } from "./types.ts";
+
+/** Version of the persisted runtime-readiness receipt contract. */
+export const READINESS_RECEIPT_SCHEMA_VERSION = 1 as const;
+
+export type ReadinessStatus = "ready" | "degraded" | "blocked" | "quarantined" | "unknown";
+
+/** Values that may be copied into a diagnostic receipt without carrying secrets. */
+export type ReadinessValue = string | number | boolean;
+
+/** The boundary at which a readiness claim was observed. */
+export interface ReadinessScope {
+  readonly residentId: string;
+  readonly lane: string;
+  readonly operations: readonly string[];
+  readonly host: string;
+  readonly networkPath: string;
+  /** Deployed/runtime version, not a repository version guessed by the caller. */
+  readonly version: string;
+}
+
+/** Stable capability identity. Runtime readiness never changes this definition. */
+export interface ReadinessDefinition {
+  readonly pluginId: string;
+  readonly capabilityId: string;
+  readonly version: string;
+  readonly moduleRef: string;
+}
+
+/** The implementation path selected for this host and network path. */
+export interface ReadinessBinding {
+  readonly pluginId: string;
+  readonly capabilityId: string;
+  readonly version: string;
+  readonly moduleRef: string;
+  readonly host: string;
+  readonly networkPath: string;
+}
+
+/** Authorization is an input to readiness, not a fact inferred from a successful probe. */
+export interface ReadinessAuthorization {
+  readonly residentId: string;
+  readonly lane: string;
+  readonly operations: readonly string[];
+}
+
+export type RuntimeEvidenceKind = "existence" | "running" | "readback";
+export type RuntimeEvidenceOutcome = "pass" | "fail";
+
+/**
+ * One externally observed fact. `source: "self"` is accepted by the type so callers can
+ * report a bad probe, but the evaluator deliberately refuses to use self-reported evidence.
+ */
+export interface RuntimeEvidence {
+  readonly kind: RuntimeEvidenceKind;
+  readonly source: "external" | "self";
+  readonly probeId: string;
+  readonly observedAt: string;
+  readonly scope: ReadinessScope;
+  readonly version: string;
+  readonly moduleRef: string;
+  readonly outcome: RuntimeEvidenceOutcome;
+  /** Conditions and measurements belong to the same evidence row; no naked numbers. */
+  readonly conditions: Readonly<Record<string, ReadinessValue>>;
+  readonly measurements?: Readonly<Record<string, number>>;
+  readonly detail?: string;
+}
+
+export interface ReadinessEvaluationInput {
+  readonly definition: ReadinessDefinition;
+  readonly binding: ReadinessBinding | null;
+  readonly authorization: ReadinessAuthorization | null;
+  readonly scope: ReadinessScope;
+  readonly expectedConditions?: Readonly<Record<string, ReadinessValue>>;
+  readonly evidence?: readonly RuntimeEvidence[];
+  /** Clock injection keeps freshness tests deterministic. */
+  readonly now?: string;
+  readonly maxAgeMs?: number;
+}
+
+export interface ReadinessReceipt {
+  readonly schemaVersion: typeof READINESS_RECEIPT_SCHEMA_VERSION;
+  readonly status: ReadinessStatus;
+  readonly definition: ReadinessDefinition;
+  readonly binding: ReadinessBinding | null;
+  readonly authorization: ReadinessAuthorization | null;
+  /** This is the requested/proven boundary; it is proof only when status is ready. */
+  readonly verifiedScope: ReadinessScope;
+  /** Always present with verifiedScope; null means no successful verification exists. */
+  readonly lastVerifiedAt: string | null;
+  readonly evidence: readonly RuntimeEvidence[];
+  readonly reasonCode?: ReasonCode;
+  readonly reason?: ReadinessReason;
+  readonly detail: string;
+}
+
+export type ReadinessReason =
+  | "binding-missing"
+  | "authorization-missing"
+  | "evidence-missing"
+  | "evidence-not-independent"
+  | "scope-mismatch"
+  | "version-mismatch"
+  | "condition-mismatch"
+  | "evidence-stale"
+  | "existence-failed"
+  | "running-failed"
+  | "readback-failed";
+
+export interface RuntimeReadbackProbe {
+  readonly existence: (scope: ReadinessScope) => Promise<RuntimeEvidence>;
+  readonly running: (scope: ReadinessScope) => Promise<RuntimeEvidence>;
+  readonly readback: (scope: ReadinessScope) => Promise<RuntimeEvidence>;
+}
+
+/**
+ * Run an independent existence/running/readback probe and evaluate its receipt.
+ * A probe that cannot answer is represented by missing evidence and therefore `unknown`;
+ * this function never turns a thrown probe into an optimistic ready result.
+ */
+export async function readRuntimeReadiness(
+  input: ReadinessEvaluationInput,
+  probe: RuntimeReadbackProbe,
+): Promise<ReadinessReceipt> {
+  const evidence: RuntimeEvidence[] = [];
+  for (const run of [probe.existence, probe.running, probe.readback]) {
+    try {
+      evidence.push(await run(input.scope));
+    } catch {
+      // An unavailable readback is not a failed assertion about the target. Keep it unknown.
+    }
+  }
+  return evaluateRuntimeReadiness({ ...input, evidence });
+}
+
+/** Evaluate only evidence that is independent, scoped, current, and condition-bound. */
+export function evaluateRuntimeReadiness(input: ReadinessEvaluationInput): ReadinessReceipt {
+  const evidence = [...(input.evidence ?? [])];
+  const base = {
+    schemaVersion: READINESS_RECEIPT_SCHEMA_VERSION,
+    definition: cloneDefinition(input.definition),
+    binding: input.binding === null ? null : cloneBinding(input.binding),
+    authorization: input.authorization === null ? null : cloneAuthorization(input.authorization),
+    verifiedScope: cloneScope(input.scope),
+    lastVerifiedAt: null,
+    evidence: cloneEvidence(evidence),
+  } as const;
+
+  const invalid = (reason: ReadinessReason, detail: string): ReadinessReceipt => ({
+    ...base,
+    status: "unknown",
+    reasonCode: "CAPABILITY_UNVERIFIED",
+    reason,
+    detail,
+  });
+
+  if (!validScope(input.scope) || !validDefinition(input.definition)) {
+    return invalid(
+      "scope-mismatch",
+      "readiness scope or definition is not a valid non-empty contract",
+    );
+  }
+  if (input.binding === null) {
+    return invalid("binding-missing", "capability definition exists but has no runtime binding");
+  }
+  if (!validBinding(input.binding)) {
+    return invalid("version-mismatch", "runtime binding is not a valid scoped binding");
+  }
+  if (input.authorization === null) {
+    return {
+      ...base,
+      status: "blocked",
+      reasonCode: "PERMISSION_DENIED",
+      reason: "authorization-missing",
+      detail: "no authorization exists for this resident, lane, and operation set",
+    };
+  }
+  if (!validAuthorization(input.authorization)) {
+    return {
+      ...base,
+      status: "blocked",
+      reasonCode: "PERMISSION_DENIED",
+      reason: "authorization-missing",
+      detail: "authorization is malformed or empty",
+    };
+  }
+  if (!sameDefinition(input.definition, input.binding)) {
+    return invalid(
+      "version-mismatch",
+      "definition, deployment, and runtime module identity disagree",
+    );
+  }
+  if (!sameIdentityScope(input.scope, input.binding)) {
+    return invalid("scope-mismatch", "runtime binding does not cover this host or network path");
+  }
+  if (
+    input.authorization.residentId !== input.scope.residentId ||
+    input.authorization.lane !== input.scope.lane ||
+    !containsAll(input.authorization.operations, input.scope.operations)
+  ) {
+    return {
+      ...base,
+      status: "blocked",
+      reasonCode: "PERMISSION_DENIED",
+      reason: "authorization-missing",
+      detail: "authorization does not cover the requested resident, lane, or operations",
+    };
+  }
+  if (input.expectedConditions !== undefined && !validConditions(input.expectedConditions)) {
+    return invalid("condition-mismatch", "expected conditions are not a valid non-empty-key map");
+  }
+  if (evidence.length === 0) {
+    return invalid(
+      "evidence-missing",
+      "no independent runtime existence, running, or readback evidence",
+    );
+  }
+
+  const now = input.now === undefined ? Date.now() : Date.parse(input.now);
+  if (!Number.isFinite(now))
+    return invalid("evidence-stale", "readiness clock is not a valid ISO timestamp");
+  if (input.maxAgeMs !== undefined && (!Number.isFinite(input.maxAgeMs) || input.maxAgeMs < 0)) {
+    return invalid("evidence-stale", "maxAgeMs must be a non-negative finite number");
+  }
+
+  for (const item of evidence) {
+    const observed = Date.parse(item.observedAt);
+    if (item.source !== "external") {
+      return invalid(
+        "evidence-not-independent",
+        "runtime evidence is self-reported and cannot prove readiness",
+      );
+    }
+    if (
+      !validEvidence(item) ||
+      !sameIdentityScope(item.scope, input.scope) ||
+      item.scope.residentId !== input.scope.residentId ||
+      item.scope.lane !== input.scope.lane ||
+      !containsAll(input.scope.operations, item.scope.operations) ||
+      item.version !== input.definition.version ||
+      item.version !== input.binding.version ||
+      item.moduleRef !== input.definition.moduleRef ||
+      item.moduleRef !== input.binding.moduleRef
+    ) {
+      return invalid(
+        "scope-mismatch",
+        "runtime evidence is self-reported or outside the requested scope",
+      );
+    }
+    if (input.maxAgeMs !== undefined && now - observed > input.maxAgeMs) {
+      return invalid(
+        "evidence-stale",
+        "runtime evidence is older than the accepted verification window",
+      );
+    }
+    if (observed > now) return invalid("evidence-stale", "runtime evidence is from the future");
+    if (
+      input.expectedConditions !== undefined &&
+      !sameConditions(input.expectedConditions, item.conditions)
+    ) {
+      return invalid(
+        "condition-mismatch",
+        "runtime evidence conditions do not match the requested path",
+      );
+    }
+  }
+
+  const requiredKinds: readonly RuntimeEvidenceKind[] = ["existence", "running", "readback"];
+  for (const kind of requiredKinds) {
+    if (!evidence.some((item) => item.kind === kind)) {
+      return invalid("evidence-missing", `missing independent ${kind} evidence`);
+    }
+  }
+
+  const readbackOperations = new Set(
+    evidence.filter((item) => item.kind === "readback").flatMap((item) => item.scope.operations),
+  );
+  if (!containsAll([...readbackOperations], input.scope.operations)) {
+    return invalid("evidence-missing", "runtime readback does not cover every requested operation");
+  }
+
+  const failed = evidence.filter((item) => item.outcome === "fail");
+  if (failed.length > 0) {
+    const first = failed[0];
+    if (first?.kind === "existence") {
+      return failedReceipt(
+        base,
+        "existence-failed",
+        "PLUGIN_RUNTIME_FAILED",
+        "independent existence probe failed",
+      );
+    }
+    if (first?.kind === "running") {
+      return failedReceipt(
+        base,
+        "running-failed",
+        "PLUGIN_RUNTIME_FAILED",
+        "independent running probe failed",
+      );
+    }
+    const passedReadbackOperations = new Set(
+      evidence
+        .filter((item) => item.kind === "readback" && item.outcome === "pass")
+        .flatMap((item) => item.scope.operations),
+    );
+    const hasPartialReadback = input.scope.operations.some((operation) =>
+      passedReadbackOperations.has(operation),
+    );
+    return failedReceipt(
+      base,
+      "readback-failed",
+      "PLUGIN_RUNTIME_FAILED",
+      hasPartialReadback
+        ? "runtime readback failed for part of the authorized operation set"
+        : "runtime readback failed for the requested path",
+      hasPartialReadback ? "degraded" : "blocked",
+    );
+  }
+
+  const verifiedAt = latestObservedAt(evidence);
+  return {
+    ...base,
+    status: "ready",
+    lastVerifiedAt: verifiedAt,
+    detail: "independent existence, running, and scoped runtime readback all passed",
+  };
+}
+
+/** Stable parser used by the durable authority store; malformed receipts cannot project ready. */
+export function isReadinessReceipt(value: unknown): value is ReadinessReceipt {
+  if (!isRecord(value)) return false;
+  if (
+    value.schemaVersion !== READINESS_RECEIPT_SCHEMA_VERSION ||
+    !isReadinessStatus(value.status) ||
+    typeof value.detail !== "string"
+  ) {
+    return false;
+  }
+  if (!validDefinition(value.definition)) return false;
+  const definition = value.definition;
+  const binding = value.binding;
+  const authorization = value.authorization;
+  const verifiedScope = value.verifiedScope;
+  const evidence = value.evidence;
+  if (binding !== null && !validBinding(binding)) return false;
+  if (authorization !== null && !validAuthorization(authorization)) return false;
+  if (!validScope(verifiedScope)) return false;
+  if (
+    value.lastVerifiedAt !== null &&
+    (typeof value.lastVerifiedAt !== "string" || !Number.isFinite(Date.parse(value.lastVerifiedAt)))
+  )
+    return false;
+  if (!Array.isArray(evidence) || !evidence.every(validEvidence)) return false;
+  if (value.status !== "unknown" && evidence.some((item) => item.source !== "external"))
+    return false;
+  if (
+    value.status === "ready" &&
+    (value.lastVerifiedAt === null ||
+      binding === null ||
+      authorization === null ||
+      !sameDefinition(definition, binding) ||
+      !sameIdentityScope(verifiedScope, binding) ||
+      authorization.residentId !== verifiedScope.residentId ||
+      authorization.lane !== verifiedScope.lane ||
+      !containsAll(authorization.operations, verifiedScope.operations) ||
+      evidence.some(
+        (item) =>
+          item.outcome !== "pass" ||
+          item.source !== "external" ||
+          item.version !== definition.version ||
+          item.moduleRef !== definition.moduleRef ||
+          item.scope.residentId !== verifiedScope.residentId ||
+          item.scope.lane !== verifiedScope.lane ||
+          !containsAll(verifiedScope.operations, item.scope.operations) ||
+          !sameIdentityScope(item.scope, verifiedScope),
+      ) ||
+      !["existence", "running", "readback"].every((kind) =>
+        evidence.some((item) => item.kind === kind),
+      ) ||
+      !containsAll(
+        evidence
+          .filter((item) => item.kind === "readback")
+          .flatMap((item) => item.scope.operations),
+        verifiedScope.operations,
+      ))
+  )
+    return false;
+  if (value.reasonCode !== undefined && !isReasonCode(value.reasonCode)) return false;
+  if (value.reason !== undefined && !isReadinessReason(value.reason)) return false;
+  return true;
+}
+
+/** A projection used by the host: an active plugin without a receipt is explicitly unknown. */
+export interface ReadinessProjection {
+  readonly status: ReadinessStatus;
+  readonly reasonCode: ReasonCode;
+  readonly detail: string;
+  readonly receipt?: ReadinessReceipt;
+}
+
+export function projectReadiness(
+  lifecycleState:
+    | "active"
+    | "blocked"
+    | "quarantined"
+    | "disposed"
+    | "disposing"
+    | "prepared"
+    | "validated"
+    | "discovered",
+  receipt: ReadinessReceipt | undefined,
+): ReadinessProjection {
+  if (lifecycleState === "active" && receipt !== undefined && isReadinessReceipt(receipt)) {
+    return {
+      status: receipt.status,
+      reasonCode: receipt.reasonCode ?? "CAPABILITY_UNVERIFIED",
+      detail: receipt.detail,
+      receipt,
+    };
+  }
+  if (lifecycleState === "quarantined") {
+    return {
+      status: "quarantined",
+      reasonCode: "DISPOSE_INCOMPLETE",
+      detail: "plugin is quarantined; readiness is fail-closed",
+    };
+  }
+  if (lifecycleState === "blocked") {
+    return {
+      status: "blocked",
+      reasonCode: "CAPABILITY_UNVERIFIED",
+      detail: "plugin is blocked; no readiness projection is exposed",
+    };
+  }
+  return {
+    status: "unknown",
+    reasonCode: "CAPABILITY_UNVERIFIED",
+    detail: "no runtime readiness receipt is available",
+  };
+}
+
+function failedReceipt(
+  base: Omit<ReadinessReceipt, "status" | "reasonCode" | "reason" | "detail" | "lastVerifiedAt"> & {
+    readonly lastVerifiedAt: null;
+  },
+  reason: ReadinessReason,
+  reasonCode: ReasonCode,
+  detail: string,
+  status: ReadinessStatus = "blocked",
+): ReadinessReceipt {
+  return { ...base, status, reasonCode, reason, detail, lastVerifiedAt: null };
+}
+
+function latestObservedAt(evidence: readonly RuntimeEvidence[]): string {
+  return (
+    evidence
+      .map((item) => item.observedAt)
+      .sort()
+      .at(-1) ?? new Date(0).toISOString()
+  );
+}
+
+function cloneDefinition(value: ReadinessDefinition): ReadinessDefinition {
+  return { ...value };
+}
+function cloneBinding(value: ReadinessBinding): ReadinessBinding {
+  return { ...value };
+}
+function cloneAuthorization(value: ReadinessAuthorization): ReadinessAuthorization {
+  return { ...value, operations: [...value.operations] };
+}
+function cloneScope(value: ReadinessScope): ReadinessScope {
+  return { ...value, operations: [...value.operations] };
+}
+function cloneEvidence(values: readonly RuntimeEvidence[]): RuntimeEvidence[] {
+  return values.map((value) => ({
+    ...value,
+    scope: cloneScope(value.scope),
+    conditions: { ...value.conditions },
+    ...(value.measurements === undefined ? {} : { measurements: { ...value.measurements } }),
+  }));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function isReadinessStatus(value: unknown): value is ReadinessStatus {
+  return (
+    value === "ready" ||
+    value === "degraded" ||
+    value === "blocked" ||
+    value === "quarantined" ||
+    value === "unknown"
+  );
+}
+function isReadinessReason(value: unknown): value is ReadinessReason {
+  return (
+    typeof value === "string" &&
+    [
+      "binding-missing",
+      "authorization-missing",
+      "evidence-missing",
+      "evidence-not-independent",
+      "scope-mismatch",
+      "version-mismatch",
+      "condition-mismatch",
+      "evidence-stale",
+      "existence-failed",
+      "running-failed",
+      "readback-failed",
+    ].includes(value)
+  );
+}
+function isReasonCode(value: unknown): value is ReasonCode {
+  return (
+    typeof value === "string" &&
+    [
+      "MANIFEST_INVALID",
+      "HOST_INCOMPATIBLE",
+      "PLUGIN_ID_CONFLICT",
+      "CONFIG_INVALID",
+      "REQUIREMENT_MISSING",
+      "CREDENTIAL_TYPE_MISMATCH",
+      "CREDENTIAL_ISSUER_UNAVAILABLE",
+      "PERMISSION_DENIED",
+      "PREPARE_FAILED",
+      "ACTIVATE_FAILED",
+      "RECOVERY_HANDLE_UNAVAILABLE",
+      "MIGRATION_FAILED",
+      "UPGRADE_PERMISSION_CONFIRMATION_REQUIRED",
+      "DISPOSE_INCOMPLETE",
+      "LIFECYCLE_RECOVERY_PENDING",
+      "PLUGIN_RUNTIME_FAILED",
+      "CONTEXT_INJECTION_MISMATCH",
+      "SENSITIVE_OUTPUT_BLOCKED",
+      "CAPABILITY_UNVERIFIED",
+    ].includes(value)
+  );
+}
+function validDefinition(value: unknown): value is ReadinessDefinition {
+  return (
+    isRecord(value) &&
+    nonEmpty(value.pluginId) &&
+    nonEmpty(value.capabilityId) &&
+    nonEmpty(value.version) &&
+    nonEmpty(value.moduleRef)
+  );
+}
+function validBinding(value: unknown): value is ReadinessBinding {
+  return (
+    isRecord(value) &&
+    nonEmpty(value.pluginId) &&
+    nonEmpty(value.capabilityId) &&
+    nonEmpty(value.version) &&
+    nonEmpty(value.moduleRef) &&
+    nonEmpty(value.host) &&
+    nonEmpty(value.networkPath)
+  );
+}
+function validAuthorization(value: unknown): value is ReadinessAuthorization {
+  return (
+    isRecord(value) &&
+    nonEmpty(value.residentId) &&
+    nonEmpty(value.lane) &&
+    stringArray(value.operations)
+  );
+}
+function validScope(value: unknown): value is ReadinessScope {
+  return (
+    isRecord(value) &&
+    nonEmpty(value.residentId) &&
+    nonEmpty(value.lane) &&
+    stringArray(value.operations) &&
+    value.operations.length > 0 &&
+    nonEmpty(value.host) &&
+    nonEmpty(value.networkPath) &&
+    nonEmpty(value.version)
+  );
+}
+function validEvidence(value: unknown): value is RuntimeEvidence {
+  return (
+    isRecord(value) &&
+    (value.kind === "existence" || value.kind === "running" || value.kind === "readback") &&
+    (value.source === "external" || value.source === "self") &&
+    nonEmpty(value.probeId) &&
+    nonEmpty(value.observedAt) &&
+    Number.isFinite(Date.parse(value.observedAt)) &&
+    validScope(value.scope) &&
+    nonEmpty(value.version) &&
+    nonEmpty(value.moduleRef) &&
+    (value.outcome === "pass" || value.outcome === "fail") &&
+    validConditions(value.conditions) &&
+    (value.measurements === undefined || validMeasurements(value.measurements))
+  );
+}
+function validConditions(value: unknown): value is Readonly<Record<string, ReadinessValue>> {
+  return (
+    isRecord(value) &&
+    Object.entries(value).every(([key, item]) => nonEmpty(key) && validValue(item))
+  );
+}
+function validMeasurements(value: unknown): value is Readonly<Record<string, number>> {
+  return (
+    isRecord(value) &&
+    Object.values(value).every((item) => typeof item === "number" && Number.isFinite(item))
+  );
+}
+function validValue(value: unknown): value is ReadinessValue {
+  return (
+    (typeof value === "string" && value.length > 0) ||
+    (typeof value === "number" && Number.isFinite(value)) ||
+    typeof value === "boolean"
+  );
+}
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+function stringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every(nonEmpty);
+}
+function containsAll(haystack: readonly string[], needles: readonly string[]): boolean {
+  const values = new Set(haystack);
+  return needles.every((value) => values.has(value));
+}
+function sameDefinition(definition: ReadinessDefinition, binding: ReadinessBinding): boolean {
+  return (
+    definition.pluginId === binding.pluginId &&
+    definition.capabilityId === binding.capabilityId &&
+    definition.version === binding.version &&
+    definition.moduleRef === binding.moduleRef
+  );
+}
+function sameIdentityScope(
+  scope: ReadinessScope,
+  binding: Pick<ReadinessBinding, "host" | "networkPath" | "version">,
+): boolean {
+  return (
+    scope.host === binding.host &&
+    scope.networkPath === binding.networkPath &&
+    scope.version === binding.version
+  );
+}
+function sameConditions(
+  expected: Readonly<Record<string, ReadinessValue>>,
+  actual: Readonly<Record<string, ReadinessValue>>,
+): boolean {
+  const expectedEntries = Object.entries(expected);
+  return (
+    expectedEntries.length === Object.keys(actual).length &&
+    expectedEntries.every(([key, value]) => actual[key] === value)
+  );
+}
+
+// Descriptive aliases keep callers from coupling to whether the operation is a pure evaluation
+// or a probe-backed readback; both paths share exactly the same contract and failure semantics.
+export const checkRuntimeReadiness = readRuntimeReadiness;
+export const evaluateReadiness = evaluateRuntimeReadiness;

--- a/src/plugin/runtime-readiness.ts
+++ b/src/plugin/runtime-readiness.ts
@@ -312,25 +312,30 @@ export function evaluateRuntimeReadiness(input: ReadinessEvaluationInput): Readi
     return invalid("evidence-missing", "runtime readback does not cover every requested operation");
   }
 
-  const failed = evidence.filter((item) => item.outcome === "fail");
-  if (failed.length > 0) {
-    const first = failed[0];
-    if (first?.kind === "existence") {
-      return failedReceipt(
-        base,
-        "existence-failed",
-        "PLUGIN_RUNTIME_FAILED",
-        "independent existence probe failed",
-      );
-    }
-    if (first?.kind === "running") {
-      return failedReceipt(
-        base,
-        "running-failed",
-        "PLUGIN_RUNTIME_FAILED",
-        "independent running probe failed",
-      );
-    }
+  const failedExistence = evidence.find(
+    (item) => item.kind === "existence" && item.outcome === "fail",
+  );
+  const failedRunning = evidence.find((item) => item.kind === "running" && item.outcome === "fail");
+  const failedReadback = evidence.find(
+    (item) => item.kind === "readback" && item.outcome === "fail",
+  );
+  if (failedExistence !== undefined) {
+    return failedReceipt(
+      base,
+      "existence-failed",
+      "PLUGIN_RUNTIME_FAILED",
+      "independent existence probe failed",
+    );
+  }
+  if (failedRunning !== undefined) {
+    return failedReceipt(
+      base,
+      "running-failed",
+      "PLUGIN_RUNTIME_FAILED",
+      "independent running probe failed",
+    );
+  }
+  if (failedReadback !== undefined) {
     const passedReadbackOperations = new Set(
       evidence
         .filter((item) => item.kind === "readback" && item.outcome === "pass")
@@ -485,6 +490,7 @@ export function projectReadiness(
     | "discovered",
   receipt: ReadinessReceipt | undefined,
   now: string | number = Date.now(),
+  lifecycleReasonCode?: ReasonCode,
 ): ReadinessProjection {
   if (lifecycleState === "active" && receipt !== undefined && isReadinessReceipt(receipt)) {
     if (receipt.status === "ready" && !isReceiptCurrent(receipt, now)) {
@@ -518,7 +524,7 @@ export function projectReadiness(
   if (lifecycleState === "blocked") {
     return {
       status: "blocked",
-      reasonCode: "CAPABILITY_UNVERIFIED",
+      reasonCode: lifecycleReasonCode ?? "CAPABILITY_UNVERIFIED",
       detail: "plugin is blocked; no readiness projection is exposed",
     };
   }

--- a/src/plugin/transaction-host.ts
+++ b/src/plugin/transaction-host.ts
@@ -154,7 +154,7 @@ export class PluginTransactionHost {
     if (
       request.readiness !== undefined &&
       (!isReadinessReceipt(request.readiness) ||
-        !readinessMatchesAuthority(record, request.readiness))
+        !readinessMatchesAuthority(record, request.readiness, null))
     ) {
       throw new Error("runtime readiness receipt does not match the current plugin authority");
     }
@@ -211,21 +211,24 @@ export class PluginTransactionHost {
           request.readinessRequest.probe,
         );
       } catch {
+        // Normal probe failures become an explicit non-ready receipt. Malformed probe output
+        // can still fail during evaluation and must roll back the in-flight transaction.
         return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
       }
-      const generatedRecord: PluginAuthorityRecord = {
-        ...record,
-        verifiedScope: generated.verifiedScope,
-        readiness: generated,
-      };
       if (!isReadinessReceipt(generated)) {
         return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
       }
-      if (!readinessMatchesAuthority(generatedRecord, generated)) {
+      if (
+        !readinessMatchesAuthority(
+          record,
+          generated,
+          record.verifiedScope === null ? undefined : record.verifiedScope,
+        )
+      ) {
         // A probe can report a valid receipt for a different deployed version. Keep the
         // lifecycle activation usable, but never persist that receipt as this authority's
         // readiness. Other identity/scope mismatches remain activation failures.
-        if (!isAuthorityVersionMismatch(generatedRecord, generated)) {
+        if (!isAuthorityVersionMismatch(record, generated, record.verifiedScope)) {
           return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
         }
         Reflect.deleteProperty(record, "readiness");
@@ -241,7 +244,7 @@ export class PluginTransactionHost {
     } else if (
       request.readiness !== undefined &&
       (!isReadinessReceipt(request.readiness) ||
-        !readinessMatchesAuthority(record, request.readiness))
+        !readinessMatchesAuthority(record, request.readiness, null))
     ) {
       return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
     }
@@ -459,15 +462,15 @@ export class PluginTransactionHost {
     if (
       record.readiness !== undefined &&
       (!isReadinessReceipt(record.readiness) ||
-        !readinessMatchesAuthority(record, record.readiness))
+        !readinessMatchesAuthority(record, record.readiness, record.verifiedScope ?? null))
     ) {
       return {
         status: "unknown",
-        reasonCode: "CAPABILITY_UNVERIFIED",
+        reasonCode: record.reasonCode ?? "CAPABILITY_UNVERIFIED",
         detail: "runtime readiness receipt does not describe the current plugin authority",
       };
     }
-    return projectReadiness(record.lifecycleState, record.readiness, now);
+    return projectReadiness(record.lifecycleState, record.readiness, now, record.reasonCode);
   }
 
   /**
@@ -483,7 +486,7 @@ export class PluginTransactionHost {
     const updated: PluginAuthorityRecord = { ...record, verifiedScope: null };
     Reflect.deleteProperty(updated, "readiness");
     this.#store.save(updated);
-    return projectReadiness(updated.lifecycleState, undefined, now);
+    return projectReadiness(updated.lifecycleState, undefined, now, updated.reasonCode);
   }
 
   /** Persist a fresh external receipt without changing lifecycle or capability definitions. */
@@ -501,7 +504,10 @@ export class PluginTransactionHost {
         "ready runtime readiness must be produced by a current-process readback probe",
       );
     }
-    if (!isReadinessReceipt(receipt) || !readinessMatchesAuthority(record, receipt)) {
+    if (
+      !isReadinessReceipt(receipt) ||
+      !readinessMatchesAuthority(record, receipt, record.verifiedScope)
+    ) {
       throw new Error("runtime readiness receipt does not match the current plugin authority");
     }
     const updated: PluginAuthorityRecord = {
@@ -510,7 +516,7 @@ export class PluginTransactionHost {
       readiness: receipt,
     };
     this.#store.save(updated);
-    return projectReadiness(updated.lifecycleState, updated.readiness, now);
+    return projectReadiness(updated.lifecycleState, updated.readiness, now, updated.reasonCode);
   }
 
   /** Execute the current-process probe before persisting a fresh readiness receipt. */
@@ -537,17 +543,23 @@ export class PluginTransactionHost {
     if (!isReadinessReceipt(receipt)) {
       throw new Error("runtime readiness probe result does not match the current plugin authority");
     }
-    if (!readinessMatchesAuthority(updated, receipt)) {
-      if (isAuthorityVersionMismatch(updated, receipt)) {
+    if (
+      !readinessMatchesAuthority(
+        record,
+        receipt,
+        record.verifiedScope === null ? undefined : record.verifiedScope,
+      )
+    ) {
+      if (isAuthorityVersionMismatch(record, receipt, record.verifiedScope)) {
         Reflect.deleteProperty(record, "readiness");
         Object.assign(record, { verifiedScope: null });
         this.#store.save(record);
-        return projectReadiness(record.lifecycleState, undefined, now);
+        return projectReadiness(record.lifecycleState, undefined, now, record.reasonCode);
       }
       throw new Error("runtime readiness probe result does not match the current plugin authority");
     }
     this.#store.save(updated);
-    return projectReadiness(updated.lifecycleState, updated.readiness, now);
+    return projectReadiness(updated.lifecycleState, updated.readiness, now, updated.reasonCode);
   }
 
   async #rollbackCurrent(
@@ -667,18 +679,26 @@ export class PluginTransactionHost {
 
 /**
  * The operation authority has plugin/module identity but deliberately does not become a
- * capability registry. Check the receipt's binding tuple against that identity and against
- * its own definition/scope, while leaving canonical capability ownership to #100.
+ * capability registry. Check the receipt's binding tuple against that identity and, when a
+ * prior authority scope exists, that historical scope; canonical scope ownership remains #100's.
  */
 function readinessMatchesAuthority(
   record: PluginAuthorityRecord,
   receipt: ReadinessReceipt,
+  authorityScopeValue: unknown,
 ): boolean {
   const { binding, definition, verifiedScope } = receipt;
   const declaredCapabilityIds = record.operation.resources.flatMap((resource) =>
     resource.capabilityId === undefined ? [] : [resource.capabilityId],
   );
-  const authorityScope = isReadinessScope(record.verifiedScope) ? record.verifiedScope : null;
+  // v0 may have no authority-side resident/lane/operation/host anchor yet. In that case
+  // the evaluator still checks the receipt's internal scope/binding/authorization, but this
+  // function must not pretend that a scope comparison happened. `undefined` means no anchor
+  // exists yet (so a fresh probe may establish one); an explicit null/malformed value means a
+  // ready receipt cannot be projected. Once verifiedScope exists, callers pass the pre-existing
+  // value rather than copying the receipt into it.
+  const hasAuthorityScope = authorityScopeValue !== undefined;
+  const authorityScope = isReadinessScope(authorityScopeValue) ? authorityScopeValue : null;
   const authorityVersion = record.runtimeVersion;
   const versionMatches =
     authorityVersion === undefined
@@ -693,8 +713,11 @@ function readinessMatchesAuthority(
     (declaredCapabilityIds.length === 0 ||
       declaredCapabilityIds.includes(definition.capabilityId)) &&
     (receipt.status !== "ready"
-      ? authorityScope === null || sameReadinessScope(authorityScope, verifiedScope)
-      : authorityScope !== null && sameReadinessScope(authorityScope, verifiedScope)) &&
+      ? !hasAuthorityScope ||
+        authorityScope === null ||
+        sameReadinessScope(authorityScope, verifiedScope)
+      : !hasAuthorityScope ||
+        (authorityScope !== null && sameReadinessScope(authorityScope, verifiedScope))) &&
     versionMatches &&
     verifiedScope.version === definition.version &&
     (binding === null ||
@@ -715,20 +738,21 @@ function readinessMatchesAuthority(
 function isAuthorityVersionMismatch(
   record: PluginAuthorityRecord,
   receipt: ReadinessReceipt,
+  authorityScopeValue: unknown,
 ): boolean {
-  const authorityScope = isReadinessScope(record.verifiedScope) ? record.verifiedScope : null;
+  const authorityScope = isReadinessScope(authorityScopeValue) ? authorityScopeValue : null;
   const { binding, definition, verifiedScope } = receipt;
   const declaredCapabilityIds = record.operation.resources.flatMap((resource) =>
     resource.capabilityId === undefined ? [] : [resource.capabilityId],
   );
   const scopeIdentityMatches =
-    authorityScope !== null &&
-    authorityScope.residentId === verifiedScope.residentId &&
-    authorityScope.lane === verifiedScope.lane &&
-    authorityScope.host === verifiedScope.host &&
-    authorityScope.networkPath === verifiedScope.networkPath &&
-    authorityScope.operations.length === verifiedScope.operations.length &&
-    authorityScope.operations.every((operation) => verifiedScope.operations.includes(operation));
+    authorityScope === null ||
+    (authorityScope.residentId === verifiedScope.residentId &&
+      authorityScope.lane === verifiedScope.lane &&
+      authorityScope.host === verifiedScope.host &&
+      authorityScope.networkPath === verifiedScope.networkPath &&
+      authorityScope.operations.length === verifiedScope.operations.length &&
+      authorityScope.operations.every((operation) => verifiedScope.operations.includes(operation)));
   const bindingIdentityMatches =
     binding === null ||
     (binding.pluginId === record.pluginId &&

--- a/src/plugin/transaction-host.ts
+++ b/src/plugin/transaction-host.ts
@@ -112,6 +112,16 @@ export class PluginTransactionHost {
     // （fail-closed，原字节不动）；仅 ENOENT、blocked 显式重试、disposed 重装放行。
     const refused = refuseActiveIdOverwrite(request.pluginId, this.#active, this.#store);
     if (refused !== null) return refused;
+    if (
+      request.readiness?.status === "ready" &&
+      (!isReadinessReceipt(request.readiness) ||
+        !isReadinessScope(request.verifiedScope) ||
+        !sameReadinessScope(request.verifiedScope, request.readiness.verifiedScope))
+    ) {
+      throw new Error(
+        "ready runtime readiness requires an authority verifiedScope matching the receipt",
+      );
+    }
     const operationId = this.#newOperationId();
     const record: PluginAuthorityRecord = {
       schemaVersion: 1,
@@ -563,7 +573,9 @@ function readinessMatchesAuthority(
     definition.moduleRef === record.moduleRef &&
     (declaredCapabilityIds.length === 0 ||
       declaredCapabilityIds.includes(definition.capabilityId)) &&
-    (authorityScope === null || sameReadinessScope(authorityScope, verifiedScope)) &&
+    (receipt.status !== "ready"
+      ? authorityScope === null || sameReadinessScope(authorityScope, verifiedScope)
+      : authorityScope !== null && sameReadinessScope(authorityScope, verifiedScope)) &&
     verifiedScope.version === definition.version &&
     (binding === null ||
       (binding.pluginId === record.pluginId &&

--- a/src/plugin/transaction-host.ts
+++ b/src/plugin/transaction-host.ts
@@ -15,7 +15,9 @@ import {
 import {
   type ReadinessProjection,
   type ReadinessReceipt,
+  type ReadinessScope,
   isReadinessReceipt,
+  isReadinessScope,
   projectReadiness,
 } from "./runtime-readiness.ts";
 import type {
@@ -132,6 +134,13 @@ export class PluginTransactionHost {
         cleanupAttempts: [],
       },
     };
+    if (
+      request.readiness !== undefined &&
+      (!isReadinessReceipt(request.readiness) ||
+        !readinessMatchesAuthority(record, request.readiness))
+    ) {
+      throw new Error("runtime readiness receipt does not match the current plugin authority");
+    }
     this.#store.save(record);
     await this.#emit("operation-persisted", record);
 
@@ -382,13 +391,12 @@ export class PluginTransactionHost {
   }
 
   /** Runtime readiness never defaults from lifecycle `active`; missing receipt is unknown. */
-  readiness(pluginId: string): ReadinessProjection {
+  readiness(pluginId: string, now: string | number = Date.now()): ReadinessProjection {
     const record = this.#store.read(pluginId);
     if (
       record.readiness !== undefined &&
       (!isReadinessReceipt(record.readiness) ||
-        record.readiness.definition.pluginId !== record.pluginId ||
-        record.readiness.definition.moduleRef !== record.moduleRef)
+        !readinessMatchesAuthority(record, record.readiness))
     ) {
       return {
         status: "unknown",
@@ -396,20 +404,20 @@ export class PluginTransactionHost {
         detail: "runtime readiness receipt does not describe the current plugin authority",
       };
     }
-    return projectReadiness(record.lifecycleState, record.readiness);
+    return projectReadiness(record.lifecycleState, record.readiness, now);
   }
 
   /** Persist a fresh external receipt without changing lifecycle or capability definitions. */
-  recordReadiness(pluginId: string, receipt: ReadinessReceipt): ReadinessProjection {
+  recordReadiness(
+    pluginId: string,
+    receipt: ReadinessReceipt,
+    now: string | number = Date.now(),
+  ): ReadinessProjection {
     const record = this.#store.read(pluginId);
     if (record.lifecycleState !== "active") {
       throw new Error(`plugin ${pluginId} is not active; runtime readiness cannot be recorded`);
     }
-    if (
-      !isReadinessReceipt(receipt) ||
-      receipt.definition.pluginId !== record.pluginId ||
-      receipt.definition.moduleRef !== record.moduleRef
-    ) {
+    if (!isReadinessReceipt(receipt) || !readinessMatchesAuthority(record, receipt)) {
       throw new Error("runtime readiness receipt does not match the current plugin authority");
     }
     const updated: PluginAuthorityRecord = {
@@ -418,7 +426,7 @@ export class PluginTransactionHost {
       readiness: receipt,
     };
     this.#store.save(updated);
-    return projectReadiness(updated.lifecycleState, updated.readiness);
+    return projectReadiness(updated.lifecycleState, updated.readiness, now);
   }
 
   async #rollbackCurrent(
@@ -534,4 +542,47 @@ export class PluginTransactionHost {
       ...(resourceId === undefined ? {} : { resourceId }),
     });
   }
+}
+
+/**
+ * The operation authority has plugin/module identity but deliberately does not become a
+ * capability registry. Check the receipt's binding tuple against that identity and against
+ * its own definition/scope, while leaving canonical capability ownership to #100.
+ */
+function readinessMatchesAuthority(
+  record: PluginAuthorityRecord,
+  receipt: ReadinessReceipt,
+): boolean {
+  const { binding, definition, verifiedScope } = receipt;
+  const declaredCapabilityIds = record.operation.resources.flatMap((resource) =>
+    resource.capabilityId === undefined ? [] : [resource.capabilityId],
+  );
+  const authorityScope = isReadinessScope(record.verifiedScope) ? record.verifiedScope : null;
+  return (
+    definition.pluginId === record.pluginId &&
+    definition.moduleRef === record.moduleRef &&
+    (declaredCapabilityIds.length === 0 ||
+      declaredCapabilityIds.includes(definition.capabilityId)) &&
+    (authorityScope === null || sameReadinessScope(authorityScope, verifiedScope)) &&
+    verifiedScope.version === definition.version &&
+    (binding === null ||
+      (binding.pluginId === record.pluginId &&
+        binding.capabilityId === definition.capabilityId &&
+        binding.version === definition.version &&
+        binding.moduleRef === record.moduleRef &&
+        binding.host === verifiedScope.host &&
+        binding.networkPath === verifiedScope.networkPath))
+  );
+}
+
+function sameReadinessScope(left: ReadinessScope, right: ReadinessScope): boolean {
+  return (
+    left.residentId === right.residentId &&
+    left.lane === right.lane &&
+    left.host === right.host &&
+    left.networkPath === right.networkPath &&
+    left.version === right.version &&
+    left.operations.length === right.operations.length &&
+    left.operations.every((operation) => right.operations.includes(operation))
+  );
 }

--- a/src/plugin/transaction-host.ts
+++ b/src/plugin/transaction-host.ts
@@ -12,6 +12,12 @@ import {
   type RecoveryModuleLoader,
   operationOutcome,
 } from "./recovery-coordinator.ts";
+import {
+  type ReadinessProjection,
+  type ReadinessReceipt,
+  isReadinessReceipt,
+  projectReadiness,
+} from "./runtime-readiness.ts";
 import type {
   ActivePlugin,
   DisposableHandle,
@@ -51,6 +57,7 @@ export interface ActivatePluginRequest {
   readonly env: Readonly<Record<string, string>>;
   readonly bindings: unknown;
   readonly verifiedScope: unknown;
+  readonly readiness?: ReadinessReceipt;
 }
 
 export interface PublishedPluginResource {
@@ -113,6 +120,7 @@ export class PluginTransactionHost {
       config: request.config,
       bindings: request.bindings,
       verifiedScope: request.verifiedScope,
+      ...(request.readiness === undefined ? {} : { readiness: request.readiness }),
       operation: {
         operationId,
         operation: "activate",
@@ -223,6 +231,7 @@ export class PluginTransactionHost {
         enabled: false,
         config: deactivation.config,
       };
+      Reflect.deleteProperty(terminal, "readiness");
       this.#store.save(terminal);
       return this.#outcome(terminal);
     }
@@ -255,6 +264,7 @@ export class PluginTransactionHost {
       };
       Reflect.deleteProperty(parked, "reasonCode");
       Reflect.deleteProperty(parked, "quarantine");
+      Reflect.deleteProperty(parked, "readiness");
       this.#store.save(parked);
       this.#published.delete(pluginId);
       parked.lifecycleState = "disposed";
@@ -285,6 +295,7 @@ export class PluginTransactionHost {
     };
     Reflect.deleteProperty(record, "reasonCode");
     Reflect.deleteProperty(record, "quarantine");
+    Reflect.deleteProperty(record, "readiness");
     this.#store.save(record);
     this.#published.delete(pluginId);
 
@@ -370,6 +381,46 @@ export class PluginTransactionHost {
     return (this.#published.get(pluginId) ?? []).map((resource) => ({ ...resource }));
   }
 
+  /** Runtime readiness never defaults from lifecycle `active`; missing receipt is unknown. */
+  readiness(pluginId: string): ReadinessProjection {
+    const record = this.#store.read(pluginId);
+    if (
+      record.readiness !== undefined &&
+      (!isReadinessReceipt(record.readiness) ||
+        record.readiness.definition.pluginId !== record.pluginId ||
+        record.readiness.definition.moduleRef !== record.moduleRef)
+    ) {
+      return {
+        status: "unknown",
+        reasonCode: "CAPABILITY_UNVERIFIED",
+        detail: "runtime readiness receipt does not describe the current plugin authority",
+      };
+    }
+    return projectReadiness(record.lifecycleState, record.readiness);
+  }
+
+  /** Persist a fresh external receipt without changing lifecycle or capability definitions. */
+  recordReadiness(pluginId: string, receipt: ReadinessReceipt): ReadinessProjection {
+    const record = this.#store.read(pluginId);
+    if (record.lifecycleState !== "active") {
+      throw new Error(`plugin ${pluginId} is not active; runtime readiness cannot be recorded`);
+    }
+    if (
+      !isReadinessReceipt(receipt) ||
+      receipt.definition.pluginId !== record.pluginId ||
+      receipt.definition.moduleRef !== record.moduleRef
+    ) {
+      throw new Error("runtime readiness receipt does not match the current plugin authority");
+    }
+    const updated: PluginAuthorityRecord = {
+      ...record,
+      verifiedScope: receipt.verifiedScope,
+      readiness: receipt,
+    };
+    this.#store.save(updated);
+    return projectReadiness(updated.lifecycleState, updated.readiness);
+  }
+
   async #rollbackCurrent(
     record: PluginAuthorityRecord,
     resources: readonly RegisteredResource[],
@@ -402,6 +453,7 @@ export class PluginTransactionHost {
     record.reasonCode = reasonCode;
     record.operation.phase = "completed";
     Reflect.deleteProperty(record, "quarantine");
+    Reflect.deleteProperty(record, "readiness");
     this.#store.save(record);
     return this.#outcome(record);
   }
@@ -447,6 +499,7 @@ export class PluginTransactionHost {
     record.quarantine = { reasonCode, remainingResourceIds, manualActions };
     this.#published.delete(record.pluginId);
     this.#active.delete(record.pluginId);
+    Reflect.deleteProperty(record, "readiness");
     this.#store.save(record);
     return this.#outcome(record);
   }

--- a/src/plugin/transaction-host.ts
+++ b/src/plugin/transaction-host.ts
@@ -16,9 +16,11 @@ import {
   type ReadinessProjection,
   type ReadinessReceipt,
   type ReadinessScope,
+  type RuntimeReadinessRequest,
   isReadinessReceipt,
   isReadinessScope,
   projectReadiness,
+  readRuntimeReadiness,
 } from "./runtime-readiness.ts";
 import type {
   ActivePlugin,
@@ -59,7 +61,10 @@ export interface ActivatePluginRequest {
   readonly env: Readonly<Record<string, string>>;
   readonly bindings: unknown;
   readonly verifiedScope: unknown;
+  /** Legacy compatibility input: ready receipts are rejected unless produced by a probe. */
   readonly readiness?: ReadinessReceipt;
+  /** Current-process probe request; its result is the only new ready receipt source. */
+  readonly readinessRequest?: RuntimeReadinessRequest;
 }
 
 export interface PublishedPluginResource {
@@ -112,14 +117,9 @@ export class PluginTransactionHost {
     // （fail-closed，原字节不动）；仅 ENOENT、blocked 显式重试、disposed 重装放行。
     const refused = refuseActiveIdOverwrite(request.pluginId, this.#active, this.#store);
     if (refused !== null) return refused;
-    if (
-      request.readiness?.status === "ready" &&
-      (!isReadinessReceipt(request.readiness) ||
-        !isReadinessScope(request.verifiedScope) ||
-        !sameReadinessScope(request.verifiedScope, request.readiness.verifiedScope))
-    ) {
+    if (request.readiness?.status === "ready") {
       throw new Error(
-        "ready runtime readiness requires an authority verifiedScope matching the receipt",
+        "ready runtime readiness must be produced by a current-process readback probe",
       );
     }
     const operationId = this.#newOperationId();
@@ -132,7 +132,11 @@ export class PluginTransactionHost {
       config: request.config,
       bindings: request.bindings,
       verifiedScope: request.verifiedScope,
-      ...(request.readiness === undefined ? {} : { readiness: request.readiness }),
+      ...(request.readinessRequest !== undefined
+        ? {}
+        : request.readiness === undefined
+          ? {}
+          : { readiness: request.readiness }),
       operation: {
         operationId,
         operation: "activate",
@@ -193,10 +197,36 @@ export class PluginTransactionHost {
       return this.#rollbackCurrent(record, resources, undefined, "PREPARE_FAILED");
     }
 
-    // Resource capability declarations are only authoritative after prepare(). Re-check a
-    // caller-supplied receipt before any resource activation or public projection; a receipt
-    // that passed the pre-write identity check must not outrun the plugin's actual inventory.
-    if (
+    // Resource capability declarations are only authoritative after prepare(). A readiness
+    // request is executed by this host at this point; callers never hand the host a ready
+    // receipt to persist. The temporary record binds the generated scope before activation.
+    if (request.readinessRequest !== undefined) {
+      let generated: ReadinessReceipt;
+      try {
+        generated = await readRuntimeReadiness(
+          request.readinessRequest.input,
+          request.readinessRequest.probe,
+        );
+      } catch {
+        return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
+      }
+      const generatedRecord: PluginAuthorityRecord = {
+        ...record,
+        verifiedScope: generated.verifiedScope,
+        readiness: generated,
+      };
+      if (
+        !isReadinessReceipt(generated) ||
+        !readinessMatchesAuthority(generatedRecord, generated)
+      ) {
+        return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
+      }
+      Object.assign(record, {
+        verifiedScope: generated.verifiedScope,
+        readiness: generated,
+      });
+      this.#store.save(record);
+    } else if (
       request.readiness !== undefined &&
       (!isReadinessReceipt(request.readiness) ||
         !readinessMatchesAuthority(record, request.readiness))
@@ -438,6 +468,11 @@ export class PluginTransactionHost {
     if (record.lifecycleState !== "active") {
       throw new Error(`plugin ${pluginId} is not active; runtime readiness cannot be recorded`);
     }
+    if (receipt.status === "ready") {
+      throw new Error(
+        "ready runtime readiness must be produced by a current-process readback probe",
+      );
+    }
     if (!isReadinessReceipt(receipt) || !readinessMatchesAuthority(record, receipt)) {
       throw new Error("runtime readiness receipt does not match the current plugin authority");
     }
@@ -446,6 +481,34 @@ export class PluginTransactionHost {
       verifiedScope: receipt.verifiedScope,
       readiness: receipt,
     };
+    this.#store.save(updated);
+    return projectReadiness(updated.lifecycleState, updated.readiness, now);
+  }
+
+  /** Execute the current-process probe before persisting a fresh readiness receipt. */
+  async recordReadinessFromProbe(
+    pluginId: string,
+    request: RuntimeReadinessRequest,
+    now: string | number = Date.now(),
+  ): Promise<ReadinessProjection> {
+    const record = this.#store.read(pluginId);
+    if (record.lifecycleState !== "active") {
+      throw new Error(`plugin ${pluginId} is not active; runtime readiness cannot be recorded`);
+    }
+    let receipt: ReadinessReceipt;
+    try {
+      receipt = await readRuntimeReadiness(request.input, request.probe);
+    } catch {
+      throw new Error("current-process runtime readiness probe could not produce a receipt");
+    }
+    const updated: PluginAuthorityRecord = {
+      ...record,
+      verifiedScope: receipt.verifiedScope,
+      readiness: receipt,
+    };
+    if (!isReadinessReceipt(receipt) || !readinessMatchesAuthority(updated, receipt)) {
+      throw new Error("runtime readiness probe result does not match the current plugin authority");
+    }
     this.#store.save(updated);
     return projectReadiness(updated.lifecycleState, updated.readiness, now);
   }

--- a/src/plugin/transaction-host.ts
+++ b/src/plugin/transaction-host.ts
@@ -470,6 +470,22 @@ export class PluginTransactionHost {
     return projectReadiness(record.lifecycleState, record.readiness, now);
   }
 
+  /**
+   * Invalidate a receipt when the production manifest no longer describes the active
+   * authority. The lifecycle stays active, but runtime readiness is explicitly unknown
+   * until a matching version is activated and probed again.
+   */
+  invalidateReadiness(pluginId: string, now: string | number = Date.now()): ReadinessProjection {
+    const record = this.#store.read(pluginId);
+    if (record.lifecycleState !== "active") {
+      throw new Error(`plugin ${pluginId} is not active; runtime readiness cannot be invalidated`);
+    }
+    const updated: PluginAuthorityRecord = { ...record, verifiedScope: null };
+    Reflect.deleteProperty(updated, "readiness");
+    this.#store.save(updated);
+    return projectReadiness(updated.lifecycleState, undefined, now);
+  }
+
   /** Persist a fresh external receipt without changing lifecycle or capability definitions. */
   recordReadiness(
     pluginId: string,

--- a/src/plugin/transaction-host.ts
+++ b/src/plugin/transaction-host.ts
@@ -193,6 +193,17 @@ export class PluginTransactionHost {
       return this.#rollbackCurrent(record, resources, undefined, "PREPARE_FAILED");
     }
 
+    // Resource capability declarations are only authoritative after prepare(). Re-check a
+    // caller-supplied receipt before any resource activation or public projection; a receipt
+    // that passed the pre-write identity check must not outrun the plugin's actual inventory.
+    if (
+      request.readiness !== undefined &&
+      (!isReadinessReceipt(request.readiness) ||
+        !readinessMatchesAuthority(record, request.readiness))
+    ) {
+      return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
+    }
+
     record.lifecycleState = "prepared";
     record.operation.phase = "prepared";
     this.#store.save(record);

--- a/src/plugin/transaction-host.ts
+++ b/src/plugin/transaction-host.ts
@@ -57,6 +57,8 @@ export interface ActivatePluginRequest {
   readonly pluginId: string;
   readonly moduleRef: string;
   readonly module: PluginModuleV0;
+  /** Production enable path's manifest/runtime version; absent only for legacy direct callers. */
+  readonly runtimeVersion?: string;
   readonly config: unknown;
   readonly env: Readonly<Record<string, string>>;
   readonly bindings: unknown;
@@ -129,6 +131,7 @@ export class PluginTransactionHost {
       lifecycleState: "validated",
       enabled: true,
       moduleRef: request.moduleRef,
+      ...(request.runtimeVersion === undefined ? {} : { runtimeVersion: request.runtimeVersion }),
       config: request.config,
       bindings: request.bindings,
       verifiedScope: request.verifiedScope,
@@ -215,17 +218,26 @@ export class PluginTransactionHost {
         verifiedScope: generated.verifiedScope,
         readiness: generated,
       };
-      if (
-        !isReadinessReceipt(generated) ||
-        !readinessMatchesAuthority(generatedRecord, generated)
-      ) {
+      if (!isReadinessReceipt(generated)) {
         return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
       }
-      Object.assign(record, {
-        verifiedScope: generated.verifiedScope,
-        readiness: generated,
-      });
-      this.#store.save(record);
+      if (!readinessMatchesAuthority(generatedRecord, generated)) {
+        // A probe can report a valid receipt for a different deployed version. Keep the
+        // lifecycle activation usable, but never persist that receipt as this authority's
+        // readiness. Other identity/scope mismatches remain activation failures.
+        if (!isAuthorityVersionMismatch(generatedRecord, generated)) {
+          return this.#rollbackCurrent(record, resources, prepared, "ACTIVATE_FAILED");
+        }
+        Reflect.deleteProperty(record, "readiness");
+        Object.assign(record, { verifiedScope: null });
+        this.#store.save(record);
+      } else {
+        Object.assign(record, {
+          verifiedScope: generated.verifiedScope,
+          readiness: generated,
+        });
+        this.#store.save(record);
+      }
     } else if (
       request.readiness !== undefined &&
       (!isReadinessReceipt(request.readiness) ||
@@ -506,7 +518,16 @@ export class PluginTransactionHost {
       verifiedScope: receipt.verifiedScope,
       readiness: receipt,
     };
-    if (!isReadinessReceipt(receipt) || !readinessMatchesAuthority(updated, receipt)) {
+    if (!isReadinessReceipt(receipt)) {
+      throw new Error("runtime readiness probe result does not match the current plugin authority");
+    }
+    if (!readinessMatchesAuthority(updated, receipt)) {
+      if (isAuthorityVersionMismatch(updated, receipt)) {
+        Reflect.deleteProperty(record, "readiness");
+        Object.assign(record, { verifiedScope: null });
+        this.#store.save(record);
+        return projectReadiness(record.lifecycleState, undefined, now);
+      }
       throw new Error("runtime readiness probe result does not match the current plugin authority");
     }
     this.#store.save(updated);
@@ -642,6 +663,14 @@ function readinessMatchesAuthority(
     resource.capabilityId === undefined ? [] : [resource.capabilityId],
   );
   const authorityScope = isReadinessScope(record.verifiedScope) ? record.verifiedScope : null;
+  const authorityVersion = record.runtimeVersion;
+  const versionMatches =
+    authorityVersion === undefined
+      ? receipt.status !== "ready"
+      : definition.version === authorityVersion &&
+        verifiedScope.version === authorityVersion &&
+        (binding === null || binding.version === authorityVersion) &&
+        receipt.evidence.every((item) => item.version === authorityVersion);
   return (
     definition.pluginId === record.pluginId &&
     definition.moduleRef === record.moduleRef &&
@@ -650,6 +679,7 @@ function readinessMatchesAuthority(
     (receipt.status !== "ready"
       ? authorityScope === null || sameReadinessScope(authorityScope, verifiedScope)
       : authorityScope !== null && sameReadinessScope(authorityScope, verifiedScope)) &&
+    versionMatches &&
     verifiedScope.version === definition.version &&
     (binding === null ||
       (binding.pluginId === record.pluginId &&
@@ -658,6 +688,52 @@ function readinessMatchesAuthority(
         binding.moduleRef === record.moduleRef &&
         binding.host === verifiedScope.host &&
         binding.networkPath === verifiedScope.networkPath))
+  );
+}
+
+/**
+ * Distinguish a receipt that is structurally for this authority but for another runtime
+ * version. This narrow exception lets activation remain active/unknown while preserving
+ * rollback for capability, module, binding, or scope mismatches.
+ */
+function isAuthorityVersionMismatch(
+  record: PluginAuthorityRecord,
+  receipt: ReadinessReceipt,
+): boolean {
+  const authorityScope = isReadinessScope(record.verifiedScope) ? record.verifiedScope : null;
+  const { binding, definition, verifiedScope } = receipt;
+  const declaredCapabilityIds = record.operation.resources.flatMap((resource) =>
+    resource.capabilityId === undefined ? [] : [resource.capabilityId],
+  );
+  const scopeIdentityMatches =
+    authorityScope !== null &&
+    authorityScope.residentId === verifiedScope.residentId &&
+    authorityScope.lane === verifiedScope.lane &&
+    authorityScope.host === verifiedScope.host &&
+    authorityScope.networkPath === verifiedScope.networkPath &&
+    authorityScope.operations.length === verifiedScope.operations.length &&
+    authorityScope.operations.every((operation) => verifiedScope.operations.includes(operation));
+  const bindingIdentityMatches =
+    binding === null ||
+    (binding.pluginId === record.pluginId &&
+      binding.capabilityId === definition.capabilityId &&
+      binding.moduleRef === record.moduleRef &&
+      binding.host === verifiedScope.host &&
+      binding.networkPath === verifiedScope.networkPath);
+  const identityMatches =
+    definition.pluginId === record.pluginId &&
+    definition.moduleRef === record.moduleRef &&
+    (declaredCapabilityIds.length === 0 ||
+      declaredCapabilityIds.includes(definition.capabilityId)) &&
+    scopeIdentityMatches &&
+    bindingIdentityMatches;
+  if (!identityMatches) return false;
+  if (record.runtimeVersion === undefined) return receipt.status === "ready";
+  return (
+    definition.version !== record.runtimeVersion ||
+    verifiedScope.version !== record.runtimeVersion ||
+    (binding !== null && binding.version !== record.runtimeVersion) ||
+    receipt.evidence.some((item) => item.version !== record.runtimeVersion)
   );
 }
 

--- a/tests/plugin-runtime-readiness.test.ts
+++ b/tests/plugin-runtime-readiness.test.ts
@@ -242,6 +242,30 @@ describe("runtime readiness / readback contract", () => {
     });
   });
 
+  it("rejects a forged verification timestamp or replayed evidence outside the window", () => {
+    const receipt = evaluateRuntimeReadiness(input());
+    expect(
+      isReadinessReceipt({
+        ...receipt,
+        lastVerifiedAt: "2026-08-21T00:00:01.000Z",
+      }),
+    ).toBe(false);
+
+    const replayedEvidence = {
+      ...receipt,
+      evidence: receipt.evidence.map((item, index) =>
+        index === 0 ? { ...item, observedAt: "2026-08-20T23:00:00.000Z" } : item,
+      ),
+    };
+    expect(isReadinessReceipt(replayedEvidence)).toBe(false);
+  });
+
+  it("rejects a ready receipt that carries a failure reason", () => {
+    const receipt = evaluateRuntimeReadiness(input());
+    expect(isReadinessReceipt({ ...receipt, reasonCode: "PLUGIN_RUNTIME_FAILED" })).toBe(false);
+    expect(isReadinessReceipt({ ...receipt, reason: "readback-failed" })).toBe(false);
+  });
+
   it("rejects evidence legs that reuse one probe identity", () => {
     const receipt = evaluateRuntimeReadiness(
       input({
@@ -353,6 +377,31 @@ describe("runtime readiness / readback contract", () => {
       const receipt = evaluateRuntimeReadiness(
         input({ definition: readyDefinition, binding: readyBinding, evidence: readyEvidence }),
       );
+      await expect(
+        host.activate({
+          pluginId: definition.pluginId,
+          moduleRef,
+          module,
+          config: { enabled: true },
+          env: {},
+          bindings: {},
+          verifiedScope: null,
+          readiness: receipt,
+        }),
+      ).rejects.toThrow("ready runtime readiness requires an authority verifiedScope");
+      expect(() => store.read(definition.pluginId)).toThrow();
+      await expect(
+        host.activate({
+          pluginId: definition.pluginId,
+          moduleRef,
+          module,
+          config: { enabled: true },
+          env: {},
+          bindings: {},
+          verifiedScope: { ...receipt.verifiedScope, residentId: "resident-b" },
+          readiness: receipt,
+        }),
+      ).rejects.toThrow("ready runtime readiness requires an authority verifiedScope");
       await host.activate({
         pluginId: definition.pluginId,
         moduleRef,
@@ -412,6 +461,13 @@ describe("runtime readiness / readback contract", () => {
       expect(() => host.recordReadiness(definition.pluginId, mismatchedBinding)).toThrow(
         "runtime readiness receipt does not match the current plugin authority",
       );
+
+      const authority = store.read(definition.pluginId);
+      store.save({ ...authority, verifiedScope: null });
+      expect(host.readiness(definition.pluginId, "2026-08-21T00:00:30.000Z")).toMatchObject({
+        status: "unknown",
+        reasonCode: "CAPABILITY_UNVERIFIED",
+      });
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/tests/plugin-runtime-readiness.test.ts
+++ b/tests/plugin-runtime-readiness.test.ts
@@ -477,6 +477,18 @@ describe("runtime readiness / readback contract", () => {
       expect(probeCalls).toEqual({ existence: 3, running: 3, readback: 3 });
       expect(host.readiness(manifest.id, "2026-08-21T00:00:30.000Z").status).toBe("ready");
 
+      const callsBeforeManifestDrift = { ...probeCalls };
+      const driftedManifestRequest = {
+        ...request,
+        manifest: { ...manifest, version: "1.2.4" },
+      };
+      expect((await applyEnabledChange(host, store, driftedManifestRequest)).state).toBe("active");
+      expect(probeCalls).toEqual(callsBeforeManifestDrift);
+      expect(host.readiness(manifest.id).status).toBe("unknown");
+      expect(store.read(manifest.id).readiness).toBeUndefined();
+      expect((await applyEnabledChange(host, store, request)).state).toBe("active");
+      expect(host.readiness(manifest.id, "2026-08-21T00:00:30.000Z").status).toBe("ready");
+
       const wrongVersionRequest = probeRequest({
         definition: { ...definition, pluginId: manifest.id, moduleRef, version: "1.2.4" },
         binding: { ...binding, pluginId: manifest.id, moduleRef, version: "1.2.4" },
@@ -513,7 +525,7 @@ describe("runtime readiness / readback contract", () => {
         },
       };
       expect((await applyEnabledChange(host, store, failingRequest)).state).toBe("active");
-      expect(probeCalls).toEqual({ existence: 5, running: 5, readback: 4 });
+      expect(probeCalls).toEqual({ existence: 6, running: 6, readback: 5 });
       expect(host.readiness(manifest.id).status).toBe("unknown");
     } finally {
       rmSync(directory, { recursive: true, force: true });

--- a/tests/plugin-runtime-readiness.test.ts
+++ b/tests/plugin-runtime-readiness.test.ts
@@ -11,6 +11,8 @@ import {
   type ReadinessScope,
   type RuntimeEvidence,
   evaluateRuntimeReadiness,
+  isReadinessReceipt,
+  projectReadiness,
   readRuntimeReadiness,
 } from "../src/plugin/runtime-readiness.ts";
 import { PluginTransactionHost } from "../src/plugin/transaction-host.ts";
@@ -219,6 +221,53 @@ describe("runtime readiness / readback contract", () => {
     expect(receipt.reason).toBe("evidence-stale");
   });
 
+  it("does not create an unbounded ready receipt when maxAgeMs is omitted", () => {
+    const withoutWindow = input();
+    Reflect.deleteProperty(withoutWindow, "maxAgeMs");
+    const receipt = evaluateRuntimeReadiness(withoutWindow);
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reason).toBe("evidence-stale");
+    expect(receipt.lastVerifiedAt).toBeNull();
+    expect(receipt.verificationWindowMs).toBeNull();
+  });
+
+  it("parses a legacy ready receipt but never projects it without a persisted window", () => {
+    const receipt = evaluateRuntimeReadiness(input());
+    const legacyReceipt = { ...receipt };
+    Reflect.deleteProperty(legacyReceipt, "verificationWindowMs");
+    expect(isReadinessReceipt(legacyReceipt)).toBe(true);
+    expect(projectReadiness("active", legacyReceipt, "2026-08-21T00:00:30.000Z")).toMatchObject({
+      status: "unknown",
+      reasonCode: "CAPABILITY_UNVERIFIED",
+    });
+  });
+
+  it("rejects evidence legs that reuse one probe identity", () => {
+    const receipt = evaluateRuntimeReadiness(
+      input({
+        evidence: [
+          evidence("existence"),
+          evidence("running", "pass", { probeId: "probe-existence" }),
+          evidence("readback"),
+        ],
+      }),
+    );
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reason).toBe("evidence-not-independent");
+    expect(receipt.reasonCode).toBe("CAPABILITY_UNVERIFIED");
+  });
+
+  it("does not accept an unknown receipt with a successful-verification timestamp", () => {
+    const receipt = evaluateRuntimeReadiness(input({ evidence: [evidence("existence")] }));
+    expect(receipt.lastVerifiedAt).toBeNull();
+    expect(
+      isReadinessReceipt({
+        ...receipt,
+        lastVerifiedAt: "2026-08-21T00:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+
   it("exposes probe failures as unknown when the independent observer cannot answer", async () => {
     const receipt = await readRuntimeReadiness(input(), {
       existence: async () => evidence("existence"),
@@ -274,7 +323,15 @@ describe("runtime readiness / readback contract", () => {
       const store = new PluginOperationStore(directory);
       const host = new PluginTransactionHost({ store });
       const module: PluginModuleV0 = {
-        async prepare() {
+        async prepare(context) {
+          context.register({
+            id: "fixture-call",
+            kind: "tool",
+            capabilityId: "fixture.call",
+            recoveryKey: "fixture-call-recovery",
+            async activate() {},
+            async dispose() {},
+          });
           return {
             async activate() {
               return {
@@ -306,8 +363,55 @@ describe("runtime readiness / readback contract", () => {
         verifiedScope: receipt.verifiedScope,
         readiness: receipt,
       });
-      expect(host.readiness(definition.pluginId).status).toBe("ready");
-      expect(host.recordReadiness(definition.pluginId, receipt).status).toBe("ready");
+      expect(host.readiness(definition.pluginId, "2026-08-21T00:00:30.000Z").status).toBe("ready");
+      const restartedHost = new PluginTransactionHost({
+        store: new PluginOperationStore(directory),
+      });
+      expect(
+        restartedHost.readiness(definition.pluginId, "2026-08-21T00:01:01.000Z"),
+      ).toMatchObject({
+        status: "unknown",
+        reasonCode: "CAPABILITY_UNVERIFIED",
+      });
+      expect(
+        host.recordReadiness(definition.pluginId, receipt, "2026-08-21T00:00:30.000Z").status,
+      ).toBe("ready");
+
+      const mismatchedCapability = {
+        ...receipt,
+        definition: { ...receipt.definition, capabilityId: "fixture.other" },
+        binding:
+          receipt.binding === null ? null : { ...receipt.binding, capabilityId: "fixture.other" },
+      };
+      expect(isReadinessReceipt(mismatchedCapability)).toBe(true);
+      expect(() => host.recordReadiness(definition.pluginId, mismatchedCapability)).toThrow(
+        "runtime readiness receipt does not match the current plugin authority",
+      );
+
+      const mismatchedVersion = {
+        ...receipt,
+        definition: { ...receipt.definition, version: "1.2.4" },
+      };
+      expect(() => host.recordReadiness(definition.pluginId, mismatchedVersion)).toThrow(
+        "runtime readiness receipt does not match the current plugin authority",
+      );
+
+      const mismatchedBinding = {
+        ...receipt,
+        verifiedScope: { ...receipt.verifiedScope, networkPath: "loopback:19002/call" },
+        binding:
+          receipt.binding === null
+            ? null
+            : { ...receipt.binding, networkPath: "loopback:19002/call" },
+        evidence: receipt.evidence.map((item) => ({
+          ...item,
+          scope: { ...item.scope, networkPath: "loopback:19002/call" },
+        })),
+      };
+      expect(isReadinessReceipt(mismatchedBinding)).toBe(true);
+      expect(() => host.recordReadiness(definition.pluginId, mismatchedBinding)).toThrow(
+        "runtime readiness receipt does not match the current plugin authority",
+      );
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/tests/plugin-runtime-readiness.test.ts
+++ b/tests/plugin-runtime-readiness.test.ts
@@ -1,0 +1,315 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { moduleRefFromSource } from "../src/plugin/module-ref.ts";
+import { PluginOperationStore } from "../src/plugin/operation-store.ts";
+import {
+  type ReadinessAuthorization,
+  type ReadinessDefinition,
+  type ReadinessEvaluationInput,
+  type ReadinessScope,
+  type RuntimeEvidence,
+  evaluateRuntimeReadiness,
+  readRuntimeReadiness,
+} from "../src/plugin/runtime-readiness.ts";
+import { PluginTransactionHost } from "../src/plugin/transaction-host.ts";
+import type { PluginModuleV0 } from "../src/plugin/types.ts";
+
+const definition: ReadinessDefinition = {
+  pluginId: "fixture.tool",
+  capabilityId: "fixture.call",
+  version: "1.2.3",
+  moduleRef: "sha256:module-v1",
+};
+const scope: ReadinessScope = {
+  residentId: "resident-a",
+  lane: "primary",
+  operations: ["call"],
+  host: "host-a",
+  networkPath: "loopback:19001/call",
+  version: definition.version,
+};
+const binding = {
+  pluginId: definition.pluginId,
+  capabilityId: definition.capabilityId,
+  version: definition.version,
+  moduleRef: definition.moduleRef,
+  host: scope.host,
+  networkPath: scope.networkPath,
+};
+const authorization: ReadinessAuthorization = {
+  residentId: scope.residentId,
+  lane: scope.lane,
+  operations: [...scope.operations],
+};
+
+function evidence(
+  kind: RuntimeEvidence["kind"],
+  outcome: RuntimeEvidence["outcome"] = "pass",
+  overrides: Partial<RuntimeEvidence> = {},
+): RuntimeEvidence {
+  return {
+    kind,
+    source: "external",
+    probeId: `probe-${kind}`,
+    observedAt: "2026-08-21T00:00:00.000Z",
+    scope,
+    version: definition.version,
+    moduleRef: definition.moduleRef,
+    outcome,
+    conditions: { endpoint: scope.networkPath, transport: "loopback" },
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<ReadinessEvaluationInput> = {}): ReadinessEvaluationInput {
+  return {
+    definition,
+    binding,
+    authorization,
+    scope,
+    now: "2026-08-21T00:00:01.000Z",
+    maxAgeMs: 60_000,
+    evidence: [evidence("existence"), evidence("running"), evidence("readback")],
+    ...overrides,
+  };
+}
+
+describe("runtime readiness / readback contract", () => {
+  it("requires independent existence, running, and scoped readback before ready", () => {
+    const receipt = evaluateRuntimeReadiness(input());
+    expect(receipt.status).toBe("ready");
+    expect(receipt.lastVerifiedAt).toBe("2026-08-21T00:00:00.000Z");
+    expect(receipt.verifiedScope).toEqual(scope);
+  });
+
+  it("does not turn a present file into ready when no runtime process evidence exists", () => {
+    const receipt = evaluateRuntimeReadiness(input({ evidence: [evidence("existence")] }));
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reason).toBe("evidence-missing");
+    expect(receipt.reasonCode).toBe("CAPABILITY_UNVERIFIED");
+  });
+
+  it("does not trust a green health response when the real operation path is unreachable", () => {
+    const receipt = evaluateRuntimeReadiness(
+      input({
+        evidence: [
+          evidence("existence"),
+          evidence("running"),
+          evidence("readback", "fail", {
+            detail: "health=200 but /call cannot be reached",
+            conditions: { endpoint: "loopback:19001/call", transport: "loopback", health: 200 },
+          }),
+        ],
+      }),
+    );
+    expect(receipt.status).toBe("blocked");
+    expect(receipt.reason).toBe("readback-failed");
+    expect(receipt.reasonCode).toBe("PLUGIN_RUNTIME_FAILED");
+  });
+
+  it("keeps repository/deployment/runtime version disagreement unknown", () => {
+    const receipt = evaluateRuntimeReadiness(
+      input({
+        evidence: [
+          evidence("existence"),
+          evidence("running"),
+          evidence("readback", "pass", { version: "1.2.4" }),
+        ],
+      }),
+    );
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reason).toBe("scope-mismatch");
+    expect(receipt.reasonCode).toBe("CAPABILITY_UNVERIFIED");
+  });
+
+  it("keeps a different host or network scope unknown", () => {
+    const otherScope = { ...scope, networkPath: "tcp:203.0.113.10:19001/call" };
+    const receipt = evaluateRuntimeReadiness(
+      input({
+        scope: otherScope,
+        evidence: [evidence("existence"), evidence("running"), evidence("readback")],
+      }),
+    );
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reason).toBe("scope-mismatch");
+  });
+
+  it("does not reuse evidence from another resident, lane, or operation", () => {
+    const otherResident = evaluateRuntimeReadiness(
+      input({
+        evidence: [
+          evidence("existence"),
+          evidence("running"),
+          evidence("readback", "pass", {
+            scope: { ...scope, residentId: "resident-b" },
+          }),
+        ],
+      }),
+    );
+    expect(otherResident.status).toBe("unknown");
+    expect(otherResident.reason).toBe("scope-mismatch");
+
+    const otherLane = evaluateRuntimeReadiness(
+      input({
+        evidence: [
+          evidence("existence"),
+          evidence("running"),
+          evidence("readback", "pass", {
+            scope: { ...scope, lane: "coding" },
+          }),
+        ],
+      }),
+    );
+    expect(otherLane.status).toBe("unknown");
+    expect(otherLane.reason).toBe("scope-mismatch");
+
+    const missingOperation = evaluateRuntimeReadiness(
+      input({
+        scope: { ...scope, operations: ["call", "stream"] },
+        authorization: { ...authorization, operations: ["call", "stream"] },
+        evidence: [
+          evidence("existence"),
+          evidence("running"),
+          evidence("readback", "pass", { scope: { ...scope, operations: ["call"] } }),
+        ],
+      }),
+    );
+    expect(missingOperation.status).toBe("unknown");
+    expect(missingOperation.reason).toBe("evidence-missing");
+  });
+
+  it("does not use self-reported evidence", () => {
+    const receipt = evaluateRuntimeReadiness(
+      input({
+        evidence: [
+          evidence("existence"),
+          evidence("running"),
+          evidence("readback", "pass", { source: "self" }),
+        ],
+      }),
+    );
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reasonCode).toBe("CAPABILITY_UNVERIFIED");
+  });
+
+  it("binds conditions and measurements to the same evidence row", () => {
+    const receipt = evaluateRuntimeReadiness(
+      input({
+        expectedConditions: { endpoint: scope.networkPath, transport: "loopback" },
+        evidence: [
+          evidence("existence", "pass", { measurements: { latencyMs: 2 } }),
+          evidence("running"),
+          evidence("readback", "pass", {
+            conditions: { endpoint: "wrong-path", transport: "loopback" },
+          }),
+        ],
+      }),
+    );
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reason).toBe("condition-mismatch");
+  });
+
+  it("returns unknown for stale evidence instead of guessing current readiness", () => {
+    const receipt = evaluateRuntimeReadiness(
+      input({ now: "2026-08-21T00:02:00.000Z", maxAgeMs: 60_000 }),
+    );
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reason).toBe("evidence-stale");
+  });
+
+  it("exposes probe failures as unknown when the independent observer cannot answer", async () => {
+    const receipt = await readRuntimeReadiness(input(), {
+      existence: async () => evidence("existence"),
+      running: async () => evidence("running"),
+      readback: async () => {
+        throw new Error("observer unavailable");
+      },
+    });
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reason).toBe("evidence-missing");
+  });
+
+  it("does not project an active lifecycle as ready without a persisted receipt", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "mist-runtime-readiness-"));
+    try {
+      const store = new PluginOperationStore(directory);
+      const host = new PluginTransactionHost({ store });
+      const module: PluginModuleV0 = {
+        async prepare() {
+          return {
+            async activate() {
+              return {
+                async dispose() {
+                  return { revoked: [], failed: [] };
+                },
+              };
+            },
+            async rollback() {},
+          };
+        },
+      };
+      await host.activate({
+        pluginId: "fixture.unverified",
+        moduleRef: moduleRefFromSource("fixture-unverified"),
+        module,
+        config: { enabled: true },
+        env: {},
+        bindings: {},
+        verifiedScope: null,
+      });
+      expect(host.readiness("fixture.unverified")).toMatchObject({
+        status: "unknown",
+        reasonCode: "CAPABILITY_UNVERIFIED",
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("projects only the receipt that was produced by the external readback contract", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "mist-runtime-readiness-"));
+    try {
+      const store = new PluginOperationStore(directory);
+      const host = new PluginTransactionHost({ store });
+      const module: PluginModuleV0 = {
+        async prepare() {
+          return {
+            async activate() {
+              return {
+                async dispose() {
+                  return { revoked: [], failed: [] };
+                },
+              };
+            },
+            async rollback() {},
+          };
+        },
+      };
+      const moduleRef = moduleRefFromSource("fixture-ready");
+      const readyDefinition = { ...definition, moduleRef };
+      const readyBinding = { ...binding, moduleRef };
+      const readyEvidence = [evidence("existence"), evidence("running"), evidence("readback")].map(
+        (item) => ({ ...item, moduleRef }),
+      );
+      const receipt = evaluateRuntimeReadiness(
+        input({ definition: readyDefinition, binding: readyBinding, evidence: readyEvidence }),
+      );
+      await host.activate({
+        pluginId: definition.pluginId,
+        moduleRef,
+        module,
+        config: { enabled: true },
+        env: {},
+        bindings: {},
+        verifiedScope: receipt.verifiedScope,
+        readiness: receipt,
+      });
+      expect(host.readiness(definition.pluginId).status).toBe("ready");
+      expect(host.recordReadiness(definition.pluginId, receipt).status).toBe("ready");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/plugin-runtime-readiness.test.ts
+++ b/tests/plugin-runtime-readiness.test.ts
@@ -368,6 +368,10 @@ describe("runtime readiness / readback contract", () => {
       expect(host.publishedResources("fixture.unverified")).toEqual([
         { id: "fixture-unverified-call", kind: "tool", capabilityId: "fixture.call" },
       ]);
+      expect(store.read("fixture.unverified").runtimeVersion).toBeUndefined();
+      expect(new PluginOperationStore(directory).read("fixture.unverified").runtimeVersion).toBe(
+        undefined,
+      );
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
@@ -466,7 +470,34 @@ describe("runtime readiness / readback contract", () => {
       expect(() => store.read(manifest.id)).toThrow();
       expect((await applyEnabledChange(host, store, request)).state).toBe("active");
       expect((await applyEnabledChange(host, store, request)).state).toBe("active");
+      expect(store.read(manifest.id).runtimeVersion).toBe(manifest.version);
+      expect(new PluginOperationStore(directory).read(manifest.id).runtimeVersion).toBe(
+        manifest.version,
+      );
       expect(probeCalls).toEqual({ existence: 3, running: 3, readback: 3 });
+      expect(host.readiness(manifest.id, "2026-08-21T00:00:30.000Z").status).toBe("ready");
+
+      const wrongVersionRequest = probeRequest({
+        definition: { ...definition, pluginId: manifest.id, moduleRef, version: "1.2.4" },
+        binding: { ...binding, pluginId: manifest.id, moduleRef, version: "1.2.4" },
+        scope: { ...scope, version: "1.2.4" },
+      });
+      expect(
+        (
+          await applyEnabledChange(host, store, {
+            ...request,
+            readinessRequest: wrongVersionRequest,
+          })
+        ).state,
+      ).toBe("active");
+      expect(host.readiness(manifest.id).status).toBe("unknown");
+      expect(store.read(manifest.id).readiness).toBeUndefined();
+      expect(
+        new PluginTransactionHost({
+          store: new PluginOperationStore(directory),
+        }).readiness(manifest.id).status,
+      ).toBe("unknown");
+      expect((await applyEnabledChange(host, store, request)).state).toBe("active");
       expect(host.readiness(manifest.id, "2026-08-21T00:00:30.000Z").status).toBe("ready");
 
       const failingRequest: typeof request = {
@@ -482,7 +513,7 @@ describe("runtime readiness / readback contract", () => {
         },
       };
       expect((await applyEnabledChange(host, store, failingRequest)).state).toBe("active");
-      expect(probeCalls).toEqual({ existence: 4, running: 4, readback: 3 });
+      expect(probeCalls).toEqual({ existence: 5, running: 5, readback: 4 });
       expect(host.readiness(manifest.id).status).toBe("unknown");
     } finally {
       rmSync(directory, { recursive: true, force: true });
@@ -532,6 +563,7 @@ describe("runtime readiness / readback contract", () => {
           pluginId: definition.pluginId,
           moduleRef,
           module,
+          runtimeVersion: definition.version,
           config: { enabled: true },
           env: {},
           bindings: {},
@@ -563,6 +595,7 @@ describe("runtime readiness / readback contract", () => {
         pluginId: definition.pluginId,
         moduleRef,
         module,
+        runtimeVersion: definition.version,
         config: { enabled: true },
         env: {},
         bindings: {},

--- a/tests/plugin-runtime-readiness.test.ts
+++ b/tests/plugin-runtime-readiness.test.ts
@@ -2,6 +2,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { applyEnabledChange } from "../src/plugin/enable.ts";
+import type { PluginManifestV0 } from "../src/plugin/manifest.ts";
 import { moduleRefFromSource } from "../src/plugin/module-ref.ts";
 import { PluginOperationStore } from "../src/plugin/operation-store.ts";
 import {
@@ -10,6 +12,7 @@ import {
   type ReadinessEvaluationInput,
   type ReadinessScope,
   type RuntimeEvidence,
+  type RuntimeReadinessRequest,
   evaluateRuntimeReadiness,
   isReadinessReceipt,
   projectReadiness,
@@ -75,6 +78,24 @@ function input(overrides: Partial<ReadinessEvaluationInput> = {}): ReadinessEval
     maxAgeMs: 60_000,
     evidence: [evidence("existence"), evidence("running"), evidence("readback")],
     ...overrides,
+  };
+}
+
+function probeRequest(overrides: Partial<ReadinessEvaluationInput> = {}): RuntimeReadinessRequest {
+  const readinessInput = input(overrides);
+  const probeEvidence = (kind: RuntimeEvidence["kind"]): RuntimeEvidence => ({
+    ...evidence(kind),
+    scope: readinessInput.scope,
+    version: readinessInput.definition.version,
+    moduleRef: readinessInput.definition.moduleRef,
+  });
+  return {
+    input: readinessInput,
+    probe: {
+      existence: async () => probeEvidence("existence"),
+      running: async () => probeEvidence("running"),
+      readback: async () => probeEvidence("readback"),
+    },
   };
 }
 
@@ -310,7 +331,15 @@ describe("runtime readiness / readback contract", () => {
       const store = new PluginOperationStore(directory);
       const host = new PluginTransactionHost({ store });
       const module: PluginModuleV0 = {
-        async prepare() {
+        async prepare(context) {
+          context.register({
+            id: "fixture-unverified-call",
+            kind: "tool",
+            capabilityId: "fixture.call",
+            recoveryKey: "fixture-unverified-call",
+            async activate() {},
+            async dispose() {},
+          });
           return {
             async activate() {
               return {
@@ -336,12 +365,131 @@ describe("runtime readiness / readback contract", () => {
         status: "unknown",
         reasonCode: "CAPABILITY_UNVERIFIED",
       });
+      expect(host.publishedResources("fixture.unverified")).toEqual([
+        { id: "fixture-unverified-call", kind: "tool", capabilityId: "fixture.call" },
+      ]);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
   });
 
-  it("projects only the receipt that was produced by the external readback contract", async () => {
+  it("runs all three probes through applyEnabledChange and fails closed on probe failure", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "mist-runtime-readiness-enable-"));
+    try {
+      const store = new PluginOperationStore(directory);
+      const host = new PluginTransactionHost({ store });
+      const manifest: PluginManifestV0 = {
+        manifestSchemaVersion: 0,
+        id: "fixture.enable",
+        version: "1.2.3",
+        requiresMist: ">=0.1.0",
+        entrypoint: "dist/index.js",
+        kinds: ["tool_capability"],
+        configSchemaVersion: 1,
+        capabilities: [
+          {
+            id: "fixture.call",
+            description: "fixture call",
+            effect: "read",
+            operations: ["call"],
+            injectionMode: "eager",
+          },
+        ],
+        contextInjections: [],
+        env: [],
+        credentials: [],
+        permissions: [],
+      };
+      const moduleRef = moduleRefFromSource("fixture-enable");
+      const module: PluginModuleV0 = {
+        async prepare(context) {
+          context.register({
+            id: "fixture-enable-call",
+            kind: "tool",
+            capabilityId: "fixture.call",
+            recoveryKey: "fixture-enable-call",
+            async activate() {},
+            async dispose() {},
+          });
+          return {
+            async activate() {
+              return {
+                async dispose() {
+                  return { revoked: [], failed: [] };
+                },
+              };
+            },
+            async rollback() {},
+          };
+        },
+      };
+      const baseProbeRequest = probeRequest({
+        definition: { ...definition, pluginId: manifest.id, moduleRef },
+        binding: { ...binding, pluginId: manifest.id, moduleRef },
+      });
+      const probeCalls = { existence: 0, running: 0, readback: 0 };
+      const readinessRequest: RuntimeReadinessRequest = {
+        input: baseProbeRequest.input,
+        probe: {
+          existence: async (probeScope) => {
+            probeCalls.existence += 1;
+            return baseProbeRequest.probe.existence(probeScope);
+          },
+          running: async (probeScope) => {
+            probeCalls.running += 1;
+            return baseProbeRequest.probe.running(probeScope);
+          },
+          readback: async (probeScope) => {
+            probeCalls.readback += 1;
+            return baseProbeRequest.probe.readback(probeScope);
+          },
+        },
+      };
+      const request = {
+        pluginId: manifest.id,
+        manifest,
+        module,
+        moduleRef,
+        config: { enabled: true, settings: {}, environment: [], credentialRefs: {} },
+        resolveSecret: () => "unused",
+        readinessRequest,
+      };
+      const directReadyReceipt = await readRuntimeReadiness(
+        readinessRequest.input,
+        readinessRequest.probe,
+      );
+      const legacyRequest = { ...request };
+      Reflect.deleteProperty(legacyRequest, "readinessRequest");
+      await expect(
+        applyEnabledChange(host, store, { ...legacyRequest, readiness: directReadyReceipt }),
+      ).rejects.toThrow("must be produced by a current-process readback probe");
+      expect(() => store.read(manifest.id)).toThrow();
+      expect((await applyEnabledChange(host, store, request)).state).toBe("active");
+      expect((await applyEnabledChange(host, store, request)).state).toBe("active");
+      expect(probeCalls).toEqual({ existence: 3, running: 3, readback: 3 });
+      expect(host.readiness(manifest.id, "2026-08-21T00:00:30.000Z").status).toBe("ready");
+
+      const failingRequest: typeof request = {
+        ...request,
+        readinessRequest: {
+          ...readinessRequest,
+          probe: {
+            ...readinessRequest.probe,
+            readback: async () => {
+              throw new Error("readback unavailable");
+            },
+          },
+        },
+      };
+      expect((await applyEnabledChange(host, store, failingRequest)).state).toBe("active");
+      expect(probeCalls).toEqual({ existence: 4, running: 4, readback: 3 });
+      expect(host.readiness(manifest.id).status).toBe("unknown");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("projects only a receipt produced by the current-process readback probe", async () => {
     const directory = mkdtempSync(join(tmpdir(), "mist-runtime-readiness-"));
     try {
       const store = new PluginOperationStore(directory);
@@ -371,11 +519,13 @@ describe("runtime readiness / readback contract", () => {
       const moduleRef = moduleRefFromSource("fixture-ready");
       const readyDefinition = { ...definition, moduleRef };
       const readyBinding = { ...binding, moduleRef };
-      const readyEvidence = [evidence("existence"), evidence("running"), evidence("readback")].map(
-        (item) => ({ ...item, moduleRef }),
-      );
-      const receipt = evaluateRuntimeReadiness(
-        input({ definition: readyDefinition, binding: readyBinding, evidence: readyEvidence }),
+      const readyProbeRequest = probeRequest({
+        definition: readyDefinition,
+        binding: readyBinding,
+      });
+      const callerReceipt = await readRuntimeReadiness(
+        readyProbeRequest.input,
+        readyProbeRequest.probe,
       );
       await expect(
         host.activate({
@@ -386,29 +536,10 @@ describe("runtime readiness / readback contract", () => {
           env: {},
           bindings: {},
           verifiedScope: null,
-          readiness: receipt,
+          readiness: callerReceipt,
         }),
-      ).rejects.toThrow("ready runtime readiness requires an authority verifiedScope");
+      ).rejects.toThrow("must be produced by a current-process readback probe");
       expect(() => store.read(definition.pluginId)).toThrow();
-      await expect(
-        host.activate({
-          pluginId: definition.pluginId,
-          moduleRef,
-          module,
-          config: { enabled: true },
-          env: {},
-          bindings: {},
-          verifiedScope: { ...receipt.verifiedScope, residentId: "resident-b" },
-          readiness: receipt,
-        }),
-      ).rejects.toThrow("ready runtime readiness requires an authority verifiedScope");
-
-      const mismatchedCapabilityReceipt = {
-        ...receipt,
-        definition: { ...receipt.definition, capabilityId: "fixture.other" },
-        binding:
-          receipt.binding === null ? null : { ...receipt.binding, capabilityId: "fixture.other" },
-      };
       const mismatchedCapabilityOutcome = await host.activate({
         pluginId: definition.pluginId,
         moduleRef,
@@ -416,8 +547,11 @@ describe("runtime readiness / readback contract", () => {
         config: { enabled: true },
         env: {},
         bindings: {},
-        verifiedScope: mismatchedCapabilityReceipt.verifiedScope,
-        readiness: mismatchedCapabilityReceipt,
+        verifiedScope: null,
+        readinessRequest: probeRequest({
+          definition: { ...readyDefinition, capabilityId: "fixture.other" },
+          binding: { ...readyBinding, capabilityId: "fixture.other" },
+        }),
       });
       expect(mismatchedCapabilityOutcome).toMatchObject({
         state: "blocked",
@@ -432,10 +566,15 @@ describe("runtime readiness / readback contract", () => {
         config: { enabled: true },
         env: {},
         bindings: {},
-        verifiedScope: receipt.verifiedScope,
-        readiness: receipt,
+        verifiedScope: null,
+        readinessRequest: readyProbeRequest,
       });
-      expect(host.readiness(definition.pluginId, "2026-08-21T00:00:30.000Z").status).toBe("ready");
+      const readyProjection = host.readiness(definition.pluginId, "2026-08-21T00:00:30.000Z");
+      expect(readyProjection.status).toBe("ready");
+      expect("reasonCode" in readyProjection).toBe(false);
+      const persisted = store.read(definition.pluginId).readiness;
+      if (persisted === undefined) throw new Error("probe result was not persisted");
+      expect(persisted.status).toBe("ready");
       const restartedHost = new PluginTransactionHost({
         store: new PluginOperationStore(directory),
       });
@@ -445,45 +584,25 @@ describe("runtime readiness / readback contract", () => {
         status: "unknown",
         reasonCode: "CAPABILITY_UNVERIFIED",
       });
-      expect(
-        host.recordReadiness(definition.pluginId, receipt, "2026-08-21T00:00:30.000Z").status,
-      ).toBe("ready");
-
-      const mismatchedCapability = {
-        ...receipt,
-        definition: { ...receipt.definition, capabilityId: "fixture.other" },
-        binding:
-          receipt.binding === null ? null : { ...receipt.binding, capabilityId: "fixture.other" },
-      };
-      expect(isReadinessReceipt(mismatchedCapability)).toBe(true);
-      expect(() => host.recordReadiness(definition.pluginId, mismatchedCapability)).toThrow(
-        "runtime readiness receipt does not match the current plugin authority",
+      expect(() => host.recordReadiness(definition.pluginId, persisted)).toThrow(
+        "must be produced by a current-process readback probe",
       );
-
-      const mismatchedVersion = {
-        ...receipt,
-        definition: { ...receipt.definition, version: "1.2.4" },
-      };
-      expect(() => host.recordReadiness(definition.pluginId, mismatchedVersion)).toThrow(
-        "runtime readiness receipt does not match the current plugin authority",
-      );
-
-      const mismatchedBinding = {
-        ...receipt,
-        verifiedScope: { ...receipt.verifiedScope, networkPath: "loopback:19002/call" },
-        binding:
-          receipt.binding === null
-            ? null
-            : { ...receipt.binding, networkPath: "loopback:19002/call" },
-        evidence: receipt.evidence.map((item) => ({
-          ...item,
-          scope: { ...item.scope, networkPath: "loopback:19002/call" },
-        })),
-      };
-      expect(isReadinessReceipt(mismatchedBinding)).toBe(true);
-      expect(() => host.recordReadiness(definition.pluginId, mismatchedBinding)).toThrow(
-        "runtime readiness receipt does not match the current plugin authority",
-      );
+      await expect(
+        host.recordReadinessFromProbe(
+          definition.pluginId,
+          readyProbeRequest,
+          "2026-08-21T00:00:30.000Z",
+        ),
+      ).resolves.toMatchObject({ status: "ready" });
+      await expect(
+        host.recordReadinessFromProbe(
+          definition.pluginId,
+          probeRequest({
+            definition: { ...readyDefinition, capabilityId: "fixture.other" },
+            binding: { ...readyBinding, capabilityId: "fixture.other" },
+          }),
+        ),
+      ).rejects.toThrow("does not match the current plugin authority");
 
       const authority = store.read(definition.pluginId);
       store.save({ ...authority, verifiedScope: null });

--- a/tests/plugin-runtime-readiness.test.ts
+++ b/tests/plugin-runtime-readiness.test.ts
@@ -402,6 +402,29 @@ describe("runtime readiness / readback contract", () => {
           readiness: receipt,
         }),
       ).rejects.toThrow("ready runtime readiness requires an authority verifiedScope");
+
+      const mismatchedCapabilityReceipt = {
+        ...receipt,
+        definition: { ...receipt.definition, capabilityId: "fixture.other" },
+        binding:
+          receipt.binding === null ? null : { ...receipt.binding, capabilityId: "fixture.other" },
+      };
+      const mismatchedCapabilityOutcome = await host.activate({
+        pluginId: definition.pluginId,
+        moduleRef,
+        module,
+        config: { enabled: true },
+        env: {},
+        bindings: {},
+        verifiedScope: mismatchedCapabilityReceipt.verifiedScope,
+        readiness: mismatchedCapabilityReceipt,
+      });
+      expect(mismatchedCapabilityOutcome).toMatchObject({
+        state: "blocked",
+        reasonCode: "ACTIVATE_FAILED",
+      });
+      expect(store.read(definition.pluginId).readiness).toBeUndefined();
+
       await host.activate({
         pluginId: definition.pluginId,
         moduleRef,

--- a/tests/plugin-runtime-readiness.test.ts
+++ b/tests/plugin-runtime-readiness.test.ts
@@ -114,6 +114,30 @@ describe("runtime readiness / readback contract", () => {
     expect(receipt.reasonCode).toBe("CAPABILITY_UNVERIFIED");
   });
 
+  it("classifies simultaneous failures by probe kind, not evidence array order", () => {
+    const existenceFirst = evaluateRuntimeReadiness(
+      input({
+        evidence: [
+          evidence("readback", "fail"),
+          evidence("running", "fail"),
+          evidence("existence", "fail"),
+        ],
+      }),
+    );
+    expect(existenceFirst.reason).toBe("existence-failed");
+
+    const runningFirst = evaluateRuntimeReadiness(
+      input({
+        evidence: [
+          evidence("readback", "fail"),
+          evidence("running", "fail"),
+          evidence("existence"),
+        ],
+      }),
+    );
+    expect(runningFirst.reason).toBe("running-failed");
+  });
+
   it("does not trust a green health response when the real operation path is unreachable", () => {
     const receipt = evaluateRuntimeReadiness(
       input({
@@ -260,6 +284,15 @@ describe("runtime readiness / readback contract", () => {
     expect(projectReadiness("active", legacyReceipt, "2026-08-21T00:00:30.000Z")).toMatchObject({
       status: "unknown",
       reasonCode: "CAPABILITY_UNVERIFIED",
+    });
+  });
+
+  it("preserves a lifecycle failure reason when projecting blocked readiness", () => {
+    expect(
+      projectReadiness("blocked", undefined, "2026-08-21T00:00:30.000Z", "ACTIVATE_FAILED"),
+    ).toMatchObject({
+      status: "blocked",
+      reasonCode: "ACTIVATE_FAILED",
     });
   });
 
@@ -458,6 +491,33 @@ describe("runtime readiness / readback contract", () => {
         resolveSecret: () => "unused",
         readinessRequest,
       };
+      const malformedProbeRequest: RuntimeReadinessRequest = {
+        input: readinessRequest.input,
+        probe: {
+          existence: async () => null as unknown as RuntimeEvidence,
+          running: async () => null as unknown as RuntimeEvidence,
+          readback: async () => null as unknown as RuntimeEvidence,
+        },
+      };
+      const malformedOutcome = await host.activate({
+        pluginId: "fixture.malformed-probe",
+        moduleRef,
+        module,
+        runtimeVersion: manifest.version,
+        config: { enabled: true },
+        env: {},
+        bindings: {},
+        verifiedScope: null,
+        readinessRequest: malformedProbeRequest,
+      });
+      expect(malformedOutcome).toMatchObject({
+        state: "blocked",
+        reasonCode: "ACTIVATE_FAILED",
+      });
+      expect(store.read("fixture.malformed-probe")).toMatchObject({
+        lifecycleState: "blocked",
+        operation: { phase: "completed", rollbackCompleted: true },
+      });
       const directReadyReceipt = await readRuntimeReadiness(
         readinessRequest.input,
         readinessRequest.probe,
@@ -470,6 +530,12 @@ describe("runtime readiness / readback contract", () => {
       expect(() => store.read(manifest.id)).toThrow();
       expect((await applyEnabledChange(host, store, request)).state).toBe("active");
       expect((await applyEnabledChange(host, store, request)).state).toBe("active");
+      await expect(
+        applyEnabledChange(host, store, { ...legacyRequest, readiness: directReadyReceipt }),
+      ).resolves.toMatchObject({
+        state: "active",
+        reasonCode: "CAPABILITY_UNVERIFIED",
+      });
       expect(store.read(manifest.id).runtimeVersion).toBe(manifest.version);
       expect(new PluginOperationStore(directory).read(manifest.id).runtimeVersion).toBe(
         manifest.version,
@@ -639,6 +705,19 @@ describe("runtime readiness / readback contract", () => {
           "2026-08-21T00:00:30.000Z",
         ),
       ).resolves.toMatchObject({ status: "ready" });
+      const shiftedScope = { ...scope, residentId: "resident-b" };
+      await expect(
+        host.recordReadinessFromProbe(
+          definition.pluginId,
+          probeRequest({
+            definition: readyDefinition,
+            binding: readyBinding,
+            authorization: { ...authorization, residentId: shiftedScope.residentId },
+            scope: shiftedScope,
+          }),
+        ),
+      ).rejects.toThrow("does not match the current plugin authority");
+      expect(store.read(definition.pluginId).readiness?.verifiedScope).toEqual(scope);
       await expect(
         host.recordReadinessFromProbe(
           definition.pluginId,
@@ -652,6 +731,18 @@ describe("runtime readiness / readback contract", () => {
       const authority = store.read(definition.pluginId);
       store.save({ ...authority, verifiedScope: null });
       expect(host.readiness(definition.pluginId, "2026-08-21T00:00:30.000Z")).toMatchObject({
+        status: "unknown",
+        reasonCode: "CAPABILITY_UNVERIFIED",
+      });
+      const authorityWithoutScope = { ...authority };
+      Reflect.deleteProperty(authorityWithoutScope, "verifiedScope");
+      store.save(authorityWithoutScope);
+      const restartedWithoutScope = new PluginTransactionHost({
+        store: new PluginOperationStore(directory),
+      });
+      expect(
+        restartedWithoutScope.readiness(definition.pluginId, "2026-08-21T00:00:30.000Z"),
+      ).toMatchObject({
         status: "unknown",
         reasonCode: "CAPABILITY_UNVERIFIED",
       });

--- a/tests/pv0/pv0-f-readiness-semantics.test.ts
+++ b/tests/pv0/pv0-f-readiness-semantics.test.ts
@@ -6,7 +6,8 @@
  * external-evidence fixtures; unrelated F04/F05 and mutation accounting remain todo.
  *
  * Item source of truth: acceptance/plugin-protocol-v0.md at the #62 freeze point
- * (main@acdfcab2); titles copied verbatim.
+ * (main@acdfcab2); these tests intentionally name only the implemented narrow slice, not a
+ * completed F01/F02/F06 checklist item.
  * Awaits: readiness lamps + reason-code wiring (spans PR①-③).
  */
 import { describe, expect, it } from "vitest";
@@ -73,13 +74,13 @@ function request(overrides: Partial<ReadinessEvaluationInput> = {}): ReadinessEv
 }
 
 describe("PV0 series F — readiness 与稳定失败语义 (RFC §4/§8)", () => {
-  it("[PV0-F01] readiness 有 scope", () => {
+  it("readiness narrow slice preserves scope (not the full PV0-F01 checklist)", () => {
     const receipt = evaluateRuntimeReadiness(request());
     expect(receipt.status).toBe("ready");
     expect(receipt.verifiedScope).toEqual(scope);
     expect(receipt.lastVerifiedAt).toBe("2026-08-21T00:00:00.000Z");
   });
-  it("[PV0-F02] 原因码稳定可判", () => {
+  it("narrow slice keeps CAPABILITY_UNVERIFIED stable (not the full PV0-F02 A–E matrix)", () => {
     const receipt = evaluateRuntimeReadiness(request({ evidence: [probe("existence")] }));
     expect(receipt.status).toBe("unknown");
     expect(receipt.reasonCode).toBe("CAPABILITY_UNVERIFIED");
@@ -91,7 +92,7 @@ describe("PV0 series F — readiness 与稳定失败语义 (RFC §4/§8)", () =>
   it.todo(
     "[PV0-F05] 壳共享魂私有 — STUBBED-PENDING(readiness lamps + capability receipts — 单B 范围外)",
   );
-  it("[PV0-F06] ready 必须有当前 scope 的可用性收据", () => {
+  it("narrow slice requires a current readback receipt (not the full PV0-F06 provider matrix)", () => {
     const missingReadback = evaluateRuntimeReadiness(
       request({ evidence: [probe("existence"), probe("running")] }),
     );

--- a/tests/pv0/pv0-f-readiness-semantics.test.ts
+++ b/tests/pv0/pv0-f-readiness-semantics.test.ts
@@ -2,33 +2,108 @@
  * PV0 acceptance suite — series F: readiness 与稳定失败语义 (RFC §4/§8)
  *
  * Doctrine (#76, 旦九 2026-08-20 ruling): PV0 runs as an independent Vitest suite,
- * NOT inside the six-lights acceptance driver. Every unimplemented item stays an
- * honest `it.todo` — fixture-backed stubs must be declared STUBBED in the PR body,
- * and nothing here is allowed to impersonate green.
+ * NOT inside the six-lights acceptance driver. The readiness slice is now backed by
+ * external-evidence fixtures; unrelated F04/F05 and mutation accounting remain todo.
  *
  * Item source of truth: acceptance/plugin-protocol-v0.md at the #62 freeze point
  * (main@acdfcab2); titles copied verbatim.
  * Awaits: readiness lamps + reason-code wiring (spans PR①-③).
  */
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import {
+  type ReadinessEvaluationInput,
+  type RuntimeEvidence,
+  evaluateRuntimeReadiness,
+} from "../../src/plugin/runtime-readiness.ts";
+
+const scope = {
+  residentId: "pv0-resident",
+  lane: "primary",
+  operations: ["call"],
+  host: "pv0-host",
+  networkPath: "loopback:19001/call",
+  version: "1.0.0",
+} as const;
+const definition = {
+  pluginId: "pv0.fixture",
+  capabilityId: "pv0.call",
+  version: scope.version,
+  moduleRef: "sha256:pv0",
+} as const;
+const binding = {
+  pluginId: definition.pluginId,
+  capabilityId: definition.capabilityId,
+  version: definition.version,
+  moduleRef: definition.moduleRef,
+  host: scope.host,
+  networkPath: scope.networkPath,
+} as const;
+const authorization = {
+  residentId: scope.residentId,
+  lane: scope.lane,
+  operations: [...scope.operations],
+} as const;
+function probe(
+  kind: RuntimeEvidence["kind"],
+  outcome: RuntimeEvidence["outcome"] = "pass",
+): RuntimeEvidence {
+  return {
+    kind,
+    source: "external",
+    probeId: `pv0-${kind}`,
+    observedAt: "2026-08-21T00:00:00.000Z",
+    scope,
+    version: scope.version,
+    moduleRef: definition.moduleRef,
+    outcome,
+    conditions: { endpoint: scope.networkPath },
+  };
+}
+function request(overrides: Partial<ReadinessEvaluationInput> = {}): ReadinessEvaluationInput {
+  return {
+    definition,
+    binding,
+    authorization,
+    scope,
+    evidence: [probe("existence"), probe("running"), probe("readback")],
+    now: "2026-08-21T00:00:01.000Z",
+    maxAgeMs: 60_000,
+    ...overrides,
+  };
+}
 
 describe("PV0 series F — readiness 与稳定失败语义 (RFC §4/§8)", () => {
-  it.todo(
-    "[PV0-F01] readiness 有 scope — STUBBED-PENDING(readiness lamps + capability receipts — 单B 范围外)",
-  );
-  it.todo(
-    "[PV0-F02] 原因码稳定可判 — STUBBED-PENDING(readiness lamps + capability receipts — 单B 范围外)",
-  );
-  it.todo(
-    "[PV0-F03] 每条约束都有指定红格 — STUBBED-PENDING(readiness lamps + capability receipts — 单B 范围外)",
-  );
+  it("[PV0-F01] readiness 有 scope", () => {
+    const receipt = evaluateRuntimeReadiness(request());
+    expect(receipt.status).toBe("ready");
+    expect(receipt.verifiedScope).toEqual(scope);
+    expect(receipt.lastVerifiedAt).toBe("2026-08-21T00:00:00.000Z");
+  });
+  it("[PV0-F02] 原因码稳定可判", () => {
+    const receipt = evaluateRuntimeReadiness(request({ evidence: [probe("existence")] }));
+    expect(receipt.status).toBe("unknown");
+    expect(receipt.reasonCode).toBe("CAPABILITY_UNVERIFIED");
+  });
+  it.todo("[PV0-F03] 每条约束都有指定红格 — mutation accounting remains pending");
   it.todo(
     "[PV0-F04] boot-time 不变量不可卸载 — STUBBED-PENDING(readiness lamps + capability receipts — 单B 范围外)",
   );
   it.todo(
     "[PV0-F05] 壳共享魂私有 — STUBBED-PENDING(readiness lamps + capability receipts — 单B 范围外)",
   );
-  it.todo(
-    "[PV0-F06] ready 必须有当前 scope 的可用性收据 — STUBBED-PENDING(readiness lamps + capability receipts — 单B 范围外)",
-  );
+  it("[PV0-F06] ready 必须有当前 scope 的可用性收据", () => {
+    const missingReadback = evaluateRuntimeReadiness(
+      request({ evidence: [probe("existence"), probe("running")] }),
+    );
+    expect(missingReadback.status).toBe("unknown");
+    expect(missingReadback.reasonCode).toBe("CAPABILITY_UNVERIFIED");
+
+    const wrongPath = evaluateRuntimeReadiness(
+      request({
+        evidence: [probe("existence"), probe("running"), probe("readback", "fail")],
+      }),
+    );
+    expect(wrongPath.status).toBe("blocked");
+    expect(wrongPath.reasonCode).toBe("PLUGIN_RUNTIME_FAILED");
+  });
 });


### PR DESCRIPTION
## Summary

- Add a scope-aware runtime readiness/readback contract on top of #97 readiness receipts and verifiedScope.
- Require independent external existence, running, and readback evidence bound to resident, lane, operations, host/network, version, conditions, and freshness.
- Keep active plugins without a valid current receipt fail-closed as unknown.
- Revalidate readiness against the plugin capability inventory after prepare and before resource activation.

## Validation

- `npm run acceptance` — 6/6
- `npm run lint`
- `npm run typecheck`
- `npm test` — 421 passed, 38 todo, 3 skipped

## Scope

- No capability registry, scheduler, backend, credentials, deployment, or remote-write changes.
- PV0 F01/F02/F06 remain explicitly unchecked pending their full matrices.

Refs #101