### PR TITLE
docs(registry): 落主笔 2026-08-22 裁定——exposed 归 projection / selected 归 dispatch，v0 六格收敛（#100）

### DIFF
--- a/acceptance/capability-registry-v0.md
+++ b/acceptance/capability-registry-v0.md
@@ -79,7 +79,14 @@
 - [ ] **[CR0-F02](../docs/design/capability-registry-v0.md#capability-registry-v0-s4) registry 不得自产 ready**：registry 的对外接口中不存在
   任何返回 `ready` 的路径；以接口层断言证明（缺省即证明，另配一条「若新增则红灯」的检查）。
 
-## 未决（等主笔裁，见图纸 §2.1）
+## 已定：`exposed` / `selected` 的归属（主笔 2026-08-22 裁，见图纸 §2.1）
 
-`exposed` 与 `selected` 两态在 #100 / #101 两卡均未收，本清单**暂不为其立条目**。
-裁定归属后再补，不先占位——占位本身会变成第二张说自己是真相的表。
+`exposed` 与 `selected` **均不收**进能力登记 v0，本清单**不为其立条目**：
+
+- `exposed` 归 **projection** 层，可有损可裁剪；验收要求落在投影侧——
+  投影必须标注「这不是全库」与省略原因，**不在本清单范围内**。
+- `selected` 归 **dispatch** 路径，是一次调用的瞬时选择，不是登记事实，
+  由多 viewport / dispatch 侧安置，**不在本清单范围内**。
+
+v0 六格就此收敛为 `definition` / `installed` / `registered` / `binding` /
+`authorization` / `superseded`，本清单条目仅覆盖这六格。

--- a/docs/design/capability-registry-v0.md
+++ b/docs/design/capability-registry-v0.md
@@ -56,7 +56,7 @@
    registered + bound + authorized + current，仍然只说明账面齐全，说明不了住户敲得开门。
    为什么，见 [§4](#capability-registry-v0-s4)。
 
-### 2.1 卡面六态与露娜八态的差集（提请主笔裁）
+### 2.1 卡面六态与露娜八态的差集（主笔已裁，2026-08-22）
 
 #100 卡面列了六态；露娜在 #35 第 5 节的最小验收矩阵第 1 条列的是八项：
 `definition、installed、registered、bound、authorized、ready、exposed、selected`。差集需要显式处置，
@@ -66,14 +66,17 @@
 - `superseded` —— 卡面有、露娜第 5 节未列，但其第 4 节明确要求
   `unhealthy / deprecated / superseded / removed` 不得压成同一个 `inactive`。本图纸收，
   作为独立格（见 [§5](#capability-registry-v0-s5)）。
-- `exposed`、`selected` —— **两卡都没收，是真空。** 本图纸的建议：
-  - `exposed`（能力在某 scope 的目录里对住户可见）属于 **projection**，不是 canonical 登记态。
-    它可以有损、可以被裁剪，按露娜四分法不得反写 registry；建议**不收进本图纸的格子**，
-    但要求投影侧标注「这不是全库」与省略原因。
+- `exposed`、`selected` —— **两卡都没收，是真空。** 主笔 2026-08-22 裁定：两者**均不收**进
+  能力登记 v0 的格子，按本图纸原建议落地。
+  - `exposed`（能力在某 scope 的目录里对住户可见）归 **projection** 层，不是 canonical 登记态。
+    它可以有损、可以被裁剪，按露娜四分法不得反写 registry；**不收进本图纸的格子**，
+    但投影侧**必须**标注「这不是全库」与省略原因。
   - `selected`（dispatch 时选中了哪条 lane 绑定）是**一次调用的瞬时选择**，不是能力的登记事实，
-    属于 dispatch 路径；建议**不收**，另由多 viewport / dispatch 侧安置。
+    归 **dispatch** 路径；**不收**，另由多 viewport / dispatch 侧安置。
 
-  两条都请主笔裁；在裁定之前，本图纸不为它们预留格子，以免又长出一张说自己是真相的表。
+  **据此 v0 六格收敛为**：`definition` / `installed` / `registered` / `binding` /
+  `authorization` / `superseded`。本图纸不为 `exposed` / `selected` 预留格子，
+  以免又长出一张说自己是真相的表。
 
 <a id="capability-registry-v0-s3"></a>
 ## 3. `binding` 不是单值——两类账，互不推导
@@ -155,8 +158,8 @@ v0 若不分开立词条，后面一定有人拿记忆勘误链的语义去读�
 ## 7. v0 不做什么
 
 不定 schema、不选存储后端、不碰后台调度、不实现 registry 本体、不扩 readiness 语义、
-不为 `exposed` / `selected` 预留格子（等主笔裁 §2.1）。边界与验收收敛、主笔点头之后，
-再开只做一件事的实现 PR。
+不为 `exposed` / `selected` 预留格子（主笔 2026-08-22 已裁不收，见 §2.1）。
+边界与验收已收敛、主笔已点头，可以开只做一件事的实现 PR。
 
 ### 代价
 


### PR DESCRIPTION
落主笔 2026-08-22 在 #100 楼内的裁定，把 #107 图纸与验收清单里两处「等裁」改写为已定结论。

## 裁定内容（主笔原话）

> `exposed` 与 `selected` **不收**进能力登记 v0 的格子。
> - `exposed` 归 projection 层，可有损可裁剪，但投影侧必须标注「这不是全库」与省略原因；
> - `selected` 是一次调用的瞬时选择，归 dispatch 路径，另由多 viewport / dispatch 侧安置。

## 改了什么

**`docs/design/capability-registry-v0.md`**
- §2.1 标题：`（提请主笔裁）` → `（主笔已裁，2026-08-22）`
- §2.1 正文：把两条「建议…请主笔裁」改写为裁定结论，并写明 v0 六格收敛为
  `definition` / `installed` / `registered` / `binding` / `authorization` / `superseded`
- §7：`（等主笔裁 §2.1）` → `（主笔 2026-08-22 已裁不收，见 §2.1）`；
  末句由「主笔点头之后再开实现 PR」改为「已点头，可以开」

**`acceptance/capability-registry-v0.md`**
- 「未决（等主笔裁）」一节改写为「已定：`exposed` / `selected` 的归属」，
  写明两者各自归属与**不在本清单范围内**的理由，并声明本清单条目仅覆盖六格

## 范围

纯文档收尾，无 schema、无实现、无验收条目增删。六格本身与既有条目一字未动。
