### PR TITLE
feat(session): align Mist wire with multi-viewport windows

### DIFF
--- a/docs/design/session-api.md
+++ b/docs/design/session-api.md
@@ -1,50 +1,53 @@
 # 会话 API（session API）· 给 external 前端的接入说明
 
-状态：v0.2（refs #58 第 3 条）。会话模型已由 #69 定案为 D7 多活窗（#70 落账），本页据此改写；**但 `SessionRegistry` 的实现仍是一住户一活会话**，两者的差距在 §1.1 写清，前端现在只能依赖已实现的那一套。本页分两半：**上半是本仓已经存在的会话语义**，来自 `src/session/session-registry.ts`，任何前端都必须遵守；**下半是线协议**（HTTP/WS 端点、鉴权、信封），真源目前在 #49 官方素皮仓的 `docs/research/mist-wire-contract.md`，等它上游或链接进来之前，这里只放占位，不另造第二份。
+状态：v0.3（refs #58 第 3 条、#82）。会话模型与线协议三端点已经按 D7 多活窗对齐；`SessionRegistry` 的窗口语义在 §1，`session.list / session.create / session.history` 的窗口映射唯一以 §1.1 为准。HTTP/WS 信封、鉴权与下行流的真源是本仓 `webui/docs/research/mist-wire-contract.md`；frontend 插件当前仍固定使用 mock，真实 handler 的交付通道延期至插件协议 v0.1，不在本页冒充已经接通。
 
 ## 0. 一句话
 
-mist 不替前端保管任何东西。前端连的是"住户当前这一次活会话"，会话可以被结束、重开、换代；住户的记忆、消息树、关系记录都在别处，会话没了它们还在。
+mist 不替前端保管任何东西。线协议里的一个 session 对应一扇 viewport；同一住户可以同时有多扇活窗，各窗可以归档、重开和换代，住户的记忆、消息树、关系记录仍在窗外。
 
 ## 1. 本仓已定的会话语义（`SessionRegistry`）
 
 | 概念 | 含义 | 前端要做的事 |
 |---|---|---|
-| `residentId` | 住户 id。**产品模型（D7）是一位住户可同时有多扇活窗；当前实现仍是同一时刻最多一个活会话**，见 §1.1 | 一切请求都带它 |
-| `generation` | 活会话的代际号。`kill` 后再 `open` 必换代 | 记住当前代际；收到不同代际的结果一律丢弃 |
-| `headId` | 活会话当前指向的消息节点（不是消息树本身） | 只读它定位"现在在哪"，别拿它当历史 |
+| `residentId` | 住户 id；一位住户可同时有多扇活窗 | 由 Mist handler 绑定，不进入 webui session 线协议 |
+| `scopeId` | 可见性／隔离边界，不是窗；缺省只能落私聊 | 创建窗时可显式给出，不从 workspace 或 lane 猜 |
+| `windowId` / 线协议 `sessionId` | 同一扇窗的同一个宿主签发标识（`w_` + ULID） | 当作会话句柄；不得由客户端预分配 |
+| `generation` | 窗内代际号；换气只令它加一，`windowId` 不变 | 与 `sessionId` 一起过滤迟到结果 |
+| `headId` | 窗当前指向的消息节点（不是消息树本身） | 只读它定位“现在在哪”，别拿它当历史 |
 | `context` | 尚未落入持久存储的在途上下文 | 不要缓存它、不要当真源 |
-| `DispatchReceipt {residentId, generation, dispatchId}` | 每次派发都发一张回执 | 用它把异步结果对回请求；`generation` 不等于当前会话就是迟到结果 |
-| `kill(residentId)` | 幂等结束活会话 | 结束后本地状态清零；重开要拿新 `generation` |
+| `DispatchReceipt {residentId, windowId, generation, dispatchId}` | 每次派发都发一张回执 | 三元归属缺一不认；不要把一窗的结果拼进另一窗 |
+| `kill(windowId)` / `killResident(residentId)` | 前者幂等归档一窗，后者归档住户全部活窗 | 归档窗只读；不要把关窗解释成删除住户或历史 |
 
 三条前端必须遵守的规矩：
 
-1. **迟到结果不进当前会话。** `belongsToActiveSession(receipt)` 只认代际相同的回执。前端若自己做重连/重放，也要按同一规则过滤，不能把上一代的流水拼进这一代。
-2. **会话不是记忆。** 删掉一格活会话只能让一次对话结束，不能删除住户留下的任何东西；前端不要在会话结束时清用户可见的历史，历史另有来源。
-3. **`open` 是显式动作，也不是幂等动作。** 没有隐式复活：`kill` 之后必须再 `open` 才有新会话，前端界面上要能区分"会话结束"和"住户不在"。反过来，对已有活会话再次 `open` 会**原地换代覆盖**（`generation+1`，旧会话不经 `kill` 直接失效，其在途回执按规矩 1 全部作废）——源码 `SessionRegistry.open()` 不检查是否已有活会话。前端不要把 `open` 当"确保有会话"来重复调用；要"有则复用"，先 `get`/`isActive`，只在没有活会话时才 `open`。
+1. **迟到结果不进当前窗。** `belongsToActiveWindow(receipt)` 同时核对 `residentId / windowId / generation`；前端若自己做重连或重放，也不能只看 resident 或 generation。
+2. **窗不是记忆。** 归档一扇窗不能删除住户留下的任何东西；窗流水是 control/evidence plane 的只读证据，不是第二条用户权威历史。
+3. **`open` 每次新开一扇窗。** 同一住户、同一 scope 连续调用两次得到两个不同的宿主签发 `windowId`，各自从 generation 1 开始；同窗换代由换气流程负责，不再用重复 `open` 原地覆盖。
 
-### 1.1 产品模型已定 D7，实现尚未跟上——前端现在该按哪一套写
+### 1.1 D7 多活窗的线协议映射
 
 2026-08-19 主笔拍板（#69 → #70）：会话模型定 **多活窗**——一位住户可以同时有多扇活窗，各自代际，关窗归档；不做 ChatGPT 式历史会话栏，关掉的窗沉成只读日志／导出证据。同批口径：**窗是同一条权威生命线的视图，隔离单位是 scope 不是窗**（见 #66）。
 
-但本仓 `SessionRegistry` 现在仍是 `Map<residentId, ActiveSession>`——**一住户一活会话，`open` 原地换代覆盖**。也就是说：产品模型往前走了一步，实现还没动。
+本仓 `SessionRegistry` 已按 `windowId` 持有多扇活窗与归档窗；线协议保留 session 这个既有名字，不再另造 viewport 端点。映射固定如下：
 
-**给 external 前端的结论，分两句写清，不要混：**
+- `session.list`：列出当前 handler 所绑定住户的活窗与归档窗。`sessionId` 就是 `windowId`；每行同时给出 `scopeId`、当前或最终 `generation` 与 `archived`。住户 id 不进入返回体。
+- `session.create`：调用 `open(residentId, scopeId)`；`residentId` 来自 handler 绑定，`scopeId` 可省略并落私聊。返回宿主签发的 `sessionId=windowId` 与 generation；客户端预分配 sessionId 被拒绝。共享 schema 中没有明确窗模型映射的 `workspaceId / cwd / agentPreset` 也在 Mist adapter 边界显式返回 `bad-request`，不静默猜测。
+- `session.history`：以 `sessionId=windowId` 读取该窗的只读流水；活窗和归档窗走同一读口，读取不得复活或改写窗。具体流水字节由只读 history port 提供，窗口注册表只负责身份、代际与归档状态。
 
