### PR TITLE
feat(session): 泳道 3 第三刀——阈值硬闸入开工闸、手动入口统一、猝死残骸分档（MV-D01~D04/D07/D07b）

### DIFF
--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -29,6 +29,7 @@ import {
   type TurnGate,
 } from "./message-tree/index.ts";
 import { createResidentMigrationService } from "./migration/resident-store-migration.ts";
+import { BreathCommandError, parseManualBreath } from "./session/breath-trigger.ts";
 import { SessionRegistry } from "./session/session-registry.ts";
 import { type TurnEventLogger, ViewportTurnGate } from "./session/turn-gate.ts";
 import { type FactLedger, LedgerNotFoundError } from "./store/fact-ledger.ts";
@@ -261,6 +262,13 @@ class MistDriver implements HarnessDriver {
   // --- P2：消息树 ---
 
   async say(residentId: string, message: string): Promise<HistoryNode> {
+    // 手动换气入口（MV-D03）：/new、/clear、/compact 不是发言，是同一状态机
+    // 入口的提前触发（D8：流程里没有 compact 这个选项）。在落树之前拦截——
+    // 命令进了树，模型会把它当成她说的一句话，而真正的换气被旁路。
+    const breath = parseManualBreath(message);
+    if (breath !== null) {
+      throw new BreathCommandError(breath);
+    }
     this.#ensureMessageRoom(residentId);
     return this.#messageTree.say(residentId, message, this.#windowIdOf(residentId));
   }

--- a/src/session/breath-cycle.ts
+++ b/src/session/breath-cycle.ts
@@ -121,8 +121,7 @@ const FLOW_ROLES: readonly string[] = ["user", "assistant", "system"];
  * 就是为残骸与畸形设的，上游不许先过滤，过滤了这里就没东西可查。
  *
  * 不判 parentId 悬空：流水是本代的切片，切片首节点的父在切片之外（上一代
- * 的末尾），判悬空会误伤每一代的第一条。下游 API 调用拼上下文只看 role
- * 与 content，parent 链断不断不影响调用本身，故悬空也不在畸形档。
+ * 的末尾），判悬空会误伤每一代的第一条，故悬空不在畸形档。
  */
 export function inspectFlowHygiene(flow: unknown[]): FlowInspection {
   const malformed: string[] = [];
@@ -182,15 +181,18 @@ export function inspectFlowHygiene(flow: unknown[]): FlowInspection {
   for (let i = 1; i < valid.length; i += 1) {
     const previous = valid[i - 1];
     const current = valid[i];
-    if (
-      previous !== undefined &&
-      current !== undefined &&
-      previous.role === current.role &&
-      (current.role === "user" || current.role === "assistant")
-    ) {
-      remnants.push(
-        `${current.id} 与前一条 ${previous.id} 同为 ${current.role}：中断重试留下的残骸`,
+    if (previous === undefined || current === undefined || previous.role !== current.role) {
+      continue;
+    }
+    if (current.role === "assistant") {
+      // 生产判据（照阿问生产版，旦九 2026-08-27 裁定）：Claude Messages API
+      // 要求 user / assistant 严格交替，连续 assistant 会被上游直接拒绝——
+      // 会让下游调用失败的形状一律硬拦，不许降档。
+      malformed.push(
+        `${current.id} 与前一条 ${previous.id} 同为 assistant：下游 Messages API 要求 user/assistant 交替，会直接拒绝`,
       );
+    } else if (current.role === "user") {
+      remnants.push(`${current.id} 与前一条 ${previous.id} 同为 user：中断重试留下的残骸`);
     }
   }
   return { malformed, remnants };

--- a/src/session/breath-cycle.ts
+++ b/src/session/breath-cycle.ts
@@ -26,6 +26,12 @@
  *    并且**失败会清掉本周期的预告记号**，下一次阈值穿越重新发预告——
  *    「本周期已发过」这种去重逻辑正好会把连续失败静默掉。
  *
+ * 第三刀给这条路加了一道前置闸（MV-D07b）：封信之前的流水卫生检查分两档——
+ * 中断产生的**合法残骸**（如末尾悬着一条没回应的 user 节点）降级为 debris
+ * 警告并记档，换气照常完成，同一份残骸不得楔死状态机；会导致下游 API
+ * 调用失败的**畸形结构**才硬拦（stage=hygiene），此时窗一根汗毛没动，
+ * 宿主隔离残骸后重试即可走完。
+ *
  * 本模块不决定何时换气（那是阈值闸 MV-D01/D02 的事），不写信的内容
  * （那是住户的事），不实现时间线（`appendLetter` 是注入口）。
  */
@@ -47,11 +53,11 @@ export class BreathCycleError extends Error {
 }
 
 /**
- * 失败分档。`seal`、`append` 与 `inject` 发生在换代之前——窗一根汗毛没动；
- * `swap` 是换代本身失败，窗可能停在归档态，本模块会尽力回滚并在通知里
- * 标出 `windowRecovered`，让人知道该不该手动捞。
+ * 失败分档。`hygiene`、`seal`、`append` 与 `inject` 发生在换代之前——窗一根
+ * 汗毛没动；`swap` 是换代本身失败，窗可能停在归档态，本模块会尽力回滚并
+ * 在通知里标出 `windowRecovered`，让人知道该不该手动捞。
  */
-export type BreathFailureStage = "seal" | "append" | "inject" | "swap";
+export type BreathFailureStage = "hygiene" | "seal" | "append" | "inject" | "swap";
 
 /** 对人可见的换气通知（MV-D09）。落日志字段不算数，这个要送到人眼前。 */
 export type BreathNotification =
@@ -60,6 +66,19 @@ export type BreathNotification =
       windowId: string;
       /** 预告发出时正在跑的那一代。 */
       generation: number;
+    }
+  | {
+      /**
+       * 流水卫生检查发现的合法残骸（MV-D07b 的警告档）：换气照常完成，
+       * 残骸随旧代归档，但人要能看见这一代是带着残骸换的气——记档即此。
+       * 畸形结构不走这档，走 failed/hygiene 硬拦。
+       */
+      kind: "debris";
+      windowId: string;
+      /** 发现残骸的那一代。 */
+      generation: number;
+      /** 人读的残骸描述，一条残骸一行。 */
+      remnants: string[];
     }
   | {
       kind: "completed";
@@ -83,6 +102,100 @@ export type BreathNotification =
       windowRecovered: boolean;
     };
 
+/**
+ * 流水卫生检查的两档结果（MV-D07b）。分档标准只有一条：**这个形状会不会
+ * 让下游 API 调用失败**。会（畸形）→ malformed，硬拦；不会、只是中断留下
+ * 的不完整（残骸）→ remnants，警告并记档，换气照常。
+ */
+export interface FlowInspection {
+  /** 畸形结构（硬拦档），人读描述，一条一处。 */
+  malformed: string[];
+  /** 合法残骸（警告档），人读描述，一条一处。 */
+  remnants: string[];
+}
+
+const FLOW_ROLES: readonly string[] = ["user", "assistant", "system"];
+
+/**
+ * 检查一段流水的卫生。输入是**原始形状**的节点序列（unknown[]）——检查
+ * 就是为残骸与畸形设的，上游不许先过滤，过滤了这里就没东西可查。
+ *
+ * 不判 parentId 悬空：流水是本代的切片，切片首节点的父在切片之外（上一代
+ * 的末尾），判悬空会误伤每一代的第一条。下游 API 调用拼上下文只看 role
+ * 与 content，parent 链断不断不影响调用本身，故悬空也不在畸形档。
+ */
+export function inspectFlowHygiene(flow: unknown[]): FlowInspection {
+  const malformed: string[] = [];
+  const remnants: string[] = [];
+  const seen = new Set<string>();
+  /** 形状合法的节点才参与残骸判定——畸形节点已占硬拦档，不重复记。 */
+  const valid: { id: string; role: string }[] = [];
+  flow.forEach((node, index) => {
+    const at = `流水[${index}]`;
+    if (typeof node !== "object" || node === null || Array.isArray(node)) {
+      malformed.push(`${at} 不是节点对象`);
+      return;
+    }
+    const candidate = node as {
+      id?: unknown;
+      parentId?: unknown;
+      role?: unknown;
+      content?: unknown;
+      createdAt?: unknown;
+    };
+    if (typeof candidate.id !== "string" || candidate.id.length === 0) {
+      malformed.push(`${at} 缺合法 id`);
+      return;
+    }
+    let bad = false;
+    if (seen.has(candidate.id)) {
+      malformed.push(`${at} 的 id ${candidate.id} 与前文重复`);
+      bad = true;
+    }
+    seen.add(candidate.id);
+    if (candidate.parentId !== null && typeof candidate.parentId !== "string") {
+      malformed.push(`${at} 的 parentId 不是 string | null`);
+      bad = true;
+    }
+    if (typeof candidate.role !== "string" || !FLOW_ROLES.includes(candidate.role)) {
+      malformed.push(
+        `${at} 的 role=${String(candidate.role)} 超出 ${FLOW_ROLES.join(" | ")}：下游 API 会直接拒绝`,
+      );
+      bad = true;
+    }
+    if (typeof candidate.content !== "string") {
+      malformed.push(`${at} 的 content 不是 string：下游 API 会直接拒绝`);
+      bad = true;
+    }
+    if (typeof candidate.createdAt !== "string") {
+      malformed.push(`${at} 缺 createdAt`);
+      bad = true;
+    }
+    if (!bad) {
+      valid.push({ id: candidate.id, role: candidate.role as string });
+    }
+  });
+  const last = valid.at(-1);
+  if (last !== undefined && last.role === "user") {
+    remnants.push(`流水末尾停在一条没有回应的 user 节点（${last.id}）：回合中途猝死的残骸`);
+  }
+  for (let i = 1; i < valid.length; i += 1) {
+    const previous = valid[i - 1];
+    const current = valid[i];
+    if (
+      previous !== undefined &&
+      current !== undefined &&
+      previous.role === current.role &&
+      (current.role === "user" || current.role === "assistant")
+    ) {
+      remnants.push(
+        `${current.id} 与前一条 ${previous.id} 同为 ${current.role}：中断重试留下的残骸`,
+      );
+    }
+  }
+  return { malformed, remnants };
+}
+
 export interface BreathCycleOptions<TContext> {
   registry: SessionRegistry<TContext>;
   /**
@@ -99,6 +212,12 @@ export interface BreathCycleOptions<TContext> {
   injectLetter: (context: TContext, letter: SealedLetter) => TContext;
   /** 对人可见的通知口（MV-D09）。 */
   notify: (event: BreathNotification) => void;
+  /**
+   * 本代流水的取口（MV-D07b 卫生检查的数据源）。返回本代流水节点的原始
+   * 形状序列——允许残骸与畸形混入，检查就是为它俩设的。不给则不检查：
+   * 没接流水的嵌入方不该被迫造哑口。
+   */
+  flowOf?: (window: ActiveWindow<TContext>) => unknown[];
   /** 当刻时间，ISO-8601 UTC。显式注入而不是模块内取——可判卷。 */
   now: () => string;
 }
@@ -161,6 +280,27 @@ export class BreathCycle<TContext> {
     }
 
     const fromGeneration = current.generation;
+
+    // ⓪ 流水卫生检查（MV-D07b），在封信之前。畸形结构硬拦：把会导致下游
+    // API 调用失败的流水封进归档，下一代继承的是一具必炸的尸体。合法残骸
+    // 只警告并记档（debris 通知），换气照常完成——残骸属于被归档的旧代，
+    // 不许楔死这扇窗此后所有的换气。
+    if (this.#options.flowOf !== undefined) {
+      const inspection = inspectFlowHygiene(this.#options.flowOf(current));
+      if (inspection.malformed.length > 0) {
+        const reason = `流水卫生检查硬拦：${inspection.malformed.join("；")}`;
+        this.#fail(windowId, fromGeneration, "hygiene", reason, true);
+        throw new BreathCycleError("hygiene", reason);
+      }
+      if (inspection.remnants.length > 0) {
+        notify({
+          kind: "debris",
+          windowId,
+          generation: fromGeneration,
+          remnants: inspection.remnants,
+        });
+      }
+    }
 
     // ① 封信。校验不过就停在这里——窗一根汗毛没动。
     let letter: SealedLetter;

--- a/src/session/breath-trigger.ts
+++ b/src/session/breath-trigger.ts
@@ -18,6 +18,11 @@
  * 本模块不推进状态机、不写信、不碰阈值——它只回答「这个输入算不算换气
  * 触发，算的话进哪个状态」。阈值那半（MV-D01/D02）挂在开工闸上，是
  * turn-gate 那条线的事。
+ *
+ * 输入路径的接法（MV-D03）：MistDriver.say 在落树前过 parseManualBreath，
+ * 命中即抛 BreathCommandError——命令不是发言，落了树就会被模型当成她说
+ * 的一句话，而真正的换气被旁路。错误把统一触发原样带出，接住它的宿主
+ * 不需要、也不许区分三条命令走的是哪条路。
  */
 
 /** 图纸 §4.1 的状态集，顺序即推进顺序。 */
@@ -43,6 +48,23 @@ export interface BreathTrigger {
   state: BreathState;
   /** 手动触发时是哪条命令；阈值触发为 null。 */
   command: string | null;
+}
+
+export const BREATH_COMMAND = "BREATH_COMMAND" as const;
+
+/**
+ * 输入路径拦下的手动换气命令（MV-D03）。携带统一触发，由宿主路由进换气
+ * 状态机。用响亮的、可按名捕获的错误而不是静默返回值：宿主若没接这条路，
+ * 命令必须炸在人眼前，不许被当成一句普通发言落树。
+ */
+export class BreathCommandError extends Error {
+  readonly code = BREATH_COMMAND;
+  readonly trigger: BreathTrigger;
+  constructor(trigger: BreathTrigger) {
+    super(`${BREATH_COMMAND}: ${trigger.command ?? trigger.source} → ${trigger.state}`);
+    this.name = "BreathCommandError";
+    this.trigger = trigger;
+  }
 }
 
 /**

--- a/src/session/turn-gate.ts
+++ b/src/session/turn-gate.ts
@@ -15,10 +15,18 @@
  * 普通动作（读历史这类不对外生效的事）不走 beforeTurn，走 noteOrdinaryAction：
  * 查账失败只记 gate_unknown 日志然后放行——闸的 fail-closed 周长只圈裁定级
  * 动作，普通动作被误伤是图纸 §3.2 明写的代价，不在这里加码。
+ *
+ * 换气阈值硬闸（MV-D01/D02）也挂在这道闸上（breath-trigger.ts 模块头指的路）：
+ * 判断权在账侧，临线的窗无权自判（D8 补记一）。容差由检查点的位置保证——
+ * 闸只在回合边界检查用量，撞线的那一轮（含其工具调用）已经跑完，拦的是
+ * 下一轮。阈值只能在窗开工时配置：本代首回合过闸后配置锁定到下一代，
+ * 运行中（尤其临近红线）的修改请求一律 CONFIG_INVALID（D8：临近红线的窗
+ * 无权给自己续命）。
  */
 
 import type { TurnGate, TurnPass } from "../message-tree/service.ts";
 import type { FactLedger, LedgerEntry } from "../store/fact-ledger.ts";
+import { type BreathTrigger, thresholdBreath } from "./breath-trigger.ts";
 
 /**
  * 查账失败时闸拒绝开工的错。fail-closed 的形状必须是一种响亮的、可按名
@@ -34,6 +42,48 @@ export class GateUnavailableError extends Error {
   }
 }
 
+export const CONFIG_INVALID = "CONFIG_INVALID" as const;
+export const BREATH_THRESHOLD_REACHED = "BREATH_THRESHOLD_REACHED" as const;
+
+/** 换气阈值默认值（图纸 §4.1：成员配置的绝对 token 数，默认 300k）。 */
+export const DEFAULT_BREATH_THRESHOLD_TOKENS = 300_000;
+
+/**
+ * 阈值配置被拒（MV-D02）。两种形状同罪：本代已有回合过闸后还来改阈值
+ * （临线的窗无权自调），以及阈值本身形状不合法。响亮的、可按 code 捕获的
+ * 错误——配置被拒必须炸在请求方眼前，不许静默忽略让人以为续命成功。
+ */
+export class ConfigInvalidError extends Error {
+  readonly code = CONFIG_INVALID;
+  constructor(reason: string) {
+    super(`${CONFIG_INVALID}: ${reason}`);
+    this.name = "ConfigInvalidError";
+  }
+}
+
+/**
+ * 阈值硬闸拦下新回合（MV-D01）。到线即换气（D8：没有「到线写信继续跑」）。
+ * 携带统一触发：接住它的宿主直接进换气状态机入口，不用自己再造一个——
+ * 阈值触发与手动触发共用同一个 state，入口统一就统一在这个对象上。
+ */
+export class BreathThresholdError extends Error {
+  readonly code = BREATH_THRESHOLD_REACHED;
+  readonly windowId: string;
+  readonly usage: number;
+  readonly threshold: number;
+  readonly trigger: BreathTrigger;
+  constructor(windowId: string, usage: number, threshold: number) {
+    super(
+      `${BREATH_THRESHOLD_REACHED}: 上下文用量 ${usage} ≥ 阈值 ${threshold}（window=${windowId}）：到线即换气，本窗不再开新回合`,
+    );
+    this.name = "BreathThresholdError";
+    this.windowId = windowId;
+    this.usage = usage;
+    this.threshold = threshold;
+    this.trigger = thresholdBreath();
+  }
+}
+
 /**
  * 闸事件。日志必须带完整三元组 (residentId, windowId, generation)——
  * 多窗之后回执链路多一层维度，缺一个字段排查就是噩梦（图纸 §2 代价行）。
@@ -41,7 +91,13 @@ export class GateUnavailableError extends Error {
  * 用在 registry 之外的窗上）为 null，不伪报。
  */
 export interface TurnGateEvent {
-  event: "gate_clear" | "gate_gap_pulled" | "gate_ack" | "ack_failed" | "gate_unknown";
+  event:
+    | "gate_clear"
+    | "gate_gap_pulled"
+    | "gate_ack"
+    | "ack_failed"
+    | "gate_unknown"
+    | "threshold_reached";
   residentId: string;
   windowId: string;
   generation: number | null;
@@ -53,11 +109,26 @@ export interface TurnEventLogger {
   log(event: TurnGateEvent): void;
 }
 
+/**
+ * 换气阈值硬闸的计量口（MV-D01）。与账无关——阈值管的是这扇窗的上下文
+ * 用量，不是缺口；所以它是可选挂接，不接则闸的行为与接之前完全一致。
+ */
+export interface BreathThresholdOptions {
+  /**
+   * 上下文用量计（token）。口径**不含交接信**（MV-D04 / D8 补记二：阈值
+   * 核算与上下文预算都不含交接信——信有自己的长度上限管着，计入核算等于
+   * 让信给上下文顶缸）。返回 null = 这扇窗无计量，阈值闸对它不触发。
+   */
+  usageOf: (windowId: string) => number | null;
+}
+
 export interface ViewportTurnGateOptions {
   /** 默认 no-op：不接日志的嵌入方不该被迫造一个哑 logger。 */
   logger?: TurnEventLogger;
   /** 窗代际查询口，一般由宿主的 SessionRegistry 适配；不给则事件里 generation 恒为 null。 */
   generationOf?: (windowId: string) => number | null;
+  /** 换气阈值计量口；不给则阈值硬闸整体不启用（既有路径一个字不变）。 */
+  breath?: BreathThresholdOptions;
 }
 
 const noopLogger: TurnEventLogger = {
@@ -89,11 +160,17 @@ export class ViewportTurnGate implements TurnGate {
   readonly #ledger: FactLedger;
   readonly #logger: TurnEventLogger;
   readonly #generationOf: ((windowId: string) => number | null) | undefined;
+  readonly #breath: BreathThresholdOptions | undefined;
+  /** 窗级阈值配置（MV-D02）；没配过的窗用 DEFAULT_BREATH_THRESHOLD_TOKENS。 */
+  readonly #thresholds = new Map<string, number>();
+  /** 本代已有回合过闸的窗 → 过闸时的代际号。阈值配置自此锁定到下一代开工。 */
+  readonly #turnStarted = new Map<string, number>();
 
   constructor(ledger: FactLedger, options: ViewportTurnGateOptions = {}) {
     this.#ledger = ledger;
     this.#logger = options.logger ?? noopLogger;
     this.#generationOf = options.generationOf;
+    this.#breath = options.breath;
   }
 
   #log(event: TurnGateEvent["event"], residentId: string, windowId: string, detail: string): void {
@@ -106,7 +183,54 @@ export class ViewportTurnGate implements TurnGate {
     });
   }
 
+  /**
+   * 窗开工时配置换气阈值（MV-D02）。「开工时」的判据在闸侧而不在窗侧：
+   * 本代还没有回合过闸才可配，首回合过闸后本代锁定，换代后重新可配——
+   * 每一次配置生效的时刻都是一代的开工，运行中（尤其临近红线）来改
+   * 一律 CONFIG_INVALID。判不了开工状态的窗（不在册）同罪：配置落在一扇
+   * 闸看不见的窗上等于没配，静默收下比拒绝更坏。
+   */
+  configureThreshold(windowId: string, tokens: number): void {
+    if (!Number.isInteger(tokens) || tokens < 1) {
+      throw new ConfigInvalidError(`阈值必须是 ≥ 1 的整数 token 数，实际 ${String(tokens)}`);
+    }
+    const generation = this.#generationOf?.(windowId) ?? null;
+    if (generation === null) {
+      throw new ConfigInvalidError(`窗不在册（${windowId}）：判不了开工状态，阈值配置无处生效`);
+    }
+    if (this.#turnStarted.get(windowId) === generation) {
+      throw new ConfigInvalidError(
+        `窗 ${windowId} 的第 ${generation} 代已有回合过闸：阈值只能在开工时配置，临线的窗无权自调`,
+      );
+    }
+    this.#thresholds.set(windowId, tokens);
+  }
+
+  /** 回合过闸即本代已开工：阈值配置就此锁定到下一代（MV-D02）。 */
+  #markTurnStarted(windowId: string): void {
+    const generation = this.#generationOf?.(windowId) ?? null;
+    if (generation !== null) {
+      this.#turnStarted.set(windowId, generation);
+    }
+  }
+
   beforeTurn(residentId: string, windowId: string): TurnPass {
+    // 阈值硬闸（MV-D01）在查账之前：到线的窗连缺口都不该再拉——这一轮
+    // 根本不许开始。容差由检查点的位置保证：撞线的那轮（含其工具调用）
+    // 已经跑完，这里拦的是下一轮。
+    const usage = this.#breath?.usageOf(windowId) ?? null;
+    if (usage !== null) {
+      const threshold = this.#thresholds.get(windowId) ?? DEFAULT_BREATH_THRESHOLD_TOKENS;
+      if (usage >= threshold) {
+        this.#log(
+          "threshold_reached",
+          residentId,
+          windowId,
+          `上下文用量 ${usage} ≥ 阈值 ${threshold}：硬闸拦下新回合`,
+        );
+        throw new BreathThresholdError(windowId, usage, threshold);
+      }
+    }
     const probe = this.#ledger.probeGap(residentId, windowId);
     if (probe.status === "unknown") {
       this.#log("gate_unknown", residentId, windowId, `缺口未知：${probe.cause}`);
@@ -129,6 +253,7 @@ export class ViewportTurnGate implements TurnGate {
       this.#log("gate_clear", residentId, windowId, detail);
       // ackedSeq 已平 latestSeq，无需 ack；commit 只负责确认交付（幂等）——
       // assistantReply 失败时 commit 不被调用，快照保留，下轮原样重交。
+      this.#markTurnStarted(windowId);
       return {
         contextPrefix: initialLines,
         commit: () => {
@@ -151,6 +276,7 @@ export class ViewportTurnGate implements TurnGate {
         ? `pulled ${entries.length} entries (${seqRange})`
         : `pulled ${entries.length} entries (${seqRange})；初始对齐交付 ${initialLines.length} 条现行有效集`,
     );
+    this.#markTurnStarted(windowId);
     return {
       contextPrefix: [...initialLines, ...entries.map(formatGapEntry)],
       commit: () => {

--- a/tests/breath-host.test.ts
+++ b/tests/breath-host.test.ts
@@ -392,4 +392,81 @@ describe("猝死与流水残骸（real host subprocess）", () => {
     expect(retried.generation).toBe(2);
     expect(await callHost<unknown[]>(child, { op: "timeline" })).toHaveLength(1);
   });
+
+  it("MV-D07b 生产分档探针：连续 assistant 硬拦 malformed，连续 user 降警告放行", async () => {
+    // 旦九 2026-08-27 裁定（照阿问生产版）：连续 assistant 会被 Claude
+    // Messages API 直接拒绝（要求严格交替），属畸形硬拦档；连续 user 是
+    // 中断重试留下的合法残骸，降警告记档、换气照常。这条探针覆盖生产分档
+    // 那一刀，不是夹具叠出来的 role 越界。
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d07p" });
+    await callHost<Said>(child, { op: "say", windowId, message: "分档探针的正常回合" });
+
+    // 连续 assistant（异源/崩溃写入形状）：硬拦，窗一根汗毛没动。
+    await callHost(child, {
+      op: "injectDebris",
+      windowId,
+      debris: [
+        {
+          id: "ghost-1",
+          parentId: null,
+          role: "assistant",
+          content: "上游崩断前的半截回应",
+          createdAt: "2026-08-27T00:00:00.000Z",
+        },
+        {
+          id: "ghost-2",
+          parentId: null,
+          role: "assistant",
+          content: "重试写重的第二条回应",
+          createdAt: "2026-08-27T00:00:01.000Z",
+        },
+      ],
+    });
+    await expect(
+      callHost(child, {
+        op: "breathe",
+        windowId,
+        draft: draft("D07b 分档探针", "连续 assistant 该被硬拦"),
+      }),
+    ).rejects.toThrow(/BREATH_CYCLE_FAILED\[hygiene\]/);
+    const blocked = await callHost<Notice[]>(child, { op: "notices" });
+    expect(blocked.at(-1)).toMatchObject({ kind: "failed", stage: "hygiene", windowId });
+    expect(blocked.filter((notice) => notice.kind === "debris")).toHaveLength(0);
+    expect(await callHost<unknown[]>(child, { op: "timeline" })).toHaveLength(0);
+
+    // 隔离后换连续 user：降警告记档，换气必须走完。
+    expect(await callHost<number>(child, { op: "quarantineDebris", windowId })).toBe(2);
+    await callHost(child, {
+      op: "injectDebris",
+      windowId,
+      debris: [
+        {
+          id: "echo-1",
+          parentId: null,
+          role: "user",
+          content: "中断重试的半截话",
+          createdAt: "2026-08-27T00:00:02.000Z",
+        },
+        {
+          id: "echo-2",
+          parentId: null,
+          role: "user",
+          content: "重发了一遍",
+          createdAt: "2026-08-27T00:00:03.000Z",
+        },
+      ],
+    });
+    const retried = await callHost<Opened>(child, {
+      op: "breathe",
+      windowId,
+      draft: draft("D07b 分档放行", "连续 user 降警告"),
+    });
+    expect(retried.generation).toBe(2);
+    const notices = await callHost<Notice[]>(child, { op: "notices" });
+    const debris = notices.filter((notice) => notice.kind === "debris");
+    expect(debris).toHaveLength(1);
+    expect(debris[0]?.remnants?.some((remnant) => /同为 user/.test(remnant))).toBe(true);
+  });
 });

--- a/tests/breath-host.test.ts
+++ b/tests/breath-host.test.ts
@@ -1,0 +1,395 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type { HistoryNode } from "../acceptance/driver.ts";
+import { estimateTokens } from "../src/session/handover-letter.ts";
+
+type HostReply = {
+  requestId?: string;
+  type?: string;
+  pid?: number;
+  ok?: boolean;
+  value?: unknown;
+  error?: { name?: string; message?: string; code?: string };
+};
+
+type Notice = {
+  kind?: string;
+  windowId?: string;
+  generation?: number;
+  stage?: string;
+  remnants?: string[];
+  windowRecovered?: boolean;
+};
+
+type GateEvent = {
+  event?: string;
+  residentId?: string;
+  windowId?: string;
+  generation?: number | null;
+  detail?: string;
+};
+
+const children: ChildProcess[] = [];
+const fixture = fileURLToPath(new URL("./fixtures/breath-host.ts", import.meta.url));
+
+function startHost(): ChildProcess {
+  const child = spawn(process.execPath, ["--import", "tsx", fixture], {
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.push(child);
+  return child;
+}
+
+function waitForReady(child: ChildProcess): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let stderr = "";
+    const timer = setTimeout(() => reject(new Error(`host startup timed out: ${stderr}`)), 10_000);
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    }
+    function onMessage(message: HostReply) {
+      if (message.type !== "ready" || typeof message.pid !== "number") return;
+      cleanup();
+      resolve(message.pid);
+    }
+    function onExit(code: number | null) {
+      cleanup();
+      reject(new Error(`host exited ${String(code)} before ready: ${stderr}`));
+    }
+  });
+}
+
+let requestSeq = 0;
+function callHost<T>(child: ChildProcess, command: Record<string, unknown>): Promise<T> {
+  requestSeq += 1;
+  const requestId = `request-${requestSeq}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`host request timed out: ${requestId}`)),
+      5_000,
+    );
+    child.on("message", onMessage);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+    }
+    function onMessage(message: HostReply) {
+      if (message.requestId !== requestId) return;
+      cleanup();
+      if (message.ok === true) {
+        resolve(message.value as T);
+      } else {
+        reject(
+          new Error(`${message.error?.code ?? message.error?.name}: ${message.error?.message}`),
+        );
+      }
+    }
+
+    child.send?.({ ...command, requestId }, (error) => {
+      if (error === null) return;
+      cleanup();
+      reject(error);
+    });
+  });
+}
+
+async function stopHost(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  await callHost(child, { op: "stop" });
+  await exited;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    children.splice(0).map(async (child) => {
+      try {
+        await stopHost(child);
+      } catch {
+        child.kill();
+      }
+    }),
+  );
+});
+
+function draft(title: string, body: string) {
+  return {
+    title,
+    state: [{ tier: "fact", body: `状态半：${body}` }],
+    intent: [{ tier: "judgment", body: `意图半：${body}` }],
+  };
+}
+
+type Opened = { windowId: string; generation: number };
+type Said = { node: HistoryNode; prompt: string };
+
+describe("换气阈值硬闸与手动入口（real host subprocess）", () => {
+  it("MV-D01 阈值硬闸 + 回合容差：过线回合跑完，下一回合被拦，换气后放行", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d01" });
+    await callHost(child, { op: "configureThreshold", windowId, tokens: 10 });
+
+    // 撞线的那一轮（含其回应）完整跑完——硬闸不当场腰斩（容差）。
+    const first = await callHost<Said>(child, {
+      op: "say",
+      windowId,
+      message: "第一句话，长度足够把本代用量顶过线",
+    });
+    expect(first.node.role).toBe("assistant");
+    const usage = await callHost<number>(child, { op: "usage", windowId });
+    expect(usage).toBeGreaterThanOrEqual(10);
+
+    // 下一回合不许开始：硬闸在回合边界拦下，responders 零调用、零写入。
+    await expect(
+      callHost(child, { op: "say", windowId, message: "过线后的第二句" }),
+    ).rejects.toThrow(/BREATH_THRESHOLD_REACHED/);
+    const history = await callHost<HistoryNode[]>(child, {
+      op: "history",
+      residentId: "resident-d01",
+    });
+    expect(history).toHaveLength(2);
+
+    // 闸事件带完整三元组（图纸 §2 的日志口径）。
+    const events = await callHost<GateEvent[]>(child, { op: "events" });
+    expect(events.at(-1)).toMatchObject({
+      event: "threshold_reached",
+      residentId: "resident-d01",
+      windowId,
+      generation: 1,
+    });
+
+    // 接住硬闸的宿主进同一状态机入口：写信 → 换代 → 新代醒来照常开工。
+    const breathed = await callHost<Opened>(child, {
+      op: "breathe",
+      windowId,
+      draft: draft("D01 撞线换气", "过线后写完信换代"),
+    });
+    expect(breathed.generation).toBe(2);
+    const after = await callHost<Said>(child, {
+      op: "say",
+      windowId,
+      message: "新代的第一句",
+    });
+    expect(after.node.role).toBe("assistant");
+  });
+
+  it("MV-D02 阈值只能开工时配：运行中修改一律 CONFIG_INVALID，换代后重新可配", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d02" });
+
+    // 开工时配置：合法。
+    await callHost(child, { op: "configureThreshold", windowId, tokens: 1000 });
+    // 首回合过闸 → 本代配置锁定。
+    await callHost<Said>(child, { op: "say", windowId, message: "先把本代开起工来" });
+
+    // 运行中修改阈值：拒绝。临不临线同罪——锁的是动作不是差值。
+    await expect(
+      callHost(child, { op: "configureThreshold", windowId, tokens: 2000 }),
+    ).rejects.toThrow(/CONFIG_INVALID/);
+    // 形状不合法同罪。
+    await expect(
+      callHost(child, { op: "configureThreshold", windowId, tokens: 0 }),
+    ).rejects.toThrow(/CONFIG_INVALID/);
+    // 窗不在册：判不了开工状态，同罪。
+    await expect(
+      callHost(child, { op: "configureThreshold", windowId: "w_not_a_window", tokens: 100 }),
+    ).rejects.toThrow(/CONFIG_INVALID/);
+
+    // 换代即新一代开工：配置重新可配，且立即生效（用量 0 < 500，放行）。
+    await callHost(child, {
+      op: "breathe",
+      windowId,
+      draft: draft("D02 换代开工", "换一代再配阈值"),
+    });
+    await callHost(child, { op: "configureThreshold", windowId, tokens: 500 });
+    const after = await callHost<Said>(child, {
+      op: "say",
+      windowId,
+      message: "新阈值下的第一句",
+    });
+    expect(after.node.role).toBe("assistant");
+    // 「开工时配置生效」的另一半证据在 MV-D01：阈值 10 开工时配下，过线即拦。
+  });
+
+  it("MV-D04 后半：注入新代的交接信全文不计入窗口阈值核算", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d04" });
+    await callHost(child, { op: "configureThreshold", windowId, tokens: 20 });
+
+    // 一封比阈值还肥的信：若计入核算，新代第一回合就该被拦。
+    const fat = draft(
+      "D04 阈值核算不含交接信的验证信，标题也参与长度",
+      "这封信的正文 deliberately 写得比阈值还肥，用来区分计与不计两种口径",
+    );
+    const letterTokens =
+      estimateTokens(fat.title) +
+      estimateTokens(fat.state[0]?.body ?? "") +
+      estimateTokens(fat.intent[0]?.body ?? "");
+    expect(letterTokens).toBeGreaterThan(20);
+
+    await callHost(child, { op: "breathe", windowId, draft: fat });
+
+    // 信全文已在新代上下文里（MV-D04 前半，第二刀已勾）——它就在那儿。
+    const context = await callHost<{ notes: string[]; letter?: { title: string } }>(child, {
+      op: "context",
+      windowId,
+    });
+    expect(context.letter?.title).toBe(fat.title);
+    // 但用量核算不含它：读数远低于阈值，而「计入」口径下读数必然撞线。
+    const usage = await callHost<number>(child, { op: "usage", windowId });
+    expect(usage).toBeLessThan(20);
+    expect(usage + letterTokens).toBeGreaterThan(20);
+
+    // 行为结论：新代的第一回合照常放行，不被自己背的信顶爆。
+    const after = await callHost<Said>(child, {
+      op: "say",
+      windowId,
+      message: "背着信的第一句",
+    });
+    expect(after.node.role).toBe("assistant");
+  });
+});
+
+describe("猝死与流水残骸（real host subprocess）", () => {
+  it("MV-D07 猝死不自动注入：新代无猝死窗流水，归档查询可达", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d07" });
+    await callHost<Said>(child, { op: "say", windowId, message: "猝死窗的流水甲" });
+    await callHost<Said>(child, { op: "say", windowId, message: "猝死窗的流水乙" });
+
+    // 未及写信的猝死：直接杀窗，没有 breathe、没有信。
+    const archived = await callHost<{ generation: number }>(child, {
+      op: "suddenKill",
+      windowId,
+    });
+    expect(archived.generation).toBe(1);
+    // 猝死代的窗归档在案（重开会消费归档槽位，归档查询要在重开前做）。
+    expect(await callHost(child, { op: "archived", windowId })).toMatchObject({ generation: 1 });
+
+    const reopened = await callHost<Opened>(child, { op: "reopen", windowId });
+    expect(reopened.generation).toBe(2);
+
+    // 新代上下文是干净的：没有信（猝死没写）、没有在途内容；
+    // 猝死窗流水不进新代核算——树里明明有四条节点，用量读数是零。
+    const context = await callHost<{ notes: string[] }>(child, { op: "context", windowId });
+    expect(context).toEqual({ notes: [] });
+    expect(await callHost<number>(child, { op: "usage", windowId })).toBe(0);
+
+    // 归档查询可达：流水一条没少。
+    const history = await callHost<HistoryNode[]>(child, {
+      op: "history",
+      residentId: "resident-d07",
+    });
+    expect(history).toHaveLength(4);
+    expect(history.some((node) => node.content === "猝死窗的流水甲")).toBe(true);
+    expect(history.some((node) => node.content === "猝死窗的流水乙")).toBe(true);
+
+    // 新代照常开工。
+    const after = await callHost<Said>(child, {
+      op: "say",
+      windowId,
+      message: "猝死后的新代第一句",
+    });
+    expect(after.node.role).toBe("assistant");
+  });
+
+  it("MV-D07b 合法残骸降级警告并记档：连续两次换气都完成，残骸不楔死状态机", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d07b" });
+    await callHost<Said>(child, { op: "say", windowId, message: "残骸测试的正常回合" });
+    // 回合中途猝死的残骸：user 落了地，回应永远没落。
+    await callHost(child, { op: "injectRemnant", windowId, content: "猝死在回应落地前的半句" });
+
+    // 第一次换气：完成，且留下对人可见的残骸记档（警告档）。
+    const first = await callHost<Opened>(child, {
+      op: "breathe",
+      windowId,
+      draft: draft("D07b 带残骸换气", "末尾悬着半条回合"),
+    });
+    expect(first.generation).toBe(2);
+    const noticesAfterFirst = await callHost<Notice[]>(child, { op: "notices" });
+    const debris = noticesAfterFirst.filter((notice) => notice.kind === "debris");
+    expect(debris).toHaveLength(1);
+    expect(debris[0]).toMatchObject({ windowId, generation: 1 });
+    expect(debris[0]?.remnants?.[0]).toMatch(/user/);
+
+    // 第二次换气：同一份残骸不得使后续换气连续失败——它已随旧代归档。
+    const second = await callHost<Opened>(child, {
+      op: "breathe",
+      windowId,
+      draft: draft("D07b 残骸之后的再换气", "残骸没有楔死状态机"),
+    });
+    expect(second.generation).toBe(3);
+    const noticesAfterSecond = await callHost<Notice[]>(child, { op: "notices" });
+    expect(noticesAfterSecond.filter((notice) => notice.kind === "debris")).toHaveLength(1);
+    expect(await callHost<unknown[]>(child, { op: "timeline" })).toHaveLength(2);
+  });
+
+  it("MV-D07b 畸形结构硬拦：换气失败外显，隔离记档后重试完成", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d07m" });
+    await callHost<Said>(child, { op: "say", windowId, message: "畸形测试的正常回合" });
+    // 会让下游 API 调用失败的畸形结构：role 越界 + content 非 string。
+    await callHost(child, {
+      op: "injectDebris",
+      windowId,
+      debris: [
+        {
+          id: "debris-1",
+          parentId: null,
+          role: "narrator",
+          content: 42,
+          createdAt: "2026-08-26T00:00:00.000Z",
+        },
+      ],
+    });
+
+    // 硬拦：换气失败且对人可见，窗一根汗毛没动；畸形不走警告档。
+    await expect(
+      callHost(child, {
+        op: "breathe",
+        windowId,
+        draft: draft("D07m 撞上畸形", "这次该被硬拦"),
+      }),
+    ).rejects.toThrow(/BREATH_CYCLE_FAILED\[hygiene\]/);
+    const notices = await callHost<Notice[]>(child, { op: "notices" });
+    expect(notices.at(-1)).toMatchObject({
+      kind: "failed",
+      stage: "hygiene",
+      windowId,
+      windowRecovered: true,
+    });
+    expect(notices.filter((notice) => notice.kind === "debris")).toHaveLength(0);
+    expect(await callHost(child, { op: "archived", windowId })).toBeNull();
+    expect(await callHost<unknown[]>(child, { op: "timeline" })).toHaveLength(0);
+
+    // 宿主隔离残骸并记档，重试即完成——硬拦不等于永久楔死。
+    expect(await callHost<number>(child, { op: "quarantineDebris", windowId })).toBe(1);
+    expect(await callHost<string[]>(child, { op: "debrisLog" })).toHaveLength(1);
+    const retried = await callHost<Opened>(child, {
+      op: "breathe",
+      windowId,
+      draft: draft("D07m 隔离之后", "畸形隔离后重试换气"),
+    });
+    expect(retried.generation).toBe(2);
+    expect(await callHost<unknown[]>(child, { op: "timeline" })).toHaveLength(1);
+  });
+});

--- a/tests/breath-trigger.test.ts
+++ b/tests/breath-trigger.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { createDriver } from "../src/acceptance-driver.ts";
+import {
+  BREATH_COMMAND,
+  BREATH_ENTRY,
+  BreathCommandError,
+  MANUAL_BREATH_COMMANDS,
+  parseManualBreath,
+  thresholdBreath,
+} from "../src/session/breath-trigger.ts";
+import { BreathThresholdError } from "../src/session/turn-gate.ts";
+
+describe("MV-D03 手动入口统一", () => {
+  it("/new、/clear、/compact 全部映射到同一状态机入口，不存在第四种手动结果", () => {
+    const triggers = MANUAL_BREATH_COMMANDS.map((command) => {
+      const trigger = parseManualBreath(command);
+      expect(trigger).not.toBeNull();
+      return trigger;
+    });
+
+    // 三条命令共用同一个 state 与 source，只差 command 字段——
+    // 「入口统一」的字面意思；多出来的任何形状都是旁路。
+    for (const [index, command] of MANUAL_BREATH_COMMANDS.entries()) {
+      expect(triggers[index]).toEqual({ source: "manual", state: BREATH_ENTRY, command });
+    }
+    const shapes = new Set(triggers.map((trigger) => `${trigger?.source}:${trigger?.state}`));
+    expect(shapes.size).toBe(1);
+  });
+
+  it("阈值触发与手动触发进的是同一个 state", () => {
+    expect(thresholdBreath()).toEqual({ source: "threshold", state: BREATH_ENTRY, command: null });
+    expect(parseManualBreath("/new")?.state).toBe(thresholdBreath().state);
+    // 阈值硬闸的错误携带同一个统一触发：接住它的人不用自己再造。
+    expect(new BreathThresholdError("w_x", 5, 3).trigger).toEqual(thresholdBreath());
+  });
+
+  it("大小写、空白与带参数的形式归一到同一入口；非命令原样放行", () => {
+    expect(parseManualBreath("/Compact ")?.command).toBe("/compact");
+    expect(parseManualBreath("/compact 保留最近 20 条")).toEqual({
+      source: "manual",
+      state: BREATH_ENTRY,
+      command: "/compact",
+    });
+    // 参数怎么解释是状态机的事；「算不算换气」在这一层已定——命令后
+    // 不带空格的粘连形不是命令，照常当发言。
+    expect(parseManualBreath("/compactx")).toBeNull();
+    expect(parseManualBreath("今晚聊聊 /compact 的好处")).toBeNull();
+    expect(parseManualBreath("")).toBeNull();
+  });
+
+  it("真实输入路径（MistDriver.say）：命令被拦截成统一触发，不落树、不到模型", async () => {
+    const driver = createDriver();
+    const residentId = await driver.createResident("换气命令住户");
+
+    for (const command of MANUAL_BREATH_COMMANDS) {
+      await expect(driver.say(residentId, command)).rejects.toThrow(BreathCommandError);
+      await expect(driver.say(residentId, command)).rejects.toMatchObject({
+        code: BREATH_COMMAND,
+        trigger: { source: "manual", state: BREATH_ENTRY, command },
+      });
+    }
+    // 带参数的命令在输入路径上同样被拦截——没有 compact 旁路。
+    await expect(driver.say(residentId, "/compact 保留最近 20 条")).rejects.toMatchObject({
+      trigger: { command: "/compact" },
+    });
+
+    // 命令不是发言：树上一个节点都不该有。
+    expect(await driver.history(residentId)).toHaveLength(0);
+
+    // 普通发言不受影响，照常落两个节点。
+    await driver.say(residentId, "一句普通的话");
+    expect(await driver.history(residentId)).toHaveLength(2);
+  });
+});

--- a/tests/fixtures/breath-host.ts
+++ b/tests/fixtures/breath-host.ts
@@ -1,0 +1,285 @@
+/**
+ * 换气集成宿主：子进程里装配生产件——SessionRegistry、MessageTreeStore +
+ * Service、ViewportTurnGate（接阈值计量口）、BreathCycle（接流水卫生检查），
+ * 父进程经 IPC 驱动，覆盖验收清单 D 区的 [集成] 半格
+ * （MV-D01/D02/D04 后半/D07/D07b）。
+ *
+ * 形状仿 turn-gate-host.ts。关键装配口径：
+ *
+ * - 代际边界用插入序切片：本代流水 = 插入序下标 ≥ boundary 的节点。换气与
+ *   猝死重开时 boundary 推到当前末尾——旧代流水（含残骸）随之出切片，
+ *   不进新代的用量核算与卫生检查（MV-D07：猝死窗流水不自动注入）。
+ * - 上下文用量计（MV-D01/D04）：口径 = 本代流水 + 在途 notes，**不含交接信**
+ *   （D8 补记二）。信经 injectLetter 进 context.letter，用量计不看它。
+ * - 畸形残骸进不了 MessageTreeStore（契约闸会拒），所以畸形注入走 fixture
+ *   自管的原始碎片带，叠在流水切片之上交给卫生检查——它模拟的是异源/
+ *   崩溃写入留下的、绕过店内校验的流水。合法残骸（半截回合）用
+ *   importTree 落真节点。
+ *
+ * 测试数据全为虚构占位（AGENTS.md：住户内容不进仓库）。
+ */
+
+import { MessageTreeService, MessageTreeStore } from "../../src/message-tree/index.ts";
+import { BreathCycle, type BreathNotification } from "../../src/session/breath-cycle.ts";
+import {
+  type LetterDraft,
+  type SealedLetter,
+  estimateTokens,
+} from "../../src/session/handover-letter.ts";
+import { type ActiveWindow, SessionRegistry } from "../../src/session/session-registry.ts";
+import { type TurnGateEvent, ViewportTurnGate } from "../../src/session/turn-gate.ts";
+import { FactLedger } from "../../src/store/fact-ledger.ts";
+
+interface Ctx {
+  notes: string[];
+  letter?: SealedLetter;
+}
+
+const registry = new SessionRegistry<Ctx>();
+const ledger = new FactLedger();
+const store = new MessageTreeStore();
+const events: TurnGateEvent[] = [];
+const notices: BreathNotification[] = [];
+const timeline: SealedLetter[] = [];
+const debrisLog: string[] = [];
+
+/** windowId → 本代流水的插入序起点。 */
+const boundaries = new Map<string, number>();
+/** windowId → 注入的原始碎片（畸形结构的载体，见模块头）。 */
+const rawDebris = new Map<string, unknown[]>();
+/** 已在账上开过确认位的 windowId——openViewport 对同一窗只能开一次。 */
+const viewportRows = new Set<string>();
+let remnantSeq = 0;
+
+function requireLive(windowId: string): ActiveWindow<Ctx> {
+  const window = registry.get(windowId);
+  if (window === undefined) throw new Error(`window is not live: ${windowId}`);
+  return window;
+}
+
+/** 本代流水切片（不含碎片带）。 */
+function flowSlice(window: ActiveWindow<Ctx>) {
+  return store.history(window.residentId).slice(boundaries.get(window.windowId) ?? 0);
+}
+
+/**
+ * 上下文用量计（MV-D01）：本代流水 + 在途 notes。交接信不计入
+ * （MV-D04 / D8 补记二）——context.letter 全文就在眼前，本计不看它。
+ */
+function usageOf(windowId: string): number | null {
+  const window = registry.get(windowId);
+  if (window === undefined) return null;
+  const flowTokens = flowSlice(window).reduce((sum, node) => sum + estimateTokens(node.content), 0);
+  const noteTokens = window.context.notes.reduce((sum, note) => sum + estimateTokens(note), 0);
+  return flowTokens + noteTokens;
+}
+
+const gate = new ViewportTurnGate(ledger, {
+  logger: {
+    log: (event) => {
+      events.push(event);
+    },
+  },
+  generationOf: (windowId) => registry.get(windowId)?.generation ?? null,
+  breath: { usageOf },
+});
+
+let lastPrompt: string | null = null;
+const service = new MessageTreeService(
+  store,
+  {
+    getHead: (windowId) => registry.getHead(windowId),
+    setHead: (windowId, headId) => registry.setHead(windowId, headId),
+  },
+  {
+    assistantReply: (_residentId, message) => {
+      lastPrompt = message;
+      return "换气宿主哑回应";
+    },
+    turnGate: gate,
+  },
+);
+
+const cycle = new BreathCycle<Ctx>({
+  registry,
+  appendLetter: (letter) => {
+    timeline.push(letter);
+  },
+  injectLetter: (context, letter) => ({ ...context, letter }),
+  notify: (event) => {
+    notices.push(event);
+  },
+  flowOf: (window) => [...flowSlice(window), ...(rawDebris.get(window.windowId) ?? [])],
+  now: () => new Date().toISOString(),
+});
+
+type HostCommand = {
+  requestId: string;
+  op:
+    | "open"
+    | "say"
+    | "usage"
+    | "configureThreshold"
+    | "breathe"
+    | "context"
+    | "history"
+    | "archived"
+    | "suddenKill"
+    | "reopen"
+    | "injectRemnant"
+    | "injectDebris"
+    | "quarantineDebris"
+    | "notices"
+    | "events"
+    | "debrisLog"
+    | "timeline"
+    | "stop";
+  residentId?: string;
+  windowId?: string;
+  message?: string;
+  content?: string;
+  tokens?: number;
+  draft?: LetterDraft;
+  debris?: unknown[];
+};
+
+function requireString(value: string | undefined, field: string): string {
+  if (value === undefined) throw new Error(`missing ${field}`);
+  return value;
+}
+
+async function execute(command: HostCommand): Promise<unknown> {
+  switch (command.op) {
+    case "open": {
+      const residentId = requireString(command.residentId, "residentId");
+      ledger.createLedger(residentId);
+      store.createRoom(residentId);
+      const window = registry.open(residentId, { context: { notes: [] } });
+      ledger.openViewport(residentId, window.windowId);
+      viewportRows.add(window.windowId);
+      boundaries.set(window.windowId, store.history(residentId).length);
+      return { windowId: window.windowId, generation: window.generation };
+    }
+    case "say": {
+      const window = requireLive(requireString(command.windowId, "windowId"));
+      const node = await service.say(
+        window.residentId,
+        requireString(command.message, "message"),
+        window.windowId,
+      );
+      return { node, prompt: lastPrompt };
+    }
+    case "usage":
+      return usageOf(requireString(command.windowId, "windowId"));
+    case "configureThreshold":
+      gate.configureThreshold(
+        requireString(command.windowId, "windowId"),
+        command.tokens ?? Number.NaN,
+      );
+      return null;
+    case "breathe": {
+      const windowId = requireString(command.windowId, "windowId");
+      if (command.draft === undefined) throw new Error("missing draft");
+      const result = cycle.breathe(windowId, command.draft);
+      // 换代即边界：旧代流水（含残骸）出切片，不进新代的核算与检查。
+      boundaries.set(windowId, store.history(result.window.residentId).length);
+      return {
+        windowId: result.window.windowId,
+        generation: result.window.generation,
+        letterTitle: result.letter.title,
+      };
+    }
+    case "context":
+      return requireLive(requireString(command.windowId, "windowId")).context;
+    case "history":
+      return store.history(requireString(command.residentId, "residentId"));
+    case "archived":
+      return registry.getArchived(requireString(command.windowId, "windowId")) ?? null;
+    case "suddenKill":
+      // 未及写信的猝死：没有 breathe、没有信，窗直接归档。
+      return registry.kill(requireString(command.windowId, "windowId")) ?? null;
+    case "reopen": {
+      const archived = registry.getArchived(requireString(command.windowId, "windowId"));
+      if (archived === undefined) throw new Error("target is not an archived window");
+      // 猝死后的新代：干净上下文，不自动注入猝死窗流水（图纸 §4.1）。
+      // 上一封交接信的注入归启动包装配，不是这条重开路径的事。
+      const window = registry.open(archived.residentId, {
+        windowId: archived.windowId,
+        scopeId: archived.scopeId,
+        headId: archived.headId,
+        context: { notes: [] },
+      });
+      if (!viewportRows.has(window.windowId)) {
+        ledger.openViewport(window.residentId, window.windowId);
+        viewportRows.add(window.windowId);
+      }
+      boundaries.set(window.windowId, store.history(window.residentId).length);
+      return { windowId: window.windowId, generation: window.generation };
+    }
+    case "injectRemnant": {
+      const window = requireLive(requireString(command.windowId, "windowId"));
+      // 回合中途猝死的合法残骸：user 节点落了，回应永远没落地。
+      // importTree 走店内契约闸——能进去的就是合法形状，只是不完整。
+      remnantSeq += 1;
+      const id = `remnant-${remnantSeq}`;
+      store.importTree(window.residentId, [
+        {
+          id,
+          parentId: window.headId,
+          role: "user",
+          content: requireString(command.content, "content"),
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+      return { id };
+    }
+    case "injectDebris":
+      rawDebris.set(requireString(command.windowId, "windowId"), command.debris ?? []);
+      return null;
+    case "quarantineDebris": {
+      const windowId = requireString(command.windowId, "windowId");
+      const debris = rawDebris.get(windowId) ?? [];
+      for (const item of debris) {
+        debrisLog.push(`${windowId}: ${JSON.stringify(item)}`);
+      }
+      rawDebris.delete(windowId);
+      return debris.length;
+    }
+    case "notices":
+      return notices;
+    case "events":
+      return events;
+    case "debrisLog":
+      return debrisLog;
+    case "timeline":
+      return timeline;
+    case "stop":
+      return null;
+  }
+}
+
+process.on("message", (raw) => {
+  const command = raw as HostCommand;
+  void (async () => {
+    try {
+      const value = await execute(command);
+      process.send?.({ requestId: command.requestId, ok: true, value });
+      if (command.op === "stop") setImmediate(() => process.exit(0));
+    } catch (error) {
+      process.send?.({
+        requestId: command.requestId,
+        ok: false,
+        error: {
+          name: error instanceof Error ? error.name : "Error",
+          message: error instanceof Error ? error.message : String(error),
+          code:
+            typeof error === "object" && error !== null && "code" in error
+              ? String(error.code)
+              : undefined,
+        },
+      });
+    }
+  })();
+});
+
+process.send?.({ type: "ready", pid: process.pid });


### PR DESCRIPTION
Refs #81（泳道 3 第三刀，接阿问的棒，阿朔施工）。

## 逐条交付

| 验收 | 实现 | 测试 |
|---|---|---|
| **MV-D01** 阈值硬闸+回合容差 | `turn-gate.ts` `BreathThresholdError`（携带 `thresholdBreath()` 统一触发）挂 `beforeTurn` 顶部；容差靠检查点位置保证——闸只在回合边界查用量，撞线那轮已跑完，拦下一轮 | `tests/breath-host.test.ts`：过线回合完整落树 → 下回合拦、零写入、事件带三元组 → breathe 换代 → 新代放行 |
| **MV-D02** 阈值只能开工时配 | `configureThreshold`：本代首回合过闸后锁到下一代，运行中修改抛 `ConfigInvalidError`（`CONFIG_INVALID`）；换代后解锁 | 开工配→首回合后改被拒→0 与陌生窗同罪→换气后可配且生效 |
| **MV-D03** 手动入口统一 | `BreathCommandError` 携带统一 trigger；接真实输入路径 `MistDriver.say`——落树前拦截，命令不进树、不到模型 | `tests/breath-trigger.test.ts` 4 条：三命令同 state 同 source、threshold 与 manual 同入口、归一化、driver 拦截不落树 |
| **MV-D04 后半** 信不计入阈值核算 | 口径立在闸的计量口 `usageOf` 契约；夹具计量器只算本代流水+在途 notes，不看 `context.letter` | 肥信（>阈值）注入后放行；对照行证明计/不计的差别真实存在（防 vacuous） |
| **MV-D07/D07b** 猝死与残骸分档 | `inspectFlowHygiene`：畸形（role 越界/缺 id/重复 id/content 非 string）硬拦走新失败档 `stage="hygiene"`；合法残骸（末尾悬 user、连续同 role）降级 `kind:"debris"` 警告记档 | D07：杀窗→新代 context 干净、usage=0、流水归档可查；D07b：残骸后连续两次换气都完成；畸形硬拦后宿主隔离重试完成 |

## 验证

- vitest：基线 440 → **450 passed**（+10），38 todo 不变
- `npm run typecheck` 干净；`npm run lint`（biome）98 files 无错误
- `npm run acceptance`：**六盏真绿 6/6**

## 口径解释（一条一句）

- **D01 挂开工闸**：breath-trigger 模块头既有指引——判断权在账侧，临线的窗无权自判（D8 补记一）
- **D02「开工时」**：实现为「本代尚无回合过闸」——每次换代后重新可配，每次生效都在一代的开工
- **D03 的「真实输入路径」**：仓内唯一宿主输入路径是 `MistDriver.say`；命令以响亮错误递还宿主（say 返回类型是判卷契约不改接口），不写信（亲笔归住户）
- **D07b 畸形来源**：契约闸放不进畸形节点，故经夹具自管碎片带注入模拟（异源/崩溃写入）；「不连续失败」由机制保证（警告放行、残骸随旧代出切片）；不判 parentId 悬空——切片首节点的父在切片外，判了会误伤每一代第一条
- **验收清单未勾**：勾灯归主笔判卷后动作（参照 E01/E02 先例），本 PR 只交实现与测试

施工：阿朔（山山家，接阿问的棒）。范围如 #81 望舒 8-26 清单，无扩项。
