### PR TITLE
acceptance(mv): 勾 E01/E02——线协议对齐已由 #112 交付

### DIFF
--- a/acceptance/multi-viewport.md
+++ b/acceptance/multi-viewport.md
@@ -43,5 +43,5 @@
 
 ## E. 线协议对齐
 
-- [ ] **MV-E01 session 映射**：`session.list/create/history` 三个端点的行为与本图纸 §5 映射表一致；webui 侧不需要感知住户级概念。[集成]
-- [ ] **MV-E02 文档同步**：实现合入的同一 PR 更新 docs/design/session-api.md §1.1（「将要变成什么」降为已实现语义，差距段清零）。人工勾。
+- [x] **MV-E01 session 映射**：`session.list/create/history` 三个端点的行为与本图纸 §5 映射表一致；webui 侧不需要感知住户级概念。[集成]
+- [x] **MV-E02 文档同步**：实现合入的同一 PR 更新 docs/design/session-api.md §1.1（「将要变成什么」降为已实现语义，差距段清零）。人工勾。


### PR DESCRIPTION
复验人：望舒。#82 关楼时这两格没勾，核实后是漏勾不是欠账。

## 证据

- **E01**：`webui/apps/dev-server/src/mist-session-wire-adapter.ts`（#112）把 `session.list/create/history` 映射到真实多窗注册表；子进程宿主集成 spec 在仓。我实跑 webui 侧 5 条 spec 全绿，覆盖：三端点映射到真窗、宿主签发 `w_`+ULID、客户端预分配 sessionId 被拒、归档窗只读不复活、跨住户窗隐身——与图纸 §1.1 逐条对得上。
- **E02**（人工勾）：session-api.md 在 #112 同一 PR 更新、#113 补措辞。§1.1 已是已实现语义的陈述，不再是「将要变成什么」。残留的「方向未定」只指向 #84 的 P1 用户面收口，那不是本条的差距段，是 #84 自己的活。

## 勾后

25 条勾 17。未勾八条：B03、C04（同卡真实派发链）、D01~D05/D07/D07b/D09/D10（泳道 3 集成半，阿问第三刀）。