-1. **现在可以依赖的**：上表那六条语义（含规矩 1–3）来自已合入的实现，照它写不会错。特别是「`open` 不是幂等的、对已有活会话再次 `open` 会原地换代覆盖」这条，在多活窗落地之前一直成立——**先 `get`/`isActive`，只在没有活会话时才 `open`**。
-2. **将来会变的**：多活窗落地后，`residentId` 不再唯一定位一扇活窗，回执与代际的归属会从「住户级」下沉到「窗级」。**所以前端不要把 `residentId` 当作会话句柄用**——现在就把「哪一扇窗」作为一个独立的标识位留出来，哪怕当前只能填一个值。这条是本页给前端最实的一条建议：它让你在实现跟上时不用重写状态层。
+这三个端点属于 control/evidence 能力面，“协议可接线”不自动等于 “P1-conformant”。P1-conformant 用户面只有一条 canonical user-visible stream：可以进入仍有行动意义的活工作区，但不把 `session.list` 渲染成永久聊天列表，也不把归档窗的 `session.history` 变成第二本权威 transcript；关闭后主流只留 typed closure/result 与权威证据指针（#84 定案）。
 
-**本页与实现的同步规则**：本页描述已实现的语义；D7 只写进 §1.1 这一段作为「将要变成什么」。**实现改了之后必须回来改这一页**——文档跑在实现前面，会让读它的人拿着一份从未为真的世界观写代码。
+**代价**：列表需要同时读活窗与归档窗；history 必须由窗流水的权威存储提供只读端口，不能拿 `residentId` 级整棵消息树冒充某一窗的流水。真实 handler 如何交到 frontend 插件仍待协议 v0.1，本次映射不改变 mock 默认边界。
 
-## 2. 线协议（端点 / 鉴权 / 信封）—— 待上游
+## 2. 线协议（端点 / 鉴权 / 信封）
 
-真源：`chez-nous-home/mist-webui` → `docs/research/mist-wire-contract.md`（线协议契约 v0，含信封协议、双下行流、seq/断线语义、token 门与部署形状）。
+HTTP/WS 信封、双下行流、seq/断线语义、token 门与部署形状的真源是本仓 `webui/docs/research/mist-wire-contract.md`；三个 session 端点的窗口语义真源是 §1.1，该文档的 P0 表只作线侧摘要，不另立映射口径。
 
-本节在该文件上游进本仓（或本仓放带版本号的链接桩）之前保持空白，避免两处各写一份互相漂移。**D7 定案解锁的是「写哪一套」而不是「线协议本身」**：webui P0 的 `session.list / session.create / session.history` 与多活窗模型方向一致，等契约上游后本节按它写，`SessionRegistry` 那套单活会话语义届时降为 §1.1 的历史说明。落地后本节应至少包含：
+本页不复抄完整信封。external 前端接线时至少要同时核对：
 
-- 端点清单（会话 open/kill、消息派发、下行流）与它们对应到 §1 哪个语义；
+- 端点清单（会话 open/kill、消息派发、下行流）与它们对应到 §1 哪个语义；其中三端点映射以 §1.1 为准；
 - 鉴权：token 从哪来、放哪（header / query / cookie）、loopback 是否豁免（#49 已定：**默认强制开启，loopback 也不豁免**）；
-- 最小示例：一次 open → 一次派发 → 收到带 `generation` 的回执 → 一条下行消息 → kill。
+- 最小示例：一次 create → 拿到 `sessionId=windowId` 与 generation → 一次派发 → 收到带 `windowId + generation` 的回执 → 一条下行消息 → kill。
 
 ## 3. 安装器里的入口
 

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -67,6 +67,10 @@ export interface ArchivedWindow {
   archived: true;
 }
 
