### PR TITLE
feat(isolation): B1+B3 creation and presence flow

### DIFF
--- a/acceptance/intentional-isolation.md
+++ b/acceptance/intentional-isolation.md
@@ -1,0 +1,23 @@
+# 验收清单：有意的隔离第一刀（B1＋B3）
+
+对应 issue #108 与总单 #66。B5 的重开语义仍等主笔拍 Q2，本页不施工、
+不点亮 B5。判卷从生产模块的公开 `IntentionalIsolation.create` 进入，并用
+真实 `MessageTreeService.say` 走模型开工链；直接手拼 scope 或只调用 presence
+store 不算交卷。
+
+- [x] **IS-B1 可开可进**：从一扇现役来源 viewport 创建隔离 session；只有住户
+  身份存在、新 viewport 建立、住户级共享状态登记全部成功后才返回 `ready`。
+  来源窗无效、住户不存在、名称为空或登记失败均显式拒绝；登记失败不会留下可接收
+  用户输入的活窗。[单测＋宿主子进程集成]
+- [x] **IS-B3 存在可知、内容不通**：创建返回时共享状态已同步可见；创建发生在
+  另一扇 viewport 正在生成期间时不改变或打断该回合，只有下一次 dispatch 收到
+  只含名称、状态、scopeId 与来源的存在信封。信封不写进 user transcript，失败回合
+  不确认，下一轮重送；成功确认后不重复注入。[单测＋宿主子进程集成]
+
+## 未在本页声称
+
+- B5：scopeId 重开、scopeGeneration 与旧代回执拒收；Q2 未拍，保持未施工。
+- B1a 携带包、working folder 原子创建；属于第二刀。
+- B2 内容／文件／工具／进程隔离；本页只保证存在信封不夹带局部内容。
+- #79 的 window generation：本页不修改 SessionRegistry 的 windowId/generation
+  语义，也不拿它冒充 scopeGeneration。

--- a/src/isolation/index.ts
+++ b/src/isolation/index.ts
@@ -1,0 +1,1 @@
+export * from "./intentional-isolation.ts";

