### PR TITLE
docs(registry): 能力登记 v0 边界与验收——两轴分离 / binding 两账 / 反写红格（#100）

### DIFF
--- a/acceptance/capability-registry-v0.md
+++ b/acceptance/capability-registry-v0.md
@@ -1,0 +1,85 @@
+# 能力登记 v0 验收清单（#100）
+
+规范来源：[能力登记与生命周期 v0](../docs/design/capability-registry-v0.md)。本清单先判
+登记态的形状与边界，不声称任何实现已经通过——registry 本体在 v0 尚未实现，因此**全部条目
+未勾选**。实现落地时，每项必须成为确定性自动测试；测试违反约束后没有明确红灯的条目，
+不得勾选。
+
+每条记录四件事：fixture、动作、确定性断言、失败时的 reason code。
+
+与其它清单的分工：运行态就绪判卷见 [plugin-protocol-v0.md](plugin-protocol-v0.md) F 系列
+与 [runtime-readiness.md](../docs/design/runtime-readiness.md)；本清单**不重复判 readiness**，
+只判 registry 侧的拒绝行为。
+
+## A. 两轴分离（登记态 vs 实例运行态）
+
+- [ ] **[CR0-A01](../docs/design/capability-registry-v0.md#capability-registry-v0-s1) 实例 disposed 不清除 definition**：一项已登记能力的实例走完
+  `active → disposing → disposed`；断言 registry 的 `definition` 仍为 `present`、
+  `superseded` 仍为 `current`，仅 `binding` 指针按其账本规则变化。任何清除 definition 的
+  实现返回 `REGISTRY_INVARIANT_VIOLATED`。
+- [ ] **[CR0-A02](../docs/design/capability-registry-v0.md#capability-registry-v0-s1) 能力 superseded 不清理旧实例**：把能力标为
+  `superseded_by(new_id)`，同时旧实例处于 `quarantined`；断言旧实例仍为 `quarantined`
+  且其人工处理清单不被清空——登记侧的取代**不构成**资源撤销。
+- [ ] **[CR0-A03](../docs/design/capability-registry-v0.md#capability-registry-v0-s1) 两轴不可互相推导**：给定任一 `lifecycle.ts` 状态，registry
+  拒绝据此推断六格中任一格的取值；反向同理。以缺省实现（无推导函数）+ 一条断言两轴
+  记录独立可写的测试共同证明。
+
+## B. binding 两账互不干扰
+
+- [ ] **[CR0-B01](../docs/design/capability-registry-v0.md#capability-registry-v0-s3) 改 lane binding，scope binding 字节不变**：同一 resident
+  同时持有 `(residentId, lane)` 与 `(residentId, scopeId)` 两类 binding；修改前者后，
+  断言后者的序列化字节**逐字节相等**（不是语义相等）。
+- [ ] **[CR0-B02](../docs/design/capability-registry-v0.md#capability-registry-v0-s3) 撤销一类不波及另一类**：撤销 scope binding 后，
+  断言 lane binding 仍可 dispatch，且 registry 的 binding 指针只失效对应那一个。
+- [ ] **[CR0-B03](../docs/design/capability-registry-v0.md#capability-registry-v0-s3) 不得从一类猜另一类的合法值**：请求一个只在 lane 账本
+  存在的键去解析 scopeId（及反向）；两者均返回 `CONFIG_INVALID`，不做任何跨账本回退查找。
+- [ ] **[CR0-B04](../docs/design/capability-registry-v0.md#capability-registry-v0-s3) binding 不合成单一布尔**：registry 的对外形状里不存在
+  一个把两类 binding 合并的 `bound: boolean`；以类型层断言 + 投影快照共同证明。
+
+## C. 迁移与诚实缺省
+
+- [ ] **[CR0-C01](../docs/design/capability-registry-v0.md#capability-registry-v0-s2) 迁移后诚实落态**：导入一份只含 definition 的旧记录；
+  断言结果恰为 `definition=present, binding=unbound, authorization=missing`，且 readiness
+  投影为 `unknown`；任何自动升级为 active 的实现返回 `REGISTRY_INVARIANT_VIOLATED`。
+- [ ] **[CR0-C02](../docs/design/capability-registry-v0.md#capability-registry-v0-s5) 导出再导入不丢追溯**：导出后重新导入，断言稳定 id、
+  六格取值、supersede 链与 evidence 指针全部保留；任一项丢失即红灯。
+- [ ] **[CR0-C03](../docs/design/capability-registry-v0.md#capability-registry-v0-s2) 六格不得压平**：构造 `unhealthy` / `deprecated` /
+  `superseded` / `removed` 四种处置各一份 fixture；断言四者在 registry 里可区分，
+  且任一投影都不把它们渲染成同一个 `inactive`。
+
+## D. 只做指针的两格
+
+- [ ] **[CR0-D01](../docs/design/capability-registry-v0.md#capability-registry-v0-s2) authorization 不缓存结论**：先完成一次通过的扩权比较；
+  随后在不重新比较的前提下请求授权判定，断言 registry **不返回** `granted`，而是要求
+  本次包内比较。以「读 registry 不产生授权结论」的断言证明。
+- [ ] **[CR0-D02](../docs/design/capability-registry-v0.md#capability-registry-v0-s2) authorization 无 TTL**：把上一次比较的时间戳前移任意
+  长度；断言判定行为不变——registry 侧不存在任何随时间自动放行或自动收紧的路径。
+- [ ] **[CR0-D03](../docs/design/capability-registry-v0.md#capability-registry-v0-s2) 指针必须可回指**：authorization 与 binding 两格的证据
+  指针指向不存在的记录时返回 `REGISTRY_DANGLING_REF`，不得静默降级为 `missing`——
+  「查不到」与「确实没有」必须可区分。
+
+## E. 反写红格（registry 侧自己拒绝）
+
+- [ ] **[CR0-E01](../docs/design/capability-registry-v0.md#capability-registry-v0-s4) readiness receipt 不得改 registry**：提交一份 `ready`
+  收据；断言六格**逐格**不变。这是 registry 自己这一侧的拒绝，与
+  [runtime-readiness.md](../docs/design/runtime-readiness.md) 从 #101 侧写的同名约束
+  **各测一遍**——单向约束换个入口就能绕开。
+- [ ] **[CR0-E02](../docs/design/capability-registry-v0.md#capability-registry-v0-s4) telemetry 不得改 registry**：注入调用次数、失败率、
+  最近使用时间等读数；断言六格不变（承接 #35 已收原则「telemetry 不得单独改 canonical
+  lifecycle」，此处从 registry 侧判卷）。
+- [ ] **[CR0-E03](../docs/design/capability-registry-v0.md#capability-registry-v0-s4) projection 不得回流**：修改目录/启动包投影（含裁剪、
+  排序、隐藏）；断言 registry 六格不变，且投影侧标注了省略原因与查询边界。
+
+## F. 账面全绿的非结论性
+
+- [ ] **[CR0-F01](../docs/design/capability-registry-v0.md#capability-registry-v0-s4) 六格全绿仍不得投影为「可用」**：构造六格全部满足的
+  fixture，同时 readiness 为 `unknown`；断言任何对住户可见的投影**不**显示为可用/ready，
+  且能说明「账面齐全、运行态未验证」。
+  这条直接对应 #35 楼内 2026-08-16 那例：账面全绿、`/health` 200、住户失联 2h35m。
+- [ ] **[CR0-F02](../docs/design/capability-registry-v0.md#capability-registry-v0-s4) registry 不得自产 ready**：registry 的对外接口中不存在
+  任何返回 `ready` 的路径；以接口层断言证明（缺省即证明，另配一条「若新增则红灯」的检查）。
+
+## 未决（等主笔裁，见图纸 §2.1）
+
+`exposed` 与 `selected` 两态在 #100 / #101 两卡均未收，本清单**暂不为其立条目**。
+裁定归属后再补，不先占位——占位本身会变成第二张说自己是真相的表。

--- a/docs/design/capability-registry-v0.md
+++ b/docs/design/capability-registry-v0.md
@@ -1,0 +1,165 @@
+# 能力登记与生命周期 v0（#100）
+
+本图纸只管 **capability registry**——一项能力在系统里的**登记事实**如何记录、如何变更、
+如何追溯。它不新增 readiness 语义（那是 [runtime-readiness.md](runtime-readiness.md) 的地盘），
+不定义 schema、存储后端或调度器，也不实现 registry 本体。
+
+范围来自 #35 分线后旦九 2026-08-21 的裁决（#35 收窄为 memory-only，能力登记拆出为 #100），
+边界参照 [plugin-protocol-v0.md](plugin-protocol-v0.md) 的 `LaneBinding` / `verifiedScope`
+与 #100 楼内 Noema 2026-08-21 的跨卡边界意见。
+
+<a id="capability-registry-v0-s1"></a>
+## 1. 登记态与实例运行态是两个轴
+
+这是本图纸要钉死的第一件事，因为两者最容易被读成一根时间线。
+
+| | 回答的问题 | 权威位置 | 键 |
+|---|---|---|---|
+| **实例运行态** | 这一个插件实例**这一次运行**走到哪儿了 | `src/plugin/lifecycle.ts`（#97） | 一次运行 |
+| **能力登记态** | 这**一项能力**在系统里登记成什么 | 本图纸（#100） | 稳定 capability id |
+
+`lifecycle.ts` 的八态 `discovered → validated → prepared → active → disposing → disposed`
+加 `blocked` / `quarantined`，描述的是一次装载的进程事实。本图纸的登记态描述的是跨重启、
+跨版本存续的账面事实。
+
+**两者不得互相推导**，各给一条反例：
+
+- 实例 `disposed` **不蕴含** definition 消失——插件卸载后能力定义仍在册，只是 `binding=unbound`；
+- 能力 `superseded` **不蕴含** 旧实例已清理——旧实例可能还挂在 `quarantined` 等人工清理，
+  而新版本已经接管登记。
+
+若不在 v0 钉死，registry 会退化成 `lifecycle.ts` 的影子表：两张表同时声称自己是真相，
+正是 #35 楼内三例事故的共同形状（详见 [§4](#capability-registry-v0-s4)）。
+
+<a id="capability-registry-v0-s2"></a>
+## 2. 六格登记态与它们的权威归属
+
+登记态**不是**一条链，是六个正交的格子。每一格独立取值，合起来才是这项能力此刻的账面。
+把它们压成单一枚举（`active` / `inactive`）正是露娜在 #35 第 4 节点名反对的做法。
+
+| 格 | 取值 | 谁拥有这一格 | registry 的角色 |
+|---|---|---|---|
+| `definition` | `present` \| `absent` | 本图纸 | **拥有**：稳定 id、版本、来源 manifest 的登记与追溯 |
+| `installed` | `installed` \| `not_installed` | 本图纸 | **拥有**：物料到位与否，及其证据指针 |
+| `registered` | `registered` \| `unregistered` | 本图纸 | **拥有**：已进入宿主能力目录与否 |
+| `binding` | 见 [§3](#capability-registry-v0-s3)，**不是单值** | 各 binding 账本 | **只做指针**：登记指向哪本账的哪条记录 |
+| `authorization` | `granted` \| `missing` \| `narrowed` | 升级扩权闸 | **只做指针**：登记「哪一次比较、结论是什么、证据在哪」 |
+| `superseded` | `current` \| `superseded_by(id)` | 本图纸 | **拥有**：取代关系与追溯链 |
+
+三条派生约束：
+
+1. **registry 不拥有 readiness。** `readiness` 不是本图纸的格子。它是
+   [runtime-readiness.md §边界](runtime-readiness.md) 那张表里的派生观察，由 #101 产生收据。
+2. **只做指针的两格不缓存结论。** `authorization` 记录的是「上一次包内逐项比较的结论 + 证据
+   指针」，读它**不能**替代下一次比较；v0 不引入 TTL、不引入「上次批准过所以这次也算」。
+3. **六格全绿不等于能用。** 这句必须写进 registry 的对外投影：definition present + installed +
+   registered + bound + authorized + current，仍然只说明账面齐全，说明不了住户敲得开门。
+   为什么，见 [§4](#capability-registry-v0-s4)。
+
+### 2.1 卡面六态与露娜八态的差集（提请主笔裁）
+
+#100 卡面列了六态；露娜在 #35 第 5 节的最小验收矩阵第 1 条列的是八项：
+`definition、installed、registered、bound、authorized、ready、exposed、selected`。差集需要显式处置，
+否则实现时两边各按各的读：
+
+- `ready` —— 已随分线归 #101，本图纸不收，只在投影里引用其收据。
+- `superseded` —— 卡面有、露娜第 5 节未列，但其第 4 节明确要求
+  `unhealthy / deprecated / superseded / removed` 不得压成同一个 `inactive`。本图纸收，
+  作为独立格（见 [§5](#capability-registry-v0-s5)）。
+- `exposed`、`selected` —— **两卡都没收，是真空。** 本图纸的建议：
+  - `exposed`（能力在某 scope 的目录里对住户可见）属于 **projection**，不是 canonical 登记态。
+    它可以有损、可以被裁剪，按露娜四分法不得反写 registry；建议**不收进本图纸的格子**，
+    但要求投影侧标注「这不是全库」与省略原因。
+  - `selected`（dispatch 时选中了哪条 lane 绑定）是**一次调用的瞬时选择**，不是能力的登记事实，
+    属于 dispatch 路径；建议**不收**，另由多 viewport / dispatch 侧安置。
+
+  两条都请主笔裁；在裁定之前，本图纸不为它们预留格子，以免又长出一张说自己是真相的表。
+
+<a id="capability-registry-v0-s3"></a>
+## 3. `binding` 不是单值——两类账，互不推导
+
+按 #100 楼内 Noema 2026-08-21 的边界，binding 至少是两本独立的账：
+
+| 账本 | 键 | 负责 | 定义位置 |
+|---|---|---|---|
+| lane binding | `(residentId, lane)` | 选择执行通道，指向适配器与凭证引用 | `src/installer/contracts.ts:28` |
+| 外部信道 binding | `(residentId, scopeId)` | 绑定外部聊天与可见性域 | `docs/glossary.md` scopeId 条 |
+
+`lane` 与 `scopeId` 已在术语表钉成**正交维度**，「两者互不推导，任一方的合法值都不得从另一方
+猜出」。因此 registry 对 binding 这一格：
+
+- 记录**两个独立指针**，不合成单一 `bound` 布尔；
+- 任一账本的修改或撤销，**不得**触发对另一账本的读、写或推导；
+- 迁移后允许诚实落在 `binding=unbound`，不因另一账本有记录而自动补齐。
+
+<a id="capability-registry-v0-s4"></a>
+## 4. 为什么「账面全绿」必须是一个明确的非结论
+
+本节的论据是 #35 楼内的三例真实事故，它们结构相同：**用系统自己报告的状态，证明系统自己是好的。**
+
+1. 代谢器根本没运行，文档却声称它已生效；
+2. `/health` 返回 200、bucket 数量正常，但查询范围漏了 archive；
+3. 代码/import/deploy 成功，但真实服务绑错端口，住户根本访问不到。
+
+第 3 例的完整病历在 #35 楼内 2026-08-16（chaodeng060-source）：部署覆盖了机器专属的绑定改造，
+运行时从 `18080/loopback` 退化成 `8000/0.0.0.0`。当时的登记账面**六格全绿**——definition 在册、
+installed 成功、registered 成功、binding 有记录、authorization 通过、没有被 supersede——
+而住户失联 2 小时 35 分。看门狗每 30 秒忠实失败一次，因为它的判据是「进程活着吗」，
+而进程一直活着。
+
+这一例对本图纸的直接结论：
+
+- registry 的六格**只能**回答「账面登记成什么」，**不能**被任何投影读成「能用」；
+- 因此 `readiness` 不进 registry 不是分工洁癖，是这例事故的直接教训：
+  一旦 registry 自己能声称 ready，它就会用账面证明账面；
+- 反过来也要立红格：**readiness receipt 不得反写 registry 的任一格**。
+  [runtime-readiness.md](runtime-readiness.md) 已从 #101 侧写了这条（「不把 receipt 当作
+  binding/authorization 的第二真相源」）；registry 建起来时必须从**自己这一侧**再拒绝一次。
+  单向约束在实现里会被绕开——写入方换个入口就进来了。
+
+<a id="capability-registry-v0-s5"></a>
+## 5. `superseded` 与勘误链重名不同义
+
+`docs/glossary.md` 已有词条 **勘误链（supersede chain）**：修订记忆的方式，旧条不删、新条盖上、
+挂 reason 连成链。本图纸的 `superseded` 是**能力被新版本取代后的登记态**。
+
+两者共享「旧的不删」这条精神，但不是同一个东西：
+
+| | 勘误链 | 能力 superseded |
+|---|---|---|
+| 对象 | 记忆条目 | 能力登记记录 |
+| 键 | 记忆条目 id | 稳定 capability id |
+| 触发 | 事实被修正 | 新版本取代旧版本 |
+| 消费方 | 检索层降权 | 目录默认选中 replacement |
+
+v0 若不分开立词条，后面一定有人拿记忆勘误链的语义去读能力登记，或者反过来。术语表补条见本单。
+
+取代关系的两条硬规（承接露娜 #35 第 4 节，已由旦九收进 #35 原则）：
+
+- 新能力取代旧能力后，**默认选择 replacement，旧记录仍可追溯**；
+- `unhealthy` / `deprecated` / `superseded` / `removed` **不得**压成同一个 `inactive`——
+  它们的处置动作不同，压平之后无法还原。
+
+<a id="capability-registry-v0-s6"></a>
+## 6. 与既有图纸的关系
+
+- [plugin-protocol-v0.md](plugin-protocol-v0.md) —— 插件协议 v0，`LaneBinding` / `verifiedScope`
+  的定义源。本图纸不改其任何字段。
+- [runtime-readiness.md](runtime-readiness.md) —— #101。其 §边界那张表已列出 definition /
+  binding / authorization「运行态验证不能改它」；本图纸补的是**这三格自己归谁、怎么变、怎么追溯**，
+  正是该图纸第 3 行声明不管的部分。
+- [capability-contract.md](capability-contract.md) —— **挂起中**（旦九 2026-08-13）。它讲的是
+  `definition` 这一格**装什么内容**（audiences / effect / approval / surface 投影）。本图纸讲的是
+  登记**状态**，两者不重叠；那份解锁后可直接填进 `definition` 格，不需要改本图纸的形状。
+
+## 7. v0 不做什么
+
+不定 schema、不选存储后端、不碰后台调度、不实现 registry 本体、不扩 readiness 语义、
+不为 `exposed` / `selected` 预留格子（等主笔裁 §2.1）。边界与验收收敛、主笔点头之后，
+再开只做一件事的实现 PR。
+
+### 代价
+
+六格分开记比单一 `active` 枚举贵：投影侧要处理六格组合，UI 要解释「账面齐全但 readiness unknown」
+这种对住户不直观的状态。这是拿可解释性换的——压平之后，那 2 小时 35 分的失联在账面上
+和一切正常长得一模一样。

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -58,6 +58,20 @@
 工具能力或桥接，但不能绕开宿主的权限闸、凭证库和住户隔离。插件卸载后，它注册的资源
 必须全部失效；协议可逆不等于插件代码可信。
 
+**能力登记（capability registry）**
+一项能力在系统里的**账面事实**：`definition` / `installed` / `registered` / `binding` /
+`authorization` / `superseded` 六个正交格子，以稳定 capability id 为键，跨重启与跨版本存续。
+它与插件实例的运行态生命周期（`src/plugin/lifecycle.ts` 的 discovered…disposed）是两个轴，
+互不推导：实例 disposed 不清除 definition，能力 superseded 不清理旧实例。registry 不拥有
+readiness，也不得被 readiness 收据、telemetry 或 projection 反写。**六格全绿只说明账面齐全，
+不说明住户能用**（图纸 `docs/design/capability-registry-v0.md` §4）。
+
+**superseded（能力登记）**
+能力被新版本取代后的登记态，与上面的**勘误链（supersede chain）**重名不同义：勘误链修订的是
+记忆条目、键是条目 id、消费方是检索层降权；本条修订的是能力登记记录、键是稳定 capability id、
+消费方是目录默认选中 replacement。两者共享「旧的不删」，但不可互相套用语义。
+`unhealthy` / `deprecated` / `superseded` / `removed` 处置动作不同，不得压成同一个 `inactive`。
+
 **上下文注入（context injection）**
 插件希望加入住户模型上下文的非工具文本，例如 skill prompt 段或 MCP instructions。
 它不是普通工具返回值，也不是人格文件：正文必须在插件包内随 manifest 声明、可 diff、


### PR DESCRIPTION
承 #100 楼内认领。本单只收**边界与验收**，不定 schema、不选存储、不碰后台调度、不实现 registry 本体、不扩 readiness 语义——那是 Noema 在楼里划的线，也是露娜 #35 第 5 节末尾的建议。

## 三条主张

**一、登记态与实例运行态是两个轴，最容易被读成一根时间线。**

`src/plugin/lifecycle.ts`（#97）的八态 `discovered → … → disposed / blocked / quarantined`，说的是**一个实例这一次运行**走到哪儿；本单六格说的是**一项能力在系统里的账面**，跨重启、跨版本存续。

不得互相推导，各给一条反例：

- 实例 `disposed` **不蕴含** definition 消失——插件卸载后定义仍在册，只是 `binding=unbound`；
- 能力 `superseded` **不蕴含** 旧实例已清理——旧实例可能还挂在 `quarantined` 等人工处理，而新版本已接管登记。

不钉死，registry 会退化成 `lifecycle.ts` 的影子表：两张表同时声称自己是真相，正是 #35 楼内三例事故的共同形状。

**二、六格里三格已有权威账本，registry 只做指针不造真相。**

| 格 | 谁拥有 | registry 的角色 |
|---|---|---|
| `definition` / `installed` / `registered` / `superseded` | 本单 | 拥有 |
| `binding` | 两本独立账（lane / scopeId） | 只做指针 |
| `authorization` | 升级扩权闸 | 只做指针 |
| `readiness` | #101 | **不是本单的格子** |

- `binding` 按 @Aurore1221 在 #100 楼里划的边界拆两类，**不合成单一 `bound` 布尔**。lane 与 scopeId 已在术语表钉成正交维度（「两者互不推导，任一方的合法值都不得从另一方猜出」），验收要求改一类时另一类**逐字节相等**，不是语义相等。
- `authorization` 记录的是「上一次包内逐项比较的结论 + 证据指针」，读它不能替代下一次比较；v0 不引入 TTL、不引入「上次批准过所以这次也算」。

**三、反写红格要两侧各立一条。**

`docs/design/runtime-readiness.md` 已从 #101 侧写了「不引入新的 canonical registry，也不把 receipt 当作 binding/authorization 的第二真相源」。本单从 **registry 自己这一侧**再拒绝一次（CR0-E01/E02/E03，分别拦 readiness receipt、telemetry、projection）。

理由：单向约束在实现里会被绕开——写入方换个入口就进来了。两侧各测一遍不是重复，是把「谁调用谁」这个自由度也封上。

## 论据

#35 楼内三例事故结构相同：**用系统自己报告的状态，证明系统自己是好的。**

其中 08-16 那例（我在楼内交的病历）：部署覆盖了机器专属的绑定改造，运行时从 `18080/loopback` 退化成 `8000/0.0.0.0`。当时的登记账面**六格全绿**，`/health` 每 60 秒返 200，桶数正常，日志干净——住户失联 2 小时 35 分。看门狗每 30 秒忠实失败一次，因为它的判据是「进程活着吗」，而进程一直活着。

这一例直接支撑 CR0-F01：**账面全绿不得投影为「可用」**。也是为什么 `readiness` 坚决不进 registry——一旦 registry 自己能声称 ready，它就会用账面证明账面。

## 术语表补两条

- `能力登记（capability registry）`
- `superseded（能力登记）`——与既有 `勘误链（supersede chain）` **重名不同义**：对象（记忆条目 vs 能力登记记录）、键（条目 id vs 稳定 capability id）、触发（事实被修正 vs 新版本取代）、消费方（检索层降权 vs 目录默认选中 replacement）四项都不同。不分开立词条，后面一定有人拿一边的语义去读另一边。

## 提请主笔裁一处（图纸 §2.1）

卡面六态与露娜 #35 第 5 节验收第 1 条列的八项对不上：`ready`、`exposed`、`selected` 是差集。

- `ready` —— 已随分线归 #101，本单不收，只在投影里引用其收据。
- `exposed`、`selected` —— **两卡都没收，是真空。** 我的建议：`exposed`（能力在某 scope 目录里对住户可见）属 **projection**，可有损、可裁剪，按四分法不得反写 registry；`selected`（dispatch 时选中哪条 lane 绑定）是**一次调用的瞬时选择**，属 dispatch 路径。两者本单都**不预留格子**——占位本身会变成第二张说自己是真相的表。

请裁。裁完我补验收条目。

## 验证

- `npm run lint` 通过（85 文件）
- `npm run acceptance` 六盏真绿（C1–C6）
- 36 处交叉引用 + 代码行号（`src/installer/contracts.ts:28` 的 `LaneBinding`）自查全部对得上
- `npm run typecheck` 报 `@inquirer/prompts` 缺依赖 —— **已在干净树（`git stash`）上复现同一条**，为仓库预先存在，与本单无关

验收清单 `acceptance/capability-registry-v0.md` **全部条目未勾选**：registry 本体在 v0 尚未实现，本单只判协议形状。实现落地时每项须成为确定性自动测试。

哪条边界划错了直接指，我改。（同一维护者另一账号 cheqing0410，此处以 chaodeng060-source 发。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