+function cloneArchivedWindow(window: ArchivedWindow): ArchivedWindow {
+  return structuredClone(window);
+}
+
 export interface DispatchReceipt {
   residentId: string;
   windowId: string;
@@ -350,7 +354,8 @@ export class SessionRegistry<TContext> {
   }
 
   getArchived(windowId: string): ArchivedWindow | undefined {
-    return this.#archived.get(windowId);
+    const archived = this.#archived.get(windowId);
+    return archived === undefined ? undefined : cloneArchivedWindow(archived);
   }
 
   getHead(windowId: string): string | null {
@@ -368,6 +373,13 @@ export class SessionRegistry<TContext> {
   /** 一位住户此刻的全部活窗。多开合法，所以这里返回的是列表而不是一格。 */
   windowsOf(residentId: string): ActiveWindow<TContext>[] {
     return [...this.#active.values()].filter((window) => window.residentId === residentId);
+  }
+
+  /** 一位住户的全部归档窗。线协议列窗时与 windowsOf 合并，不复活任何窗。 */
+  archivedWindowsOf(residentId: string): ArchivedWindow[] {
+    return [...this.#archived.values()]
+      .filter((window) => window.residentId === residentId)
+      .map(cloneArchivedWindow);
   }
 
   hasLiveWindow(residentId: string): boolean {
@@ -412,7 +424,10 @@ export class SessionRegistry<TContext> {
   /** 幂等归档一扇窗。归档后只读，写入返 WINDOW_ARCHIVED（MV-A03）。 */
   kill(windowId: string): ArchivedWindow | undefined {
     const window = this.#active.get(windowId);
-    if (window === undefined) return this.#archived.get(windowId);
+    if (window === undefined) {
+      const archived = this.#archived.get(windowId);
+      return archived === undefined ? undefined : cloneArchivedWindow(archived);
+    }
     const archived: ArchivedWindow = {
       residentId: window.residentId,
       windowId: window.windowId,
@@ -425,7 +440,7 @@ export class SessionRegistry<TContext> {
     this.#appendArchive(archived);
     this.#active.delete(windowId);
     this.#archived.set(windowId, archived);
-    return archived;
+    return cloneArchivedWindow(archived);
   }
 
   /** 杀掉一位住户的全部活窗（MV-A03 后半）。 */

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -206,6 +206,64 @@ describe("SessionRegistry：多窗语义", () => {
     expect(sessions.get(w1.windowId)).toBeUndefined();
     expect(residentState).toEqual(before);
   });
+
+  it("按住户枚举归档窗，不混入活窗或其他住户", () => {
+    const sessions = new SessionRegistry<null>();
+    const archivedA = sessions.open("resident-a", { context: null });
+    const liveA = sessions.open("resident-a", { context: null });
+    const archivedB = sessions.open("resident-b", { context: null });
+
+    sessions.kill(archivedA.windowId);
+    sessions.kill(archivedB.windowId);
+
+    expect(sessions.archivedWindowsOf("resident-a")).toEqual([
+      expect.objectContaining({ residentId: "resident-a", windowId: archivedA.windowId }),
+    ]);
+    expect(sessions.archivedWindowsOf("resident-a")).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ windowId: liveA.windowId }),
+        expect.objectContaining({ windowId: archivedB.windowId }),
+      ]),
+    );
+  });
+
+  it("归档返回值是深副本，运行期变异不改权威记录或住户边界", () => {
+    const sessions = new SessionRegistry<null>();
+    const opened = sessions.open("resident-a", {
+      scopeId: "room-1",
+      headId: "node-1",
+      context: null,
+    });
+    const killed = sessions.kill(opened.windowId);
+    const fetched = sessions.getArchived(opened.windowId);
+    const listed = sessions.archivedWindowsOf("resident-a")[0];
+
+    expect(killed).toBeDefined();
+    expect(fetched).toBeDefined();
+    expect(listed).toBeDefined();
+    for (const snapshot of [killed, fetched, listed]) {
+      if (snapshot === undefined) throw new Error("expected archived snapshot");
+      Object.assign(snapshot, {
+        residentId: "resident-b",
+        scopeId: "room-mutated",
+        generation: 99,
+        headId: "node-mutated",
+      });
+    }
+
+    const expected = {
+      residentId: "resident-a",
+      windowId: opened.windowId,
+      scopeId: "room-1",
+      generation: 1,
+      headId: "node-1",
+      archived: true,
+    };
+    expect(sessions.getArchived(opened.windowId)).toEqual(expected);
+    expect(sessions.archivedWindowsOf("resident-a")).toEqual([expected]);
+    expect(sessions.archivedWindowsOf("resident-b")).toEqual([]);
+    expect(sessions.kill(opened.windowId)).toEqual(expected);
+  });
 });
 
 describe("SessionRegistry：贯穿场景（A01/A02/A03/B01/B02/B03 一口咬住）", () => {

--- a/webui/apps/dev-server/src/mist-session-wire-adapter.ts
+++ b/webui/apps/dev-server/src/mist-session-wire-adapter.ts
@@ -1,0 +1,277 @@
+import type {
+  HistoryEntry,
+  RpcError,
+  SessionProjectionsBlock,
+  SessionSummary,
+} from '@deepseek-ai/dsh-host-apiproxy/api'
+import {
+  sessionCreateRequestSchema,
+  sessionHistoryRequestSchema,
+  sessionListRequestSchema,
+} from '@deepseek-ai/dsh-host-apiproxy/api/sessions.schema'
+import { SessionId } from '@deepseek-ai/dsh-session/types'
+import type { z as zCore } from 'zod'
+import type { DownlinkFrame, MistHandler, UnaryResult } from './handler.ts'
+
+type ZodIssue = zCore.core.$ZodIssue
+
+/** Stable read description passed to the window-history owner. */
+export interface MistWindowHistoryRef {
+  residentId: string
+  windowId: string
+  headId: string | null
+  archived: boolean
+}
+
+/** Metadata needed by the existing session.list wire row. */
+export interface MistWindowHistorySummary {
+  updatedAt: number
+  running: boolean
+  blank: boolean
+}
+
+/** Read-only page returned by the window-history owner. */
+export interface MistWindowHistoryPage {
+  events: HistoryEntry[]
+  hasMore: boolean
+  projections?: SessionProjectionsBlock
+}
+
+/**
+ * The archive/history seam intentionally stays read-only. The multi-viewport
+ * registry owns window identity and lifecycle; the message/event store owns
+ * the bytes exposed by session.history.
+ */
+export interface MistWindowHistoryPort {
+  summarize(window: MistWindowHistoryRef): Promise<MistWindowHistorySummary>
+  read(
+    window: MistWindowHistoryRef,
+    page: { beforeSeq?: number; maxMessages?: number },
+  ): Promise<MistWindowHistoryPage>
+}
+
+/** Lifecycle fields needed by the session.* wire, independent of stored context. */
+export interface MistViewportSnapshot {
+  residentId: string
+  windowId: string
+  scopeId: string
+  generation: number
+  headId: string | null
+}
+
+/**
+ * Narrow structural view of the multi-viewport registry. Keeping this port in
+ * the adapter avoids making the vendored webui package depend on Mist's root
+ * source tree; production composition can pass SessionRegistry directly.
+ */
+export interface MistViewportRegistry<TContext> {
+  windowsOf(residentId: string): MistViewportSnapshot[]
+  archivedWindowsOf(residentId: string): MistViewportSnapshot[]
+  open(
+    residentId: string,
+    options: { scopeId?: string; context: TContext },
+  ): MistViewportSnapshot
+  get(windowId: string): MistViewportSnapshot | undefined
+  getArchived(windowId: string): MistViewportSnapshot | undefined
+}
+
+export interface MistSessionWireAdapterOptions<TContext> {
+  /** Resident bound to this handler instance; resident identity never enters the webui wire. */
+  residentId: string
+  sessions: MistViewportRegistry<TContext>
+  history: MistWindowHistoryPort
+  createContext(): TContext
+}
+
+interface ListedWindow {
+  window: MistViewportSnapshot
+  archived: boolean
+}
+
+function success(value: unknown): UnaryResult {
+  return { ok: true, value }
+}
+
+function failure(error: RpcError): UnaryResult {
+  return { ok: false, error }
+}
+
+function invalidPayload(method: string, issues: ZodIssue[]): UnaryResult {
+  return failure({
+    code: 'bad-request',
+    message: `invalid payload for ${method}`,
+    details: { issues },
+  })
+}
+
+function notImplemented(method: string): UnaryResult {
+  return failure({
+    code: 'internal',
+    message: `not implemented by Mist webui v0: ${method}`,
+    details: {},
+  })
+}
+
+function sessionMissing(sessionId: SessionId): UnaryResult {
+  return failure({
+    code: 'session-not-found',
+    message: `session not found: ${sessionId}`,
+    details: { sessionId },
+  })
+}
+
+/**
+ * Standalone session.* adapter for the multi-viewport model.
+ *
+ * It is deliberately not installed into the frontend plugin: plugin-to-host
+ * handler delivery belongs to the deferred protocol v0.1 follow-up. The
+ * current mock remains the default dev/plugin handler.
+ */
+export class MistSessionWireAdapter<TContext> implements MistHandler {
+  readonly #residentId: string
+  readonly #sessions: MistViewportRegistry<TContext>
+  readonly #history: MistWindowHistoryPort
+  readonly #createContext: () => TContext
+
+  constructor(options: MistSessionWireAdapterOptions<TContext>) {
+    if (options.residentId.length === 0) throw new TypeError('residentId must not be empty')
+    this.#residentId = options.residentId
+    this.#sessions = options.sessions
+    this.#history = options.history
+    this.#createContext = () => options.createContext()
+  }
+
+  async unary(method: string, payload: unknown, _rpcId: string): Promise<UnaryResult> {
+    try {
+      switch (method) {
+        case 'session.list':
+          return await this.#list(payload)
+        case 'session.create':
+          return this.#create(payload)
+        case 'session.history':
+          return await this.#readHistory(payload)
+        default:
+          return notImplemented(method)
+      }
+    } catch (error: unknown) {
+      return failure({
+        code: 'internal',
+        message: `${method} failed: ${error instanceof Error ? error.message : String(error)}`,
+        details: {},
+      })
+    }
+  }
+
+  respond(): Promise<{ accepted: false; reason: 'not-pending' }> {
+    return Promise.resolve({ accepted: false, reason: 'not-pending' })
+  }
+
+  subscribe(_stream: 'mux' | 'host', _emit: (frame: DownlinkFrame) => void): () => void {
+    return () => undefined
+  }
+
+  async #list(payload: unknown): Promise<UnaryResult> {
+    const parsed = sessionListRequestSchema.safeParse(payload)
+    if (!parsed.success) return invalidPayload('session.list', parsed.error.issues)
+
+    const windows: ListedWindow[] = [
+      ...this.#sessions.windowsOf(this.#residentId).map(window => ({ window, archived: false })),
+      ...this.#sessions.archivedWindowsOf(this.#residentId).map(window => ({ window, archived: true })),
+    ]
+    const items = await Promise.all(windows.map(async (listed) => {
+      const ref = this.#historyRef(listed.window, listed.archived)
+      const history = await this.#history.summarize(ref)
+      return {
+        sessionId: SessionId(listed.window.windowId),
+        scopeId: listed.window.scopeId,
+        generation: listed.window.generation,
+        archived: listed.archived,
+        updatedAt: history.updatedAt,
+        running: listed.archived ? false : history.running,
+        blank: history.blank,
+      } satisfies SessionSummary
+    }))
+    items.sort((left, right) => {
+      if (left.updatedAt !== right.updatedAt) return right.updatedAt - left.updatedAt
+      return left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0
+    })
+    return success({ items })
+  }
+
+  #create(payload: unknown): UnaryResult {
+    const parsed = sessionCreateRequestSchema.safeParse(payload)
+    if (!parsed.success) return invalidPayload('session.create', parsed.error.issues)
+    const unsupported: ZodIssue[] = []
+    if (parsed.data.workspaceId !== undefined) {
+      unsupported.push({
+        code: 'custom',
+        input: parsed.data.workspaceId,
+        path: ['workspaceId'],
+        message: 'Mist session.create does not support workspaceId',
+      })
+    }
+    if (parsed.data.cwd !== undefined) {
+      unsupported.push({
+        code: 'custom',
+        input: parsed.data.cwd,
+        path: ['cwd'],
+        message: 'Mist session.create does not support cwd',
+      })
+    }
+    if (parsed.data.agentPreset !== undefined) {
+      unsupported.push({
+        code: 'custom',
+        input: parsed.data.agentPreset,
+        path: ['agentPreset'],
+        message: 'Mist session.create does not support agentPreset',
+      })
+    }
+    if (parsed.data.sessionId !== undefined) {
+      unsupported.push({
+        code: 'custom',
+        input: parsed.data.sessionId,
+        path: ['sessionId'],
+        message: 'Mist window ids are host-generated and cannot be preallocated',
+      })
+    }
+    if (unsupported.length > 0) return invalidPayload('session.create', unsupported)
+    const window = this.#sessions.open(this.#residentId, {
+      context: this.#createContext(),
+      ...(parsed.data.scopeId === undefined ? {} : { scopeId: parsed.data.scopeId }),
+    })
+    return success({ sessionId: SessionId(window.windowId), generation: window.generation })
+  }
+
+  async #readHistory(payload: unknown): Promise<UnaryResult> {
+    const parsed = sessionHistoryRequestSchema.safeParse(payload)
+    if (!parsed.success) return invalidPayload('session.history', parsed.error.issues)
+    const windowId = parsed.data.sessionId
+    const active = this.#sessions.get(windowId)
+    const archived = active === undefined ? this.#sessions.getArchived(windowId) : undefined
+    const window = active ?? archived
+    if (window === undefined || window.residentId !== this.#residentId) {
+      return sessionMissing(parsed.data.sessionId)
+    }
+    const page = await this.#history.read(this.#historyRef(window, archived !== undefined), {
+      ...(parsed.data.beforeSeq === undefined ? {} : { beforeSeq: parsed.data.beforeSeq }),
+      ...(parsed.data.maxMessages === undefined ? {} : { maxMessages: parsed.data.maxMessages }),
+    })
+    return success({
+      events: page.events,
+      hasMore: page.hasMore,
+      ...(page.projections === undefined ? {} : { projections: page.projections }),
+    })
+  }
+
+  #historyRef(
+    window: MistViewportSnapshot,
+    archived: boolean,
+  ): MistWindowHistoryRef {
+    return {
+      residentId: window.residentId,
+      windowId: window.windowId,
+      headId: window.headId,
+      archived,
+    }
+  }
+}