--- a/src/isolation/intentional-isolation.ts
+++ b/src/isolation/intentional-isolation.ts
@@ -1,0 +1,280 @@
+import { randomUUID } from "node:crypto";
+import type { TurnGate, TurnPass } from "../message-tree/service.ts";
+import type { ActiveWindow, SessionRegistry } from "../session/session-registry.ts";
+
+export const ISOLATION_CREATE_INVALID = "ISOLATION_CREATE_INVALID" as const;
+export const ISOLATION_CREATE_FAILED = "ISOLATION_CREATE_FAILED" as const;
+
+export class IsolationCreateError extends Error {
+  constructor(
+    readonly code: typeof ISOLATION_CREATE_INVALID | typeof ISOLATION_CREATE_FAILED,
+    message: string,
+  ) {
+    super(`${code}: ${message}`);
+    this.name = "IsolationCreateError";
+  }
+}
+
+/**
+ * 隔离 session 在住户共享状态里的公开投影。
+ *
+ * 这里只能装“它存在”所需的字段；局部上下文、消息、工具状态和产物都不属于
+ * 这张投影。将来增加字段时，B3 的内容不过界约束仍在这个类型边界上生效。
+ */
+export interface IsolationSessionPresence {
+  residentId: string;
+  scopeId: string;
+  name: string;
+  status: "ready";
+  source: {
+    scopeId: string;
+    windowId: string;
+  };
+  /** 当前隔离 session 的首扇 viewport；它不是 scope 的身份。 */
+  entryWindowId: string;
+  createdAt: string;
+}
+
+export interface ScopePresenceEnvelope {
+  kind: "scope_presence";
+  seq: number;
+  residentId: string;
+  scope: {
+    scopeId: string;
+    name: string;
+    status: "ready";
+    source: {
+      scopeId: string;
+      windowId: string;
+    };
+  };
+}
+
+/** 住户是否存在的最窄读取口；ResidentStore 直接满足这个接口。 */
+export interface ResidentDirectory {
+  has(residentId: string): boolean;
+}
+
+/**
+ * 住户级隔离登记与存在事件的单一写入口。
+ *
+ * create 必须把共享投影与存在事件一同提交，不能先露出一半。默认实现是内存
+ * 单写者；持久实现必须维持同一原子边界。
+ */
+export interface IsolationPresenceStore {
+  create(presence: IsolationSessionPresence): ScopePresenceEnvelope;
+  list(residentId: string): IsolationSessionPresence[];
+  eventsAfter(residentId: string, seq: number): ScopePresenceEnvelope[];
+}
+
+export class InMemoryIsolationPresenceStore implements IsolationPresenceStore {
+  readonly #scopes = new Map<string, Map<string, IsolationSessionPresence>>();
+  readonly #events = new Map<string, ScopePresenceEnvelope[]>();
+
+  create(presence: IsolationSessionPresence): ScopePresenceEnvelope {
+    const scopes = this.#scopes.get(presence.residentId) ?? new Map();
+    if (scopes.has(presence.scopeId)) {
+      throw new IsolationCreateError(
+        ISOLATION_CREATE_FAILED,
+        `scope already exists: ${presence.scopeId}`,
+      );
+    }
+    const events = this.#events.get(presence.residentId) ?? [];
+    const event: ScopePresenceEnvelope = {
+      kind: "scope_presence",
+      seq: events.length + 1,
+      residentId: presence.residentId,
+      scope: {
+        scopeId: presence.scopeId,
+        name: presence.name,
+        status: presence.status,
+        source: { ...presence.source },
+      },
+    };
+
+    // 两张 Map 的写入都不会调用外部代码；先构造完整对象，再连续提交。
+    // 持久实现若不能给出同样的原子性，不得冒充这个接口的实现。
+    scopes.set(presence.scopeId, clonePresence(presence));
+    this.#scopes.set(presence.residentId, scopes);
+    this.#events.set(presence.residentId, [...events, cloneEnvelope(event)]);
+    return cloneEnvelope(event);
+  }
+
+  list(residentId: string): IsolationSessionPresence[] {
+    return [...(this.#scopes.get(residentId)?.values() ?? [])].map(clonePresence);
+  }
+
+  eventsAfter(residentId: string, seq: number): ScopePresenceEnvelope[] {
+    if (!Number.isInteger(seq) || seq < 0) {
+      throw new Error(`presence sequence must be a non-negative integer: ${seq}`);
+    }
+    return (this.#events.get(residentId) ?? [])
+      .filter((event) => event.seq > seq)
+      .map(cloneEnvelope);
+  }
+}
+
+export interface CreateIsolationOptions<TContext> {
+  name: string;
+  context: TContext;
+}
+
+export interface IntentionalIsolationOptions {
+  presenceStore?: IsolationPresenceStore;
+  scopeIdFactory?: () => string;
+  now?: () => string;
+}
+
+function clonePresence(presence: IsolationSessionPresence): IsolationSessionPresence {
+  return {
+    ...presence,
+    source: { ...presence.source },
+  };
+}
+
+function cloneEnvelope(envelope: ScopePresenceEnvelope): ScopePresenceEnvelope {
+  return {
+    ...envelope,
+    scope: {
+      ...envelope.scope,
+      source: { ...envelope.scope.source },
+    },
+  };
+}
+
+function renderEnvelope(envelope: ScopePresenceEnvelope): string {
+  return `[scope-presence] ${JSON.stringify(envelope)}`;
+}
+
+/**
+ * B1 + B3 的生产入口：从一扇现役 viewport 创建隔离 session，并把它的存在
+ * 投影给同住户的其他 viewport。
+ *
+ * scope 与 viewport 刻意分层：本类只签发 scopeId；SessionRegistry 继续只管
+ * windowId/generation。B5 的 scopeGeneration 尚待 Q2，不能在这里偷借 window
+ * generation 代替。
+ */
+export class IntentionalIsolation<TContext> implements TurnGate {
+  readonly #residents: ResidentDirectory;
+  readonly #sessions: SessionRegistry<TContext>;
+  readonly #presence: IsolationPresenceStore;
+  readonly #scopeIdFactory: () => string;
+  readonly #now: () => string;
+  /** 每扇 viewport 已确认读到的住户级存在事件序号。 */
+  readonly #ackedSeq = new Map<string, number>();
+
+  constructor(
+    residents: ResidentDirectory,
+    sessions: SessionRegistry<TContext>,
+    options: IntentionalIsolationOptions = {},
+  ) {
+    this.#residents = residents;
+    this.#sessions = sessions;
+    this.#presence = options.presenceStore ?? new InMemoryIsolationPresenceStore();
+    this.#scopeIdFactory = options.scopeIdFactory ?? (() => `scope_${randomUUID()}`);
+    this.#now = options.now ?? (() => new Date().toISOString());
+  }
+
+  /**
+   * 用户公开的“开隔离 session”动作。
+   *
+   * 返回前同时满足：来源窗仍在、住户存在、新 viewport 已建立、住户共享状态
+   * 已登记。登记失败时新 viewport 立即归档，调用方只得到显式失败，不会拿到一扇
+   * 看似 ready 的半成品窗。
+   */
+  create(
+    originWindowId: string,
+    options: CreateIsolationOptions<TContext>,
+  ): IsolationSessionPresence {
+    const origin = this.#sessions.get(originWindowId);
+    if (origin === undefined) {
+      throw new IsolationCreateError(
+        ISOLATION_CREATE_INVALID,
+        `origin window is not active: ${originWindowId}`,
+      );
+    }
+    if (!this.#residents.has(origin.residentId)) {
+      throw new IsolationCreateError(
+        ISOLATION_CREATE_INVALID,
+        `resident does not exist: ${origin.residentId}`,
+      );
+    }
+    const name = options.name.trim();
+    if (name.length === 0) {
+      throw new IsolationCreateError(ISOLATION_CREATE_INVALID, "name must not be empty");
+    }
+    const scopeId = this.#scopeIdFactory();
+    if (scopeId.length === 0) {
+      throw new IsolationCreateError(ISOLATION_CREATE_FAILED, "scope id factory returned empty id");
+    }
+
+    let window: ActiveWindow<TContext> | undefined;
+    try {
+      window = this.#sessions.open(origin.residentId, {
+        scopeId,
+        context: options.context,
+      });
+      const presence: IsolationSessionPresence = {
+        residentId: origin.residentId,
+        scopeId,
+        name,
+        status: "ready",
+        source: {
+          scopeId: origin.scopeId,
+          windowId: origin.windowId,
+        },
+        entryWindowId: window.windowId,
+        createdAt: this.#now(),
+      };
+      this.#presence.create(presence);
+      return clonePresence(presence);
+    } catch (error) {
+      if (window !== undefined) this.#sessions.kill(window.windowId);
+      if (error instanceof IsolationCreateError) throw error;
+      throw new IsolationCreateError(
+        ISOLATION_CREATE_FAILED,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  /** 用户界面的同步共享状态投影；返回副本，调用方不能反写权威状态。 */
+  sharedState(residentId: string): IsolationSessionPresence[] {
+    if (!this.#residents.has(residentId)) {
+      throw new IsolationCreateError(
+        ISOLATION_CREATE_INVALID,
+        `resident does not exist: ${residentId}`,
+      );
+    }
+    return this.#presence.list(residentId);
+  }
+
+  /**
+   * 模型侧的异步存在信封：只在下一次 dispatch 开始时读取，当前正在生成的回合
+   * 不会被中断。commit 只确认本次实际送进模型的最高序号；途中新增事件留给下轮。
+   */
+  beforeTurn(residentId: string, windowId: string): TurnPass {
+    const window = this.#sessions.get(windowId);
+    if (window === undefined || window.residentId !== residentId) {
+      throw new IsolationCreateError(
+        ISOLATION_CREATE_INVALID,
+        `window is not active for resident: ${residentId}/${windowId}`,
+      );
+    }
+    const acked = this.#ackedSeq.get(windowId) ?? 0;
+    // 创建出来的隔离 session 不需要收到一封“你自己刚被创建”的通知；B3 的
+    // 模型信封只发给同住户的其他 session。同 scope 的其他 viewport 也共享
+    // 这份存在，不必互相广播自己。
+    const pending = this.#presence
+      .eventsAfter(residentId, acked)
+      .filter((event) => event.scope.scopeId !== window.scopeId);
+    const deliveredThrough = pending.at(-1)?.seq ?? acked;
+    return {
+      contextPrefix: pending.map(renderEnvelope),
+      commit: () => {
+        const current = this.#ackedSeq.get(windowId) ?? 0;
+        if (deliveredThrough > current) this.#ackedSeq.set(windowId, deliveredThrough);
+      },
+    };
+  }
+}

--- a/tests/fixtures/intentional-isolation-host.ts
+++ b/tests/fixtures/intentional-isolation-host.ts
@@ -1,0 +1,84 @@
+import { IntentionalIsolation } from "../../src/isolation/intentional-isolation.ts";
+import { MessageTreeService } from "../../src/message-tree/service.ts";
+import { MessageTreeStore } from "../../src/message-tree/store.ts";
+import { SessionRegistry } from "../../src/session/session-registry.ts";
+import { ResidentStore } from "../../src/store/resident-store.ts";
+
+const residents = new ResidentStore();
+const residentId = residents.createResident("host-resident");
+const sessions = new SessionRegistry<null>();
+const origin = sessions.open(residentId, { scopeId: "private", context: null });
+const tree = new MessageTreeStore();
+tree.createRoom(residentId);
+const prompts: string[] = [];
+const isolation = new IntentionalIsolation(residents, sessions);
+let isolatedWindowId: string | undefined;
+const messages = new MessageTreeService(tree, sessions, {
+  turnGate: isolation,
+  assistantReply: (_residentId, prompt) => {
+    prompts.push(prompt);
+    return "host reply";
+  },
+});
+
+type Command = {
+  requestId: string;
+  op: "create" | "sharedState" | "say" | "sayIsolated" | "history" | "prompts" | "stop";
+  name?: string;
+  message?: string;
+};
+
+async function execute(command: Command): Promise<unknown> {
+  switch (command.op) {
+    case "create": {
+      const created = isolation.create(origin.windowId, {
+        name: command.name ?? "",
+        context: null,
+      });
+      isolatedWindowId = created.entryWindowId;
+      return created;
+    }
+    case "sharedState":
+      return isolation.sharedState(residentId);
+    case "say":
+      return messages.say(residentId, command.message ?? "", origin.windowId);
+    case "sayIsolated":
+      if (isolatedWindowId === undefined) throw new Error("isolation session has not been created");
+      return messages.say(residentId, command.message ?? "", isolatedWindowId);
+    case "history":
+      return tree.history(residentId);
+    case "prompts":
+      return [...prompts];
+    case "stop":
+      return null;
+  }
+}
+
+process.on("message", async (raw) => {
+  const command = raw as Command;
+  try {
+    const value = await execute(command);
+    process.send?.({ requestId: command.requestId, ok: true, value });
+    if (command.op === "stop") setImmediate(() => process.exit(0));
+  } catch (error) {
+    process.send?.({
+      requestId: command.requestId,
+      ok: false,
+      error: {
+        name: error instanceof Error ? error.name : "Error",
+        message: error instanceof Error ? error.message : String(error),
+        code:
+          typeof error === "object" && error !== null && "code" in error
+            ? String(error.code)
+            : undefined,
+      },
+    });
+  }
+});
+
+process.send?.({
+  type: "ready",
+  pid: process.pid,
+  residentId,
+  originWindowId: origin.windowId,
+});

--- a/tests/intentional-isolation-host.test.ts
+++ b/tests/intentional-isolation-host.test.ts
@@ -1,0 +1,142 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+type Reply = {
+  requestId?: string;
+  type?: string;
+  ok?: boolean;
+  value?: unknown;
+  error?: { name?: string; message?: string; code?: string };
+};
+
+const fixture = new URL("./fixtures/intentional-isolation-host.ts", import.meta.url);
+const children: ChildProcess[] = [];
+
+function startHost(): ChildProcess {
+  const child = spawn(process.execPath, ["--import", "tsx", fileURLToPath(fixture)], {
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.push(child);
+  return child;
+}
+
+function waitForReady(child: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let stderr = "";
+    const timer = setTimeout(() => reject(new Error(`host startup timed out: ${stderr}`)), 10_000);
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    }
+    function onMessage(message: Reply) {
+      if (message.type !== "ready") return;
+      cleanup();
+      resolve();
+    }
+    function onExit(code: number | null) {
+      cleanup();
+      reject(new Error(`host exited ${String(code)} before ready: ${stderr}`));
+    }
+  });
+}
+
+let requestSeq = 0;
+function callHost<T>(child: ChildProcess, command: Record<string, unknown>): Promise<T> {
+  requestSeq += 1;
+  const requestId = `request-${requestSeq}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`host request timed out: ${requestId}`)),
+      5_000,
+    );
+    child.on("message", onMessage);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+    }
+    function onMessage(message: Reply) {
+      if (message.requestId !== requestId) return;
+      cleanup();
+      if (message.ok === true) {
+        resolve(message.value as T);
+      } else {
+        reject(
+          new Error(`${message.error?.code ?? message.error?.name}: ${message.error?.message}`),
+        );
+      }
+    }
+    child.send?.({ ...command, requestId }, (error) => {
+      if (error === null) return;
+      cleanup();
+      reject(error);
+    });
+  });
+}
+
+async function stopHost(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  await callHost(child, { op: "stop" });
+  await exited;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    children.splice(0).map(async (child) => {
+      try {
+        await stopHost(child);
+      } catch {
+        child.kill();
+      }
+    }),
+  );
+});
+
+describe("intentional isolation public host path", () => {
+  it("公开 create 后共享状态立即可见，下一次 say 才注入存在且不污染 transcript", async () => {
+    const child = startHost();
+    await waitForReady(child);
+
+    const created = await callHost<{
+      scopeId: string;
+      name: string;
+      status: string;
+    }>(child, { op: "create", name: "public-path-project" });
+    expect(created).toMatchObject({ name: "public-path-project", status: "ready" });
+
+    const shared = await callHost<Array<{ scopeId: string }>>(child, { op: "sharedState" });
+    expect(shared.map((scope) => scope.scopeId)).toEqual([created.scopeId]);
+
+    await callHost(child, { op: "sayIsolated", message: "work inside isolation" });
+    const isolatedPrompt = await callHost<string[]>(child, { op: "prompts" });
+    expect(isolatedPrompt).toEqual(["work inside isolation"]);
+
+    await callHost(child, { op: "say", message: "first public input" });
+    const prompts = await callHost<string[]>(child, { op: "prompts" });
+    expect(prompts[1]).toContain("[scope-presence]");
+    expect(prompts[1]).toContain(created.scopeId);
+    expect(prompts[1]).toContain("first public input");
+
+    const history = await callHost<Array<{ role: string; content: string }>>(child, {
+      op: "history",
+    });
+    expect(
+      history.some((node) => node.role === "user" && node.content === "first public input"),
+    ).toBe(true);
+    expect(history.some((node) => node.content.includes("[scope-presence]"))).toBe(false);
+
+    await callHost(child, { op: "say", message: "second public input" });
+    const afterAck = await callHost<string[]>(child, { op: "prompts" });
+    expect(afterAck[2]).toBe("second public input");
+  });
+});

--- a/tests/intentional-isolation.test.ts
+++ b/tests/intentional-isolation.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  InMemoryIsolationPresenceStore,
+  IntentionalIsolation,
+  IsolationCreateError,
+  type IsolationPresenceStore,
+} from "../src/isolation/intentional-isolation.ts";
+import { MessageTreeService } from "../src/message-tree/service.ts";
+import { MessageTreeStore } from "../src/message-tree/store.ts";
+import { SessionRegistry } from "../src/session/session-registry.ts";
+import { ResidentStore } from "../src/store/resident-store.ts";
+
+function fixture(options: { presenceStore?: IsolationPresenceStore } = {}) {
+  const residents = new ResidentStore();
+  const residentId = residents.createResident("resident-a");
+  const sessions = new SessionRegistry<null>();
+  const origin = sessions.open(residentId, {
+    scopeId: "private",
+    context: null,
+  });
+  const isolation = new IntentionalIsolation(residents, sessions, {
+    scopeIdFactory: () => "scope_project",
+    now: () => "2026-08-24T01:30:00.000Z",
+    ...(options.presenceStore === undefined ? {} : { presenceStore: options.presenceStore }),
+  });
+  return { residents, residentId, sessions, origin, isolation };
+}
+
+describe("IntentionalIsolation B1", () => {
+  it("从现役来源窗创建，住户身份继承且登记完成后即可在隔离窗工作", async () => {
+    const { residentId, sessions, origin, isolation } = fixture();
+
+    const created = isolation.create(origin.windowId, {
+      name: "Kafka reading",
+      context: null,
+    });
+
+    expect(created).toEqual({
+      residentId,
+      scopeId: "scope_project",
+      name: "Kafka reading",
+      status: "ready",
+      source: { scopeId: "private", windowId: origin.windowId },
+      entryWindowId: created.entryWindowId,
+      createdAt: "2026-08-24T01:30:00.000Z",
+    });
+    expect(sessions.get(created.entryWindowId)).toMatchObject({
+      residentId,
+      scopeId: "scope_project",
+      generation: 1,
+    });
+    expect(isolation.sharedState(residentId)).toEqual([created]);
+
+    const tree = new MessageTreeStore();
+    tree.createRoom(residentId);
+    const prompts: string[] = [];
+    const service = new MessageTreeService(tree, sessions, {
+      turnGate: isolation,
+      assistantReply: (_residentId, prompt) => {
+        prompts.push(prompt);
+        return "working";
+      },
+    });
+    await service.say(residentId, "first isolated input", created.entryWindowId);
+    expect(prompts).toEqual(["first isolated input"]);
+  });
+
+  it("来源窗无效、住户不存在或名称为空都在开新窗前显式拒绝", () => {
+    const { residents, residentId, sessions, origin, isolation } = fixture();
+    sessions.kill(origin.windowId);
+
+    expect(() => isolation.create(origin.windowId, { name: "x", context: null })).toThrow(
+      /origin window is not active/,
+    );
+    expect(sessions.windowsOf(residentId)).toHaveLength(0);
+
+    const foreignSessions = new SessionRegistry<null>();
+    const orphan = foreignSessions.open("missing-resident", { context: null });
+    const foreign = new IntentionalIsolation(residents, foreignSessions);
+    expect(() => foreign.create(orphan.windowId, { name: "x", context: null })).toThrow(
+      /resident does not exist/,
+    );
+
+    const live = sessions.open(residentId, { context: null });
+    expect(() => isolation.create(live.windowId, { name: "   ", context: null })).toThrow(
+      /name must not be empty/,
+    );
+    expect(sessions.windowsOf(residentId)).toHaveLength(1);
+  });
+
+  it("住户级登记失败时不返回假成功，新窗被归档且共享投影为空", () => {
+    const underlying = new InMemoryIsolationPresenceStore();
+    const failing: IsolationPresenceStore = {
+      create() {
+        throw new Error("resident projection unavailable");
+      },
+      list: (residentId) => underlying.list(residentId),
+      eventsAfter: (residentId, seq) => underlying.eventsAfter(residentId, seq),
+    };
+    const { residentId, sessions, origin, isolation } = fixture({ presenceStore: failing });
+
+    let error: unknown;
+    try {
+      isolation.create(origin.windowId, { name: "will fail", context: null });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(IsolationCreateError);
+    expect(String(error)).toContain("ISOLATION_CREATE_FAILED");
+    expect(isolation.sharedState(residentId)).toEqual([]);
+    expect(sessions.windowsOf(residentId)).toEqual([origin]);
+  });
+});
+
+describe("IntentionalIsolation B3", () => {
+  it("共享状态同步可见；当前生成不被打断，下一次 dispatch 才收存在信封", async () => {
+    const { residentId, sessions, origin, isolation } = fixture();
+    const tree = new MessageTreeStore();
+    tree.createRoom(residentId);
+
+    let release: (() => void) | undefined;
+    const firstReplyCanFinish = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const prompts: string[] = [];
+    let call = 0;
+    const service = new MessageTreeService(tree, sessions, {
+      turnGate: isolation,
+      assistantReply: async (_residentId, prompt) => {
+        prompts.push(prompt);
+        call += 1;
+        if (call === 1) await firstReplyCanFinish;
+        return `reply-${call}`;
+      },
+    });
+
+    const inFlight = service.say(residentId, "already running", origin.windowId);
+    await viWaitFor(() => prompts.length === 1);
+
+    const created = isolation.create(origin.windowId, {
+      name: "isolated work",
+      context: null,
+    });
+    expect(isolation.sharedState(residentId)).toHaveLength(1);
+    expect(sessions.get(origin.windowId)?.generation).toBe(1);
+    expect(prompts[0]).toBe("already running");
+
+    release?.();
+    await inFlight;
+    await service.say(residentId, "next dispatch", origin.windowId);
+
+    expect(prompts[1]).toContain("[scope-presence]");
+    expect(prompts[1]).toContain(created.scopeId);
+    expect(prompts[1]).not.toContain("already running");
+    const history = tree.history(residentId);
+    expect(
+      history.find((node) => node.role === "user" && node.content === "next dispatch"),
+    ).toBeTruthy();
+    expect(history.some((node) => node.content.includes("[scope-presence]"))).toBe(false);
+
+    await service.say(residentId, "after ack", origin.windowId);
+    expect(prompts[2]).toBe("after ack");
+  });
+
+  it("信封只带存在与来源，不带隔离 context；失败回合不确认，下一轮重送", async () => {
+    const { residentId, sessions, origin, isolation } = fixture();
+    isolation.create(origin.windowId, {
+      name: "private project",
+      context: null,
+    });
+    const first = isolation.beforeTurn(residentId, origin.windowId);
+
+    expect(first.contextPrefix).toHaveLength(1);
+    const raw = first.contextPrefix[0] ?? "";
+    expect(raw).toContain("scope_project");
+    expect(raw).toContain("private project");
+    expect(raw).not.toContain('"context"');
+    expect(raw).not.toContain('"entryWindowId"');
+
+    const retry = isolation.beforeTurn(residentId, origin.windowId);
+    expect(retry.contextPrefix).toEqual(first.contextPrefix);
+    retry.commit();
+    expect(isolation.beforeTurn(residentId, origin.windowId).contextPrefix).toEqual([]);
+  });
+});
+
+async function viWaitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("condition timed out");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}


### PR DESCRIPTION
Closes the currently released B1 + B3 slice of #108.

What changed:
- add a public intentional-isolation creation service that returns ready only after resident validation, viewport creation, and resident-level presence registration
- expose synchronous shared-state presence plus next-dispatch, existence-only model envelopes
- keep presence envelopes out of the user transcript, retry them after failed turns, and avoid self-notifying the newly created scope
- add unit coverage and a child-process public-host integration path

Explicit boundary:
- B5 remains unimplemented pending Q2
- no scopeGeneration, reopen, or stale scope-receipt semantics
- no B1a carry pack, B2 content/process isolation, #79 generation changes, or #82 protocol changes

Validation:
- targeted: 6/6
- full Vitest: 400 passed, 38 existing todo/skipped
- npm run lint: pass
- npm run typecheck: pass
- npm run acceptance:strict: 6/6 real green

— Elio