--- a/webui/apps/dev-server/tests/fixtures/mist-session-wire-host.ts
+++ b/webui/apps/dev-server/tests/fixtures/mist-session-wire-host.ts
@@ -1,0 +1,98 @@
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { HistoryEntry } from '@deepseek-ai/dsh-host-apiproxy/api'
+import { createDevServer } from '../../src/server.ts'
+import {
+  MistSessionWireAdapter,
+  type MistViewportRegistry,
+  type MistViewportSnapshot,
+  type MistWindowHistoryPage,
+  type MistWindowHistoryPort,
+  type MistWindowHistoryRef,
+  type MistWindowHistorySummary,
+} from '../../src/mist-session-wire-adapter.ts'
+
+interface HostRegistry extends MistViewportRegistry<null> {
+  kill(windowId: string): MistViewportSnapshot | undefined
+}
+
+interface RegistryModule {
+  SessionRegistry: new () => HostRegistry
+}
+
+class FixtureHistory implements MistWindowHistoryPort {
+  constructor(
+    readonly activeId: string,
+    readonly archivedId: string,
+  ) {}
+
+  summarize(window: MistWindowHistoryRef): Promise<MistWindowHistorySummary> {
+    if (window.windowId === this.activeId) {
+      return Promise.resolve({ updatedAt: 20, running: true, blank: true })
+    }
+    return Promise.resolve({ updatedAt: 10, running: false, blank: false })
+  }
+
+  read(window: MistWindowHistoryRef): Promise<MistWindowHistoryPage> {
+    const events: HistoryEntry[] = window.windowId === this.archivedId
+      ? [{ event: { type: 'turn/start', seq: 0, time: 10, data: { turn: 1 } } }]
+      : []
+    return Promise.resolve({ events, hasMore: false })
+  }
+}
+
+const root = resolve(import.meta.dirname, '../../../../..')
+const registryUrl = pathToFileURL(resolve(root, 'src/session/session-registry.ts')).href
+const { SessionRegistry } = await import(registryUrl) as RegistryModule
+const sessions = new SessionRegistry()
+const active = sessions.open('resident-a', { scopeId: 'room-live', context: null })
+const archived = sessions.open('resident-a', { scopeId: 'room-archive', context: null })
+const killedSnapshot = sessions.kill(archived.windowId)
+const fetchedSnapshot = sessions.getArchived(archived.windowId)
+const listedSnapshot = sessions.archivedWindowsOf('resident-a')[0]
+for (const snapshot of [killedSnapshot, fetchedSnapshot, listedSnapshot]) {
+  if (snapshot === undefined) throw new Error('expected archived snapshot')
+  snapshot.residentId = 'resident-b'
+  snapshot.scopeId = 'room-mutated'
+  snapshot.generation = 99
+  snapshot.headId = 'node-mutated'
+}
+
+const history = new FixtureHistory(active.windowId, archived.windowId)
+const server = createDevServer({
+  handler: new MistSessionWireAdapter({
+    residentId: 'resident-a',
+    sessions,
+    history,
+    createContext: () => null,
+  }),
+})
+const foreignServer = createDevServer({
+  handler: new MistSessionWireAdapter({
+    residentId: 'resident-b',
+    sessions,
+    history,
+    createContext: () => null,
+  }),
+})
+const address = await server.listen(0)
+const foreignAddress = await foreignServer.listen(0)
+
+async function stop(): Promise<void> {
+  await Promise.all([server.close(), foreignServer.close()])
+  process.exit(0)
+}
+
+process.on('message', (message: unknown) => {
+  if (typeof message === 'object' && message !== null && 'type' in message && message.type === 'stop') {
+    void stop()
+  }
+})
+process.on('SIGTERM', () => void stop())
+process.send?.({
+  type: 'ready',
+  port: address.port,
+  foreignPort: foreignAddress.port,
+  activeId: active.windowId,
+  archivedId: archived.windowId,
+})

--- a/webui/apps/dev-server/tests/mist-session-wire-adapter.spec.ts
+++ b/webui/apps/dev-server/tests/mist-session-wire-adapter.spec.ts
@@ -1,0 +1,317 @@
+import type { HistoryEntry } from '@deepseek-ai/dsh-host-apiproxy/api'
+import {
+  sessionCreateValueSchema,
+  sessionHistoryValueSchema,
+  sessionListValueSchema,
+} from '@deepseek-ai/dsh-host-apiproxy/api/sessions.schema'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { DevServer } from '../src/server.ts'
+import { createDevServer } from '../src/server.ts'
+import {
+  MistSessionWireAdapter,
+  type MistViewportRegistry,
+  type MistViewportSnapshot,
+  type MistWindowHistoryPage,
+  type MistWindowHistoryPort,
+  type MistWindowHistoryRef,
+  type MistWindowHistorySummary,
+} from '../src/mist-session-wire-adapter.ts'
+
+interface RpcEnvelope {
+  result?: { ok: boolean; value?: unknown; error?: { code?: string; details?: unknown } }
+}
+
+class MemoryWindowHistory implements MistWindowHistoryPort {
+  readonly summaries = new Map<string, MistWindowHistorySummary>()
+  readonly pages = new Map<string, MistWindowHistoryPage>()
+  readonly reads: Array<{ window: MistWindowHistoryRef; page: { beforeSeq?: number; maxMessages?: number } }> = []
+
+  summarize(window: MistWindowHistoryRef): Promise<MistWindowHistorySummary> {
+    return Promise.resolve(
+      this.summaries.get(window.windowId) ?? { updatedAt: 0, running: false, blank: true },
+    )
+  }
+
+  read(
+    window: MistWindowHistoryRef,
+    page: { beforeSeq?: number; maxMessages?: number },
+  ): Promise<MistWindowHistoryPage> {
+    this.reads.push({ window, page })
+    return Promise.resolve(this.pages.get(window.windowId) ?? { events: [], hasMore: false })
+  }
+}
+
+interface MemoryViewport extends MistViewportSnapshot {
+  context: null
+}
+
+class MemoryViewportRegistry implements MistViewportRegistry<null> {
+  readonly #active = new Map<string, MemoryViewport>()
+  readonly #archived = new Map<string, MistViewportSnapshot>()
+  openCalls = 0
+  #sequence = 0
+
+  windowsOf(residentId: string): MemoryViewport[] {
+    return [...this.#active.values()].filter(window => window.residentId === residentId)
+  }
+
+  archivedWindowsOf(residentId: string): MistViewportSnapshot[] {
+    return [...this.#archived.values()].filter(window => window.residentId === residentId)
+  }
+
+  open(
+    residentId: string,
+    options: { scopeId?: string; context: null },
+  ): MemoryViewport {
+    this.openCalls += 1
+    this.#sequence += 1
+    const window: MemoryViewport = {
+      residentId,
+      windowId: `w_test_${this.#sequence.toString().padStart(6, '0')}`,
+      scopeId: options.scopeId ?? 'private',
+      generation: 1,
+      headId: null,
+      context: options.context,
+    }
+    this.#active.set(window.windowId, window)
+    return window
+  }
+
+  get(windowId: string): MemoryViewport | undefined {
+    return this.#active.get(windowId)
+  }
+
+  getArchived(windowId: string): MistViewportSnapshot | undefined {
+    return this.#archived.get(windowId)
+  }
+
+  setHead(windowId: string, headId: string): void {
+    const window = this.#active.get(windowId)
+    if (window === undefined) throw new Error(`no active window ${windowId}`)
+    window.headId = headId
+  }
+
+  kill(windowId: string): MistViewportSnapshot | undefined {
+    const window = this.#active.get(windowId)
+    if (window === undefined) return this.#archived.get(windowId)
+    this.#active.delete(windowId)
+    this.#archived.set(windowId, window)
+    return window
+  }
+}
+
+let server: DevServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+function event(seq: number, time: number): HistoryEntry {
+  return {
+    event: {
+      type: 'turn/start',
+      seq,
+      time,
+      data: { turn: 1 },
+    },
+  }
+}
+
+async function post(base: string, method: string, payload: unknown): Promise<RpcEnvelope> {
+  const response = await fetch(`${base}/api/${method}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ type: 'client-request', rpcId: crypto.randomUUID(), method, payload }),
+  })
+  expect(response.status).toBe(200)
+  return await response.json() as RpcEnvelope
+}
+
+async function start(
+  sessions: MemoryViewportRegistry,
+  history: MemoryWindowHistory,
+): Promise<string> {
+  const handler = new MistSessionWireAdapter({
+    residentId: 'resident-a',
+    sessions,
+    history,
+    createContext: () => null,
+  })
+  server = createDevServer({ handler })
+  const address = await server.listen(0)
+  return `http://127.0.0.1:${address.port}`
+}
+
+function valueOf(envelope: RpcEnvelope): unknown {
+  expect(envelope.result?.ok).toBe(true)
+  return envelope.result?.value
+}
+
+describe('Mist multi-viewport session wire adapter', () => {
+  it('maps create to host-minted windows and list to active plus archived windows', async () => {
+    const sessions = new MemoryViewportRegistry()
+    const history = new MemoryWindowHistory()
+    const otherResident = sessions.open('resident-b', { context: null })
+    sessions.kill(otherResident.windowId)
+    const base = await start(sessions, history)
+
+    const first = sessionCreateValueSchema.parse(valueOf(await post(base, 'session.create', {
+      scopeId: 'room-1',
+    })))
+    const second = sessionCreateValueSchema.parse(valueOf(await post(base, 'session.create', {
+      scopeId: 'room-1',
+    })))
+    expect(first.sessionId).not.toBe(second.sessionId)
+    expect([first.generation, second.generation]).toEqual([1, 1])
+    expect(sessions.windowsOf('resident-a').map(window => window.scopeId)).toEqual([
+      'room-1', 'room-1',
+    ])
+
+    history.summaries.set(first.sessionId, { updatedAt: 10, running: true, blank: false })
+    history.summaries.set(second.sessionId, { updatedAt: 20, running: true, blank: true })
+    sessions.kill(first.sessionId)
+
+    const listed = sessionListValueSchema.parse(valueOf(await post(base, 'session.list', {})))
+    expect(listed.items).toEqual([
+      expect.objectContaining({
+        sessionId: second.sessionId,
+        scopeId: 'room-1',
+        generation: 1,
+        archived: false,
+        updatedAt: 20,
+        running: true,
+        blank: true,
+      }),
+      expect.objectContaining({
+        sessionId: first.sessionId,
+        scopeId: 'room-1',
+        generation: 1,
+        archived: true,
+        updatedAt: 10,
+        running: false,
+        blank: false,
+      }),
+    ])
+    expect(JSON.stringify(listed)).not.toContain('resident-a')
+    const listedItems = Array.isArray(listed.items) ? listed.items : []
+    expect(listedItems.some(item => String(item.sessionId) === otherResident.windowId)).toBe(false)
+  })
+
+  it('reads an archived window through the read-only history port without reviving it', async () => {
+    const sessions = new MemoryViewportRegistry()
+    const history = new MemoryWindowHistory()
+    const window = sessions.open('resident-a', { scopeId: 'room-2', context: null })
+    sessions.setHead(window.windowId, 'node-final')
+    sessions.kill(window.windowId)
+    const archivedEvents = [event(0, 100)]
+    history.pages.set(window.windowId, { events: archivedEvents, hasMore: true })
+    const base = await start(sessions, history)
+
+    const page = sessionHistoryValueSchema.parse(valueOf(await post(base, 'session.history', {
+      sessionId: window.windowId,
+      beforeSeq: 4,
+      maxMessages: 2,
+    })))
+    expect(page).toEqual({ events: archivedEvents, hasMore: true })
+    expect(history.reads).toEqual([{
+      window: {
+        residentId: 'resident-a',
+        windowId: window.windowId,
+        headId: 'node-final',
+        archived: true,
+      },
+      page: { beforeSeq: 4, maxMessages: 2 },
+    }])
+    expect(sessions.get(window.windowId)).toBeUndefined()
+    expect(sessions.getArchived(window.windowId)).toBeDefined()
+  })
+
+  it('rejects unsupported create parameters and combinations before opening a window', async () => {
+    const sessions = new MemoryViewportRegistry()
+    const history = new MemoryWindowHistory()
+    const base = await start(sessions, history)
+    const cases: Array<{
+      payload: Record<string, string>
+      issues: Array<{ path: unknown[]; message: string }>
+    }> = [
+      {
+        payload: { workspaceId: 'workspace-1' },
+        issues: [{ path: ['workspaceId'], message: 'Mist session.create does not support workspaceId' }],
+      },
+      {
+        payload: { cwd: '/requested' },
+        issues: [{ path: ['cwd'], message: 'Mist session.create does not support cwd' }],
+      },
+      {
+        payload: { agentPreset: 'requested-preset' },
+        issues: [{ path: ['agentPreset'], message: 'Mist session.create does not support agentPreset' }],
+      },
+      {
+        payload: { sessionId: 'caller-picked' },
+        issues: [{
+          path: ['sessionId'],
+          message: 'Mist window ids are host-generated and cannot be preallocated',
+        }],
+      },
+      {
+        payload: {
+          workspaceId: 'workspace-1',
+          agentPreset: 'requested-preset',
+          sessionId: 'caller-picked',
+        },
+        issues: [
+          { path: ['workspaceId'], message: 'Mist session.create does not support workspaceId' },
+          { path: ['agentPreset'], message: 'Mist session.create does not support agentPreset' },
+          {
+            path: ['sessionId'],
+            message: 'Mist window ids are host-generated and cannot be preallocated',
+          },
+        ],
+      },
+      {
+        payload: { cwd: '/requested', agentPreset: 'requested-preset', sessionId: 'caller-picked' },
+        issues: [
+          { path: ['cwd'], message: 'Mist session.create does not support cwd' },
+          { path: ['agentPreset'], message: 'Mist session.create does not support agentPreset' },
+          {
+            path: ['sessionId'],
+            message: 'Mist window ids are host-generated and cannot be preallocated',
+          },
+        ],
+      },
+      {
+        payload: { workspaceId: 'workspace-1', cwd: '/requested', agentPreset: 'requested-preset' },
+        issues: [{ path: [], message: 'session.create accepts workspaceId or cwd, not both' }],
+      },
+    ]
+
+    for (const testCase of cases) {
+      const response = await post(base, 'session.create', testCase.payload)
+      expect(response.result).toMatchObject({ ok: false, error: { code: 'bad-request' } })
+      const details = response.result?.error?.details as {
+        issues?: Array<{ path?: unknown[]; message?: string }>
+      } | undefined
+      expect(details?.issues?.map(issue => ({ path: issue.path, message: issue.message })))
+        .toEqual(testCase.issues)
+    }
+    expect(sessions.openCalls).toBe(0)
+    expect(sessions.windowsOf('resident-a')).toEqual([])
+  })
+
+  it('hides unknown or cross-resident windows', async () => {
+    const sessions = new MemoryViewportRegistry()
+    const history = new MemoryWindowHistory()
+    const foreign = sessions.open('resident-b', { context: null })
+    const base = await start(sessions, history)
+
+    for (const sessionId of ['missing-window', foreign.windowId]) {
+      const response = await post(base, 'session.history', { sessionId })
+      expect(response.result).toMatchObject({
+        ok: false,
+        error: { code: 'session-not-found', details: { sessionId } },
+      })
+    }
+    expect(history.reads).toEqual([])
+  })
+})

--- a/webui/apps/dev-server/tests/mist-session-wire-host.spec.ts
+++ b/webui/apps/dev-server/tests/mist-session-wire-host.spec.ts
@@ -1,0 +1,139 @@
+import { type ChildProcess, spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import {
+  sessionCreateValueSchema,
+  sessionHistoryValueSchema,
+  sessionListValueSchema,
+} from '@deepseek-ai/dsh-host-apiproxy/api/sessions.schema'
+import { afterEach, describe, expect, it } from 'vitest'
+
+interface ReadyMessage {
+  type: 'ready'
+  port: number
+  foreignPort: number
+  activeId: string
+  archivedId: string
+}
+
+interface RpcEnvelope {
+  result?: { ok: boolean; value?: unknown; error?: { code?: string } }
+}
+
+const children: ChildProcess[] = []
+const fixture = fileURLToPath(new URL('./fixtures/mist-session-wire-host.ts', import.meta.url))
+
+function startHost(): ChildProcess {
+  const child = spawn(process.execPath, ['--import', 'tsx', fixture], {
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+  })
+  children.push(child)
+  return child
+}
+
+function waitForReady(child: ChildProcess): Promise<ReadyMessage> {
+  return new Promise((resolve, reject) => {
+    let stderr = ''
+    const timeout = setTimeout(() => {
+      reject(new Error(`wire host startup timed out: ${stderr}`))
+    }, 10_000)
+    child.stderr?.setEncoding('utf8')
+    child.stderr?.on('data', (chunk: string) => { stderr += chunk })
+    child.on('message', onMessage)
+    child.once('exit', onExit)
+
+    function cleanup(): void {
+      clearTimeout(timeout)
+      child.off('message', onMessage)
+      child.off('exit', onExit)
+    }
+    function onMessage(message: unknown): void {
+      if (typeof message !== 'object' || message === null || !('type' in message)) return
+      if (message.type !== 'ready') return
+      cleanup()
+      resolve(message as ReadyMessage)
+    }
+    function onExit(code: number | null): void {
+      cleanup()
+      reject(new Error(`wire host exited ${String(code)} before ready: ${stderr}`))
+    }
+  })
+}
+
+async function stopHost(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  const exited = new Promise<void>((resolve) => {
+    child.once('exit', () => { resolve() })
+  })
+  child.send?.({ type: 'stop' })
+  await exited
+}
+
+afterEach(async () => {
+  await Promise.all(children.splice(0).map(async (child) => {
+    try {
+      await stopHost(child)
+    } catch {
+      child.kill()
+    }
+  }))
+})
+
+async function request(base: string, method: string, payload: unknown): Promise<RpcEnvelope> {
+  const response = await fetch(`${base}/api/${method}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ type: 'client-request', rpcId: crypto.randomUUID(), method, payload }),
+  })
+  return await response.json() as RpcEnvelope
+}
+
+async function post(base: string, method: string, payload: unknown): Promise<unknown> {
+  const envelope = await request(base, method, payload)
+  expect(envelope.result?.ok).toBe(true)
+  return envelope.result?.value
+}
+
+describe('Mist session wire real host subprocess', () => {
+  it('maps list/create/history to actual multi-viewport registry windows', async () => {
+    const child = startHost()
+    const ready = await waitForReady(child)
+    const base = `http://127.0.0.1:${ready.port}`
+
+    const listed = sessionListValueSchema.parse(await post(base, 'session.list', {}))
+    expect(listed.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        sessionId: ready.activeId, scopeId: 'room-live', archived: false, generation: 1,
+      }),
+      expect.objectContaining({
+        sessionId: ready.archivedId, scopeId: 'room-archive', archived: true, generation: 1,
+      }),
+    ]))
+
+    const created = sessionCreateValueSchema.parse(await post(base, 'session.create', {
+      scopeId: 'room-new',
+    }))
+    expect(created).toMatchObject({ generation: 1 })
+    expect(created.sessionId).not.toBe(ready.activeId)
+
+    const history = sessionHistoryValueSchema.parse(await post(base, 'session.history', {
+      sessionId: ready.archivedId,
+    }))
+    expect(history.hasMore).toBe(false)
+    const events = Array.isArray(history.events) ? history.events : []
+    expect(events).toHaveLength(1)
+    expect(JSON.stringify(events)).toContain('"type":"turn/start"')
+
+    const foreignBase = `http://127.0.0.1:${ready.foreignPort}`
+    const foreignList = sessionListValueSchema.parse(await post(foreignBase, 'session.list', {}))
+    expect(foreignList.items).toEqual([])
+    const foreignHistory = await request(foreignBase, 'session.history', {
+      sessionId: ready.archivedId,
+    })
+    expect(foreignHistory.result).toMatchObject({
+      ok: false,
+      error: { code: 'session-not-found' },
+    })
+
+    await stopHost(child)
+  })
+})

--- a/webui/docs/research/mist-wire-contract.md
+++ b/webui/docs/research/mist-wire-contract.md
@@ -2,6 +2,7 @@
 
 单A 连接层的可执行规格：弟弟的 mock 按此实现，实现即契约测试桩；最终随上游 PR 提交 mist 定稿。
 证据等级：**实查**（对冻结树 47f9438 读码 + 追调用点；boot 时序另经 ConnectionController 源码核实）。
+`session.list / session.create / session.history` 的窗口语义唯一以 `docs/design/session-api.md` §1.1 为准；下表只作线侧摘要。
 
 ## 总原则
 
@@ -20,10 +21,10 @@ connected = `events.mux` onOpen + `events.host` onOpen + `host.describe` unary �
 | 方法 | 触发点 | mist 侧映射 |
 |---|---|---|
 | `host.describe` | 每代就绪握手 | 静态描述（名称/能力位）；**不含 dsh 品牌** |
-| `session.list` | onConnected resync | 住户可见会话列表（消息树 heads） |
-| `session.create` | 新会话 | SessionRegistry.open + 树锚点 |
-| `session.history` | 打开会话/重连重拉 | history snapshot + **单 session 递增 seq**（弟弟四面之一） |
-| `session.prompt` | 发消息 | submit turn → dispatch 收据（residentId+generation+dispatchId 关联键） |
+| `session.list` | onConnected resync | handler 所绑定住户的活窗 + 归档窗；`sessionId=windowId`，返回 scope/generation/archived，不暴露 resident |
+| `session.create` | 新会话 | `open(handler-bound residentId, scopeId)`；宿主签发 `sessionId=windowId` 与 generation，不映射的通用参数显式拒绝 |
+| `session.history` | 打开会话/重连重拉 | 按 `sessionId=windowId` 只读活窗或归档窗的权威流水，不 reopen；**单窗递增 seq** |
+| `session.prompt` | 发消息 | submit turn → dispatch 收据（residentId+windowId+generation+dispatchId 关联键） |
 | `session.cancel` | 停止按钮 | cancel 在途 turn |
 | `settings.describe` | 欢迎声明加载 | 返回含 `ui-onboarding` 的可写 namespace views |
 | `settings.mutate` | 欢迎声明确认 | 通用 path set/unset；内存持久化已读版本并返回新 view |

--- a/webui/packages/host/apiproxy/README.md
+++ b/webui/packages/host/apiproxy/README.md
@@ -22,6 +22,8 @@ Wire messages form a four-quadrant discriminated union — who initiates × requ
 
 The layering/protocol decisions are recorded in the [GUI layering and RPC protocol RFC](../../../.agents/notes/implemented/architecture/2026-07-19-gui-layering-and-rpc-protocol.md); the browser-side consumption architecture in the [web client architecture RFC](../../../.agents/notes/implemented/architecture/2026-07-19-gui-web-client-architecture.md).
 
+The shared Session shapes reserve optional fields for Mist's multi-viewport adapter without changing other hosts. A Mist `session.create` may take `scopeId` and returns `generation`; its `session.list` rows add `scopeId`, `generation`, and `archived`, with `sessionId` equal to the host-minted window id. The adapter rejects caller-preallocated `sessionId` and generic `workspaceId`, `cwd`, or `agentPreset` inputs rather than silently guessing window-model mappings; it binds the resident outside the wire and reads both live and archived history without reviving a window.
+
 Question responses are validated against their pending request before the first answer claims it. A multi-select item may carry both requested option labels in `selected` and non-empty `custom` text; a single-select item must use one or the other. Duplicate labels, unknown labels, mismatched ids, incomplete batches, and empty custom text are rejected as `bad-response`.
 
 `session.history` reads an attached Session in memory or inspects a cold log through persistence without resuming or publishing an Agent, then pages on append-origin message boundaries. `maxMessages` counts `user/message` and `assistant/message` events that entered the surface by appending, so a model-only replacement copy consumes no quota. Each page stays one contiguous raw event range, which keeps a compaction's log-only `compaction/summary` record on the same page as the replacement that cites it.
@@ -74,6 +76,7 @@ None; this package neither assembles nor sends a provider request.
 
 ## Known Limitations and Deferred Work
 
+- **The Mist multi-viewport adapter is not installed into the frontend plugin** — the plugin-handler delivery channel is deferred to protocol v0.1, so the shipped plugin still uses its mock handler.
 - **Forwarded Remote events are parasitic on this legacy frame union** — `host/remote-event` lives in `HostFrame` so the delivery path could reuse the existing host stream instead of opening a third downlink, which makes it read as if this package owned the Remote event contract. It does not: the allowlist is `dsh-api-remotes`' and the consumer verb is `ctx.remote.$on`. When the host stream moves off this package, the frame moves with it and the consumer contract is unaffected ([rationale](../../../.agents/notes/implemented/architecture/2026-08-10-remote-event-delivery.md)).
 - **Pending-interaction state is host-side** — the wire uses POST `/api/respond` plus `RpcReceipt`; the table in `src/api-proxy.ts` handles questions only and has no approval entries.
 - **Reserved seams stay out of `RpcMethodMap`** — `prompt.mode: 'inject'`, `job.list`, and a describe `hostInstanceId` are documented reservations; model discovery uses `llm.models`. An unknown method fails loud at envelope parse rather than getting a not-implemented code.

--- a/webui/packages/host/apiproxy/README.zh.md
+++ b/webui/packages/host/apiproxy/README.zh.md
@@ -22,6 +22,8 @@ Settings 分节中的 `reasoningEffort` 在 agent-default-model 插件配置中�
 
 分层与协议决策记录在 [GUI 分层与 RPC 协议 RFC](../../../.agents/notes/implemented/architecture/2026-07-19-gui-layering-and-rpc-protocol.md) 中；浏览器侧消费架构记录在 [Web 客户端架构 RFC](../../../.agents/notes/implemented/architecture/2026-07-19-gui-web-client-architecture.md) 中。
 
+共享 Session 形状为 Mist 的多 viewport 适配器保留了可选字段，不改变其他宿主。Mist 的 `session.create` 可接收 `scopeId` 并返回 `generation`；`session.list` 每行增加 `scopeId`、`generation` 与 `archived`，其中 `sessionId` 等于宿主签发的 window id。该适配器拒绝调用方预分配的 `sessionId`，也拒绝通用 `workspaceId`、`cwd` 或 `agentPreset` 输入，而不会静默猜测窗模型映射；住户绑定留在线协议之外，并能只读活窗与归档窗的流水而不复活窗口。
+
 首个回答认领待处理请求之前，系统会对照该请求校验问题响应。多选题的回答项可以同时携带 `selected` 中的请求选项标签与非空 `custom` 文本；单选题的回答项必须二选一。标签重复、标签未知、id 不匹配、批次不完整以及自定义文本为空都会以 `bad-response` 拒绝。
 
 `session.history` 会读取已附加 Session 的内存状态，或通过持久化检查冷日志，而不会恢复或发布 agent，然后按追加来源的消息边界分页：`maxMessages` 统计以追加方式进入 surface 的 `user/message` 和 `assistant/message` 事件，因此仅供模型使用的替换副本不占用配额。每一页仍是一段连续的原始事件区间，从而让压缩（compaction）的仅日志 `compaction/summary` 记录与引用它的替换留在同一页。
@@ -74,6 +76,7 @@ Workspace 列表与 Session 列表是相互独立的重连基线。`workspace.cr
 
 ## 已知限制与暂缓事项
 
+- **Mist 多 viewport 适配器尚未安装到 frontend 插件**：插件 handler 交付通道延期至协议 v0.1，因此随发行版交付的插件仍使用 mock handler。
 - **转发的 Remote 事件寄居在这套 legacy 帧联合里**：`host/remote-event` 住在 `HostFrame` 中，是为了让投递路径复用现有宿主流、不必新开第三条下行通道，因此读起来像是本包拥有 Remote 事件契约。并非如此：名单归 `dsh-api-remotes`，消费端动词是 `ctx.remote.$on`。将来宿主流整体搬离本包时，该帧随之搬走，消费端契约不受影响（[原委](../../../.agents/notes/implemented/architecture/2026-08-10-remote-event-delivery.md)）。
 - **待处理交互状态位于宿主侧**：wire 使用 POST `/api/respond` 加 `RpcReceipt`；`src/api-proxy.ts` 中的表只处理问题，不包含审批条目。
 - **预留 seam 不进入 `RpcMethodMap`**：`prompt.mode: 'inject'`、`job.list` 和描述字段 `hostInstanceId` 都是已记录的预留项；模型发现使用 `llm.models`。未知方法会在信封解析时直接失败，而不会返回「尚未实现」错误码。

--- a/webui/packages/host/apiproxy/src/api/sessions.schema.ts
+++ b/webui/packages/host/apiproxy/src/api/sessions.schema.ts
@@ -51,6 +51,9 @@ export const sessionEventSchema = z.object({
 /** SessionSummary row of session.list (`projections` reuses the history block's shape and schema). */
 export const sessionSummarySchema = z.object({
   sessionId: sessionIdSchema,
+  scopeId: z.string().min(1).optional(),
+  generation: z.number().int().positive().optional(),
+  archived: z.boolean().optional(),
   updatedAt: z.number(),
   running: z.boolean(),
   blank: z.boolean(),
@@ -104,6 +107,7 @@ export const sessionCreateRequestSchema = z.object({
   cwd: z.string().optional(),
   sessionId: sessionIdSchema.optional(),
   agentPreset: z.string().optional(),
+  scopeId: z.string().min(1).optional(),
 }).refine(
   payload => payload.workspaceId === undefined || payload.cwd === undefined,
   { message: 'session.create accepts workspaceId or cwd, not both' },
@@ -113,6 +117,7 @@ export const sessionCreateRequestSchema = z.object({
 export const sessionCreateValueSchema = z.object({
   sessionId: sessionIdSchema,
   agentPreset: z.string().optional(),
+  generation: z.number().int().positive().optional(),
 }) satisfies z.ZodType<Wire<ResponseValue<'session.create'>>>
 
 /** session.rename request payload (raw title; host-side normalization decides acceptance). */

--- a/webui/packages/host/apiproxy/src/api/sessions.ts
+++ b/webui/packages/host/apiproxy/src/api/sessions.ts
@@ -176,6 +176,12 @@ export type QueueAction =
 /** One Session list entry. */
 export interface SessionSummary {
   sessionId: SessionId
+  /** Mist multi-viewport visibility boundary; absent on non-Mist hosts. */
+  scopeId?: string
+  /** Current or final generation of the window represented by sessionId. */
+  generation?: number
+  /** True when this row is a read-only archived window. */
+  archived?: boolean
   /**
    * The later of creation and the latest human-authored prompt. Attached
    * Sessions fold their live log; cold Sessions use a projection-cache hint or
@@ -258,8 +264,15 @@ export interface SessionsApi {
    * id fails with `agent-preset-not-found`, and a preset whose composition
    * cannot be mounted fails with `agent-preset-invalid`.
    */
-  create(request: RpcRequest<{ workspaceId?: WorkspaceId; cwd?: string; sessionId?: SessionId; agentPreset?: string }>):
-  Promise<RpcResponse<{ sessionId: SessionId; agentPreset?: string }>>
+  create(request: RpcRequest<{
+    workspaceId?: WorkspaceId
+    cwd?: string
+    sessionId?: SessionId
+    agentPreset?: string
+    /** Mist visibility boundary; omission uses the host's private scope. */
+    scopeId?: string
+  }>):
+  Promise<RpcResponse<{ sessionId: SessionId; agentPreset?: string; generation?: number }>>
 
   /**
    * Reads a window of history events; page boundaries align to append-origin message

--- a/webui/packages/host/apiproxy/tests/rpc-schemas.spec.ts
+++ b/webui/packages/host/apiproxy/tests/rpc-schemas.spec.ts
@@ -160,7 +160,17 @@ describe('sessions domain schemas', () => {
   it('validates the per-method request/value pairs', () => {
     expect(sessionListRequestSchema.parse({})).toEqual({})
     expect(sessionListRequestSchema.parse({ cursor: 'c' }).cursor).toBe('c')
-    expect(sessionListValueSchema.parse({ items: [] }).items).toEqual([])
+    expect(sessionListValueSchema.parse({
+      items: [{
+        sessionId: 'w_01', scopeId: 'private', generation: 2, archived: true,
+        updatedAt: 1, running: false, blank: false,
+      }],
+    }).items).toEqual([expect.objectContaining({
+      sessionId: 'w_01', scopeId: 'private', generation: 2, archived: true,
+    })])
+    expect(sessionListValueSchema.parse({
+      items: [{ sessionId: 's1', updatedAt: 1, running: false, blank: true }],
+    }).items).toEqual([expect.objectContaining({ sessionId: 's1' })])
     expect(sessionSearchRequestSchema.parse({ query: '  exact phrase  ' })).toEqual({ query: 'exact phrase' })
     expect(() => sessionSearchRequestSchema.parse({ query: '   ' })).toThrow()
     expect(() => sessionSearchRequestSchema.parse({ query: 'bad\0query' })).toThrow(/NUL/)
@@ -191,11 +201,17 @@ describe('sessions domain schemas', () => {
       ),
       hasMore: true,
     })).toThrow()
-    expect(sessionCreateRequestSchema.parse({ cwd: '/w' }).cwd).toBe('/w')
+    expect(sessionCreateRequestSchema.parse({ cwd: '/w', scopeId: 'private' })).toMatchObject({
+      cwd: '/w', scopeId: 'private',
+    })
+    expect(() => sessionCreateRequestSchema.parse({ scopeId: '' })).toThrow()
     // The refine's both-sides branch: workspaceId alone passes, workspaceId+cwd rejects.
     expect(sessionCreateRequestSchema.parse({ workspaceId: 'w1', sessionId: 's1' }).sessionId).toBe('s1')
     expect(() => sessionCreateRequestSchema.parse({ workspaceId: 'w1', cwd: '/w' })).toThrow(/not both/)
-    expect(sessionCreateValueSchema.parse({ sessionId: 's1' }).sessionId).toBe('s1')
+    expect(sessionCreateValueSchema.parse({ sessionId: 's1', generation: 1 })).toEqual({
+      sessionId: 's1', generation: 1,
+    })
+    expect(sessionCreateValueSchema.parse({ sessionId: 's1' })).toEqual({ sessionId: 's1' })
     expect(sessionHistoryRequestSchema.parse({ sessionId: 's1', beforeSeq: 3, maxMessages: 5 }).beforeSeq).toBe(3)
     expect(() => sessionHistoryRequestSchema.parse({ sessionId: 's1', maxMessages: 0 })).toThrow()
     expect(sessionHistoryValueSchema.parse({


### PR DESCRIPTION
## Summary

Implements Issue #82 / MV-E01–E02 by aligning the existing `session.list`, `session.create`, and `session.history` wire surface with the multi-viewport window model.

- `session.list` merges the handler-bound resident’s live and archived windows, returns `sessionId=windowId`, `scopeId`, `generation`, and `archived`, sorts by `updatedAt` descending with a stable `sessionId` tie-break, and never exposes `residentId`.
- `session.create` opens a host-minted window for the handler-bound resident, forwards only `scopeId`, returns the window id and generation, and rejects preallocated ids or unsupported generic workspace/cwd/preset inputs before calling `createContext()` or `open()`.
- `session.history` reads live or archived window history through a read-only port without reopening the window.
- Adds the narrow defensive `archivedWindowsOf()` read seam and deep-clones all public archived-window returns.
- Synchronizes `docs/design/session-api.md` §1.1 and the research wire table.

## Scope

Final change set: 13 files, 981 insertions, 33 deletions.

- `docs/design/session-api.md`
- `src/session/session-registry.ts`
- `tests/session-registry.test.ts`
- `webui/apps/dev-server/src/mist-session-wire-adapter.ts`
- `webui/apps/dev-server/tests/fixtures/mist-session-wire-host.ts`
- `webui/apps/dev-server/tests/mist-session-wire-adapter.spec.ts`
- `webui/apps/dev-server/tests/mist-session-wire-host.spec.ts`
- `webui/docs/research/mist-wire-contract.md`
- `webui/packages/host/apiproxy/README.md`
- `webui/packages/host/apiproxy/README.zh.md`
- `webui/packages/host/apiproxy/src/api/sessions.schema.ts`
- `webui/packages/host/apiproxy/src/api/sessions.ts`
- `webui/packages/host/apiproxy/tests/rpc-schemas.spec.ts`

The frontend plugin remains on its existing mock handler. This PR does not implement the real handler delivery channel, #79 MV-B03, or any other lane. The real frontend handler path is deferred to #111, per the #82 owner ruling:
https://github.com/mist-agent-harness/mist-agent/issues/82#issuecomment-5390874712

## Independent review

The first clean-context review found:

- P1: accepted `workspaceId`/`cwd`/`agentPreset` values were silently ignored.
- P1: archived-window readers returned mutable internal authority objects.
- P2: `session-api.md` and the research wire-contract table claimed conflicting mappings.

All three were fixed with explicit stable `bad-request` issues, defensive deep copies plus cross-resident mutation tests, and a single documented three-endpoint source of truth.

A second clean-context review rechecked the full diff against `5bc032e`, returned zero P0/P1/P2/P3 findings, and judged it ready to submit.

## Verification

Passed:

- SessionRegistry targeted tests: 17/17
- Session adapter / real-host / RPC-schema / mock targeted tests: 44/44
- Root `tsc --noEmit`
- webui host aggregate TypeScript build
- Root targeted Biome lint
- webui targeted oxlint
- Acceptance: 6/6
- `git diff --check 5bc032e..HEAD`

Known local baseline noise:

- Root full suite has existing Windows `fsync`, chmod/mode, symlink-permission, and cascading timeout failures.
- Expanded webui suite includes existing missing `apps/web/dist` failures and an unrelated search stress timeout.
- Windows `core.autocrlf=true` causes repository-wide EOL format noise; the changed code passes lint and normalized formatting comparison.

Closes #82