### PR TITLE
feat: add canonical resident stream core

### DIFF
--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -27,7 +27,7 @@
 每条带主证据形式。标 [集成] 的测试真实启动宿主并可注入断线、猝死和重试；
 标 [协议/客户端] 的测试同时检查能力授权与第一方 read model。
 
-- [ ] **OS-01 两个 viewport 只长一条有序主流** [集成]：同一 resident 的 viewport A、
+- [x] **OS-01 两个 viewport 只长一条有序主流** [集成]：同一 resident 的 viewport A、
   B 并发产生两个合法事件；桌面与手机最终得到相同的 canonical `eventId` 集合和相同
   顺序。第三个客户端在两事件发生期间离线，重连后得到同一集合与顺序且无重复。
   测试交换 A、B 的到达次序重复运行；不要求某一 viewport 固定先赢，只要求主流 writer
@@ -36,11 +36,20 @@
   效果语义必须逐项等价，只有明确声明的投影层展示元数据可排除。保留相同 id/顺序却改了
   payload 仍判红。任一 viewport 的局部 transcript 都不得成为第二个权威源。
 
-- [ ] **OS-02 猝死重放至多入流一次，回执不冒充生效** [集成]：对同一投递分别在
+  证据：`tests/one-stream-host.test.ts` 通过真实子进程宿主交换 A/B 到达顺序，并核对 desktop、
+  mobile、offline 三个投影的完整事件、顺序与 payload hash；`tests/one-stream-core.test.ts`
+  保留同一 id/seq 后篡改 payload，投影校验会 fail-closed。
+
+- [x] **OS-02 猝死重放至多入流一次，回执不冒充生效** [集成]：对同一投递分别在
   “生成后、主流写入前”和“主流写入后、回执前”杀死宿主，再恢复并重试。最终 canonical
   stream 中该投递恰有一条；同一幂等把手换内容重试必须拒绝。未取得真实入流回执时
   不得标为 delivered；仅 delivered 不得标为 committed-effective，也不得推进对应权威
   head。日志里的 attempted / started 不能充当任何一档成功回执。
+
+  证据：`tests/one-stream-host.test.ts` 在 generated-before-write 与
+  durable-write-before-receipt 两个 checkpoint 杀死宿主后恢复重试，最终都恰一条；换内容
+  重试被拒且 snapshot 字节不变，delivery receipt 也不产生 effect/head。
+  `tests/one-stream-core.test.ts` 另证同进程双 writer 被拒、坏 snapshot 恢复 fail-closed。
 
 - [ ] **OS-03 归档流水只进证据面，不长成第二条聊天史** [协议/客户端]：活工作区可从
   first-party workspace navigator 进入；关闭后其活动入口消失，canonical stream 留下

--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -27,7 +27,7 @@
 每条带主证据形式。标 [集成] 的测试真实启动宿主并可注入断线、猝死和重试；
 标 [协议/客户端] 的测试同时检查能力授权与第一方 read model。
 
-- [x] **OS-01 两个 viewport 只长一条有序主流** [集成]：同一 resident 的 viewport A、
+- [ ] **OS-01 两个 viewport 只长一条有序主流** [集成]：同一 resident 的 viewport A、
   B 并发产生两个合法事件；桌面与手机最终得到相同的 canonical `eventId` 集合和相同
   顺序。第三个客户端在两事件发生期间离线，重连后得到同一集合与顺序且无重复。
   测试交换 A、B 的到达次序重复运行；不要求某一 viewport 固定先赢，只要求主流 writer
@@ -40,7 +40,7 @@
   mobile、offline 三个投影的完整事件、顺序与 payload hash；`tests/one-stream-core.test.ts`
   保留同一 id/seq 后篡改 payload，投影校验会 fail-closed。
 
-- [x] **OS-02 猝死重放至多入流一次，回执不冒充生效** [集成]：对同一投递分别在
+- [ ] **OS-02 猝死重放至多入流一次，回执不冒充生效** [集成]：对同一投递分别在
   “生成后、主流写入前”和“主流写入后、回执前”杀死宿主，再恢复并重试。最终 canonical
   stream 中该投递恰有一条；同一幂等把手换内容重试必须拒绝。未取得真实入流回执时
   不得标为 delivered；仅 delivered 不得标为 committed-effective，也不得推进对应权威

--- a/docs/design/one-stream-master-plan.md
+++ b/docs/design/one-stream-master-plan.md
@@ -371,7 +371,7 @@ PR A 已完成 canonical event contract、每 resident durable snapshot store、
   `tests/one-stream-core.test.ts`（5 项）点亮；两处 crash window、换内容重试、payload
   mutation、坏 snapshot 与同进程双 writer 均有转红断言；
 - `npm run typecheck`、`npm run lint`、`npm run acceptance` 通过；全仓 `npm test` 为
-  41 个文件通过、3 个跳过，448 项通过、38 项 todo；
+  46 个文件通过、3 个跳过，488 项通过、38 项 todo；
 - 100 条事件时最终 snapshot 为 85,022 bytes，累计写入 4,294,176 bytes，约为最终快照的
   50.5 倍，证实 v0 全量 snapshot 的写入成本随 stream 增长，暂不凭这一组数据拍阈值。
 

--- a/docs/design/one-stream-master-plan.md
+++ b/docs/design/one-stream-master-plan.md
@@ -1,6 +1,6 @@
 # 一位住户，一条权威生命线：master plan
 
-- 状态：draft for implementation review
+- 状态：approved；PR A implemented locally，等待提交复核
 - 主单：issue #84
 - 验收真源：`acceptance/one-stream.md`（OS-01～OS-06）
 - 决策真源：`docs/decisions.md` D9、`docs/design/session-api.md` §1.1
@@ -361,3 +361,19 @@ commit；先写红测试和 mutation，再写生产实现。
 3. 哪些能力仍未接、哪些成本仍未测。
 
 不以“文件写了”“接口存在”“测试对象能返回期望值”冒充完成。
+
+## 16. PR A 本地施工回执
+
+PR A 已完成 canonical event contract、每 resident durable snapshot store、进程内唯一 writer、
+幂等 receipt 与 cursor projection，并补齐真实子进程宿主 fixture。当前证据如下：
+
+- OS-01/02 已由 `tests/one-stream-host.test.ts`（3 项）和
+  `tests/one-stream-core.test.ts`（5 项）点亮；两处 crash window、换内容重试、payload
+  mutation、坏 snapshot 与同进程双 writer 均有转红断言；
+- `npm run typecheck`、`npm run lint`、`npm run acceptance` 通过；全仓 `npm test` 为
+  41 个文件通过、3 个跳过，448 项通过、38 项 todo；
+- 100 条事件时最终 snapshot 为 85,022 bytes，累计写入 4,294,176 bytes，约为最终快照的
+  50.5 倍，证实 v0 全量 snapshot 的写入成本随 stream 增长，暂不凭这一组数据拍阈值。
+
+这刀尚未接 message turn、MessageTree/head、first-party read model 或真实 frontend，因此只
+声称 OS-01/02 成立，不声称 D9 或 #84 整体完成。下一决策闸仍按 §12 评估 PR B。

--- a/docs/design/one-stream-master-plan.md
+++ b/docs/design/one-stream-master-plan.md
@@ -1,0 +1,363 @@
+# 一位住户，一条权威生命线：master plan
+
+- 状态：draft for implementation review
+- 主单：issue #84
+- 验收真源：`acceptance/one-stream.md`（OS-01～OS-06）
+- 决策真源：`docs/decisions.md` D9、`docs/design/session-api.md` §1.1
+- 计划基线：`origin/main` at `e46f7a9`
+
+这份文件只负责施工顺序、模块边界和验收取证，不改 D9，也不替
+`acceptance/one-stream.md` 另写一套成功定义。最终字段名可以在实现中收紧；本文写死的是
+权威归属、提交顺序、失败语义与每盏灯需要的证据。
+
+## 1. 目标与完成定义
+
+完成 #84 后，同一 resident 的所有第一方用户可见事件必须经同一个 canonical writer
+排序并持久化。viewport 可以保留自己的工作树、模型上下文和证据流水，但这些都不是第二本
+用户权威历史。
+
+“完成”同时要求：
+
+1. OS-01～OS-06 各有真实生产模块参与的可重复测试，六灯全部点亮；
+2. 第一方用户面只从 canonical stream 和 live workspace navigator 读，不从
+   `session.list/history` 拼聊天史；
+3. 会话消息、progress、blocked、result、closure 和宿主生命周期失败都能落入同一主流；
+4. crash/retry 后主流无重复、无假 delivered、无假 committed-effective；
+5. control/evidence 能力面仍能读归档流水，但不能写回、续聊或被默认用户主体看到。
+
+## 2. 明确不做
+
+- 不做分布式共识，也不支持两个宿主进程同时持有同一 resident 的写权。v0 的部署不变量是
+  一个宿主拥有一个 writer；所有 viewport 通过它提交候选事件。若未来要多宿主主动写，另开
+  一张共识／租约单，不能把本计划的进程内串行冒充成跨机安全。
+- 不把 `session.list/history` 删除或降级。它们继续属于 control/evidence plane。
+- 不在本单接真实 frontend 插件。第一方 read model、能力检查和协议响应会做成生产模块并
+  参加测试；线协议到现有 frontend 的真实交付仍受 `session-api.md` 里已写明的延期约束。
+- 不让 viewport 自由发送任意 transcript、消息数组或上下文正文到主流。
+- 不把 stream delivery 当成业务副作用生效；也不靠日志、attempted 或 started 代替回执。
+- 不在第一刀重写所有旧 P1/P2 存储。旧 `ResidentStore.nodes` 暂留兼容形状，不能再被当作
+  用户权威读源；其退役或迁移另开数据迁移单。
+
+## 3. 现状地图与缺口
+
+| 现有部件 | 当前职责 | 本单判断 |
+|---|---|---|
+| `SessionRegistry` | 多活窗、generation、head、归档 JSONL、dispatch receipt | 保留为 workspace/control 状态；不是主流 writer |
+| `MessageTreeStore` | resident 级 append-only 工作树；当前为内存态 | 保留为模型上下文与证据投影；不能直接冒充 durable stream |
+| `MessageTreeService` | responder → appendPair → setHead | 需要被 turn coordinator 包住；不能继续独自宣布用户可见提交成功 |
+| `ResidentStore.nodes` | 旧 P1 快照里的持久节点形状 | 与新 MessageTree 已分叉；只作兼容数据，不作为 #84 基础 |
+| `FactLedger` / `ViewportTurnGate` | 权威事实 seq、开工闸与 ack | 复用其 fail-closed 与“回执晚于真实提交”的原则，不合并账本 |
+| `BreathCycle` | 换气、失败通知、失败后重置预告 | OS-05 的真实生产接缝；失败通知要接主流 reporter |
+| intentional isolation | scope presence 与 next-turn 注入 | 只提供工作区存在感；关闭与 closure 仍缺 |
+| `session.list/create/history` adapter | control/evidence 线协议 | 保留；另建 P1 first-party projection，禁止复用列表当聊天栏 |
+| plugin transaction host | 持久阶段与 crash checkpoint 先例 | 复用测试方式和阶段命名纪律，不复用其 plugin schema |
+
+关键缺口不是“再加一个事件数组”，而是当前没有一个同时负责以下四件事的唯一操作 owner：
+分配顺序、持久提交、幂等裁决、发出 delivery receipt。
+
+## 4. 目标架构
+
+### 4.1 数据流
+
+```text
+viewport / host lifecycle / turn coordinator
+                  │ typed candidate + idempotency key
+                  ▼
+        CanonicalStreamWriter（唯一写口）
+                  │ validate → canonicalize → serialize
+                  ▼
+        CanonicalStreamStore（resident 物理隔离）
+                  │ durable commit receipt
+          ┌───────┴────────┐
+          ▼                ▼
+  canonical projections   internal projectors
+  desktop/mobile/offline  message tree / workspace state
+          │                │
+          └──── first-party read models ────┐
+                                            ▼
+                                stream + live navigator
+
+session.list/history ── separate authorized control/evidence reader
+```
+
+### 4.2 权威边界
+
+- 只有 writer 可以分配 `eventId` 与单调 `streamSeq`。
+- viewport 只能提交 candidate；来源字段是 provenance，不带 authority。
+- store 的已提交字节是 canonical stream 真源。桌面、手机与离线补拉都只按 cursor 读同一
+  真源；投影层不能改正文、来源、效果语义或 payload hash。
+- MessageTree 是可重建的内部投影。它回答“某个工作区下一轮模型从哪继续”，不回答
+  “用户最终看见了什么”。
+- `SessionRegistry` 的 head 只在相应内部投影成功后推进；stream delivered 本身不能冒充
+  对应业务 authority 或会话 head 已提交。
+
+### 4.3 模块边界（拟定）
+
+第一刀预计新增 `src/one-stream/`：
+
+- `event-contract.ts`：闭合的 candidate/event union、精确字段闸、规范化字节与 hash；
+- `store.ts`：每 resident 的 durable commits、恢复校验、cursor 读取；
+- `writer.ts`：唯一序列分配、幂等裁决、串行提交、delivery receipt；
+- `projection.ts`：按 cursor 读主流并校验 payload hash；
+- `turn-coordinator.ts`：后续把 user/assistant 事件与 MessageTree/head 投影接起来；
+- `workspace-read-model.ts`：live navigator、closure/result card、evidence pointer；
+- `lifecycle-reporter.ts`：宿主签发的失败事件；
+- `reply-router.ts`：blocked candidate 索引与精确回话路由。
+
+文件可以在实现时合并，但每项职责只能有一个 owner。特别是 writer 与 store 不能同时各自
+发号，read model 不能反向写任何底层状态。
+
+## 5. Canonical event 契约
+
+### 5.1 两组正交语义
+
+每个用户可见事件都必须同时表达：
+
+1. 用途：message、progress、blocked、result、closure、lifecycle；
+2. 效果：not-applicable、attempted、rejected、failed-not-effective、
+   committed-effective；
+3. 是否需要用户动作；
+4. 自动重试、等待外部条件或不重试；
+5. reporter/authority source；
+6. subject、来源 viewport、`workRef`、发生时刻与可选权威产物／证据指针。
+
+不能用一个 `completed` 或 `success` 布尔值折叠这些轴。字段名可以调整，语义不能合并。
+
+### 5.2 两条写入口
+
+- **turn 入口**只接明确的 user/assistant message event，由 turn coordinator 调用。它允许
+  消息正文，但不允许 viewport 自造 role 或替宿主签 lifecycle 事件。
+- **bounded dispatch 入口**只接 progress/blocked/result。它使用闭合字段表；额外键、
+  transcript、messages、context、未声明自由文本 envelope 一律整单拒绝。
+
+closure 与 lifecycle 由各自的宿主 adapter 签发，不开放给普通 viewport。来源 viewport
+只能当 subject 或 provenance，不能把自己写成 host authority。
+
+### 5.3 规范化与 payload hash
+
+candidate 先做精确结构校验，再按固定键序列化为 UTF-8 字节；writer-assigned 的 id/seq
+加入最终 immutable payload 后计算摘要。所有投影返回同一个 digest。测试会做两类变异：
+
+- 保留 id/seq，改正文、来源或效果语义，必须被 hash 比对抓住；
+- 同 idempotency key 改 candidate 任一权威字段，必须报冲突且主流字节不变。
+
+只排除明确列入 projection-only allowlist 的展示字段；不能用“客户端元数据”当万能豁免。
+
+## 6. Durable writer、幂等与 crash 恢复
+
+### 6.1 v0 持久形状
+
+沿用仓内已经验证过的同步原子快照策略：每 resident 一份版本化 stream snapshot，候选写入
+先在内存副本上完成，再写同目录临时文件、`fsync`、原子 rename；成功后才替换内存视图并
+返回 receipt。snapshot 至少保存：
+
+- contiguous events；
+- 下一条 seq；
+- `idempotencyKey → requestHash + event receipt` 索引；
+- schema version 与 resident identity。
+
+启动时逐项校验 seq 连续、eventId 唯一、幂等键唯一、request hash 与 payload hash 可重算。
+坏 schema 或中段坏账 fail-closed；孤立 `.tmp` 只表示 rename 前猝死，权威仍是旧 snapshot。
+
+选择快照而不是追加 JSONL，是为了第一阶段直接继承 `ResidentStore` / `FactLedger` 已有的
+rename 恢复证据，先把 OS-02 做真。代价是每次写 O(stream size)。计划在测试里记录写放大；
+达到真实瓶颈后再以相同接口换 framed journal/SQLite，不在没有数据时先造阈值。
+
+### 6.2 单写保护
+
+- host assembly 只构造一个 writer；viewport、reporter、router 只拿窄 submission port；
+- writer 对每个 resident 串行处理请求，store 写方法不对 viewport 导出；
+- 同一进程尝试为同一 data root 建第二个 writer 时显式拒绝；
+- crash 测试永远先确认旧宿主已经退出，再让恢复宿主接管同一 data root；
+- v0 不声称文件存储能阻止两个独立进程同时打开同一 data root。当前保护边界是“一个宿主
+  进程内只有一个 writer，所有 viewport 经它排队”。若部署需要共享根上的多宿主，就必须
+  先换成带事务排他能力的存储或新增经实测的 OS lock；本单不靠有竞态的 pid 文件或拍脑袋
+  stale TTL 冒充锁。
+
+### 6.3 幂等状态机
+
+1. `generated`：生产者形成 candidate；尚无交付事实；
+2. `queued`：writer 接受等待串行；尚无交付事实；
+3. `delivered`：snapshot 已 fsync + rename，writer 返回 durable receipt；
+4. `committed-effective`：仅当对应业务 authority 的真实 commit receipt 已存在时，事件的
+   effect 语义才可如此声明。writer 不从 delivered 推导它。
+
+- 同 key、同 request hash 重试：返回原 receipt，不追加。
+- 同 key、不同 request hash 重试：拒绝冲突，主流一个字节不动。
+- 生成后写前猝死：恢复后没有事件，重试正常写一条。
+- 写后回执前猝死：恢复索引已有事件，重试返回原 receipt，仍只有一条。
+
+stream head 在 durable append 后自然前进；任何会话 head、事实账 ack 或业务 authority head
+都不能仅凭这个 delivery 前进。
+
+## 7. MessageTree 与主流的关系
+
+MessageTree 不删除，但降为内部工作区投影。最终接线遵守下面的方向：
+
+```text
+canonical message event(s) committed
+        → idempotent tree projection
+        → session head update
+        → projection receipt
+```
+
+不能反过来先让 tree/head 成为对用户可见的成功，再“有空补主流”。projector 使用 canonical
+eventId 派生或携带稳定 node identity；重放时若节点已存在且内容一致就返回原 projection
+receipt，内容不一致则 fail-closed。进程在 stream commit 后、tree update 前死亡，重启从
+cursor 补投影；用户生命线不丢，内部工作树最终追上。
+
+`reviseNode` 也不能原地改 canonical event：它追加 typed amendment message event，再把
+MessageTree 投影到新 sibling。旧说法仍在证据里，新说法从新事件开始生效。
+
+在这条接线完成前，PR 不得声称整个 D9 已经落地；第一刀只声称 OS-01/02 的主流内核成立。
+
+## 8. OS-03：first-party 与 evidence 分面
+
+新增两个不可互换的 read port：
+
+- **FirstPartyResidentView**：canonical stream + live workspace navigator。navigator 只列
+  `SessionRegistry.windowsOf(residentId)` 中仍有行动意义的工作区；不列 archived window，
+  不暴露可续写的 transcript handle。
+- **EvidenceViewportReader**：必须有显式 evidence principal，并沿 canonical closure/result
+  里的权威 pointer 读取绑定 window 的只读流水。没有 pointer 不允许按 resident 扫全库；
+  reader 没有 write/resume 方法。
+
+关闭 workspace 由一个 lifecycle owner 协调：先形成 durable typed closure/result，再让
+first-party navigator 消失。中途猝死由 reconciliation 依据 closure 事件补做幂等归档；
+不能出现“归档了但主流没有解释”或“主流说关了但导航永久还活着”。`session.create` 只返回
+workspace handle，客户端文案与结构都不能把它当作新聊天。
+
+## 9. OS-04：有界 dispatch
+
+生产验证器使用 closed union 与 exact-key check。三类合法事件都必须带可核 provenance、
+`workRef`、时间、效果状态；result/closure 的产物指针按事件类型要求。拒绝测试在调用前后
+读取完整 stream bytes，证明以下输入零写入：
+
+- transcript 或 messages 数组；
+- 任意 context/content dump；
+- 未声明字段；
+- 缺 event kind 的自由文本；
+- viewport 自称 host authority。
+
+不靠任意字符上限冒充“有界”；边界来自 schema 的表达能力。如果后来要加大小上限，必须用
+真实 transport/store 数据给参数出生证明。
+
+## 10. OS-05：宿主失败 reporter
+
+给 `BreathCycle.notify` 接 `CanonicalLifecycleReporter`。对 `failed` 通知：
+
+- reporter 是 host，window 是 subject；
+- effect 明确 `failed-not-effective`；
+- `windowRecovered`、stage 和 retry 语义保真；
+- host 自动重试时 `requiresUserAction=false`；真需要人捞窗时才给具体动作；
+- delivery 失败要向宿主上抛或进入 durable retry，不能只写日志。
+
+测试复用 MV-D09 的同一份换气失败 fixture 与“失败后下一次阈值重新 announced”断言；不复制
+一套会漂移的 breath 成功定义。再加 mutation：把 reporter 换成 viewport、把 effect 改成
+committed-effective、只写日志不入流，三支都必须转红。
+
+## 11. OS-06：reply router
+
+router 只从 canonical stream 的未解决 blocked 事件与 live workspace 状态建立候选集：
+
+- `replyToEventId` 精确命中事件；
+- `workRef` 精确命中工作；
+- 裸回复仅在候选集恰好一个时放行；
+- 候选为零返回无目标；候选大于一返回显式消歧，任何 workspace 都收不到原回复。
+
+focus、最近事件、window 创建时间、当前 UI tab 与模型猜测都不进入路由输入。成功投递后才
+写 resolved receipt；派发失败仍保持 blocked 可回答。
+
+## 12. 三段施工与决策闸
+
+### PR A：canonical stream core（先做，点 OS-01/02）
+
+范围：event core、durable store、writer、cursor projection、subprocess host fixture。
+
+主要改动：
+
+- `src/one-stream/{event-contract,store,writer,projection}.ts`；
+- `tests/one-stream-core.test.ts`：结构、hash、幂等、resident 隔离；
+- `tests/one-stream-host.test.ts` + fixture host：真实进程猝死、恢复、离线补拉；
+- `acceptance/one-stream.md`：只在真实证据成立后勾 OS-01/02 并附测试名。
+
+退出条件：
+
+- A/B 并发到达顺序交换后，三个投影 id/seq/hash 一致；
+- 两个 crash window 都恰一条；changed-content retry 拒绝；
+- 同一宿主内第二个 writer 被拒绝；旧宿主退出后恢复宿主可读取原账并继续；
+- 保留 id/seq 改 payload 的 mutation 转红；
+- 全仓 typecheck、相关 tests、acceptance 通过；
+- 明确报告写放大数据与“尚未接 message turn”的剩余缺口。
+
+**决策闸 A**：PR A 本地证据成立后再评估 PR B/C。若核心接口稳定、剩余规模与本文相符，
+Elio 继续；若 OS-03～05 暴露独立项目量，则保持本文架构，由其他 builder 分 lane。无论谁做，
+不重开 D9、不复制 writer。
+
+### PR B：first-party semantics（预案，点 OS-03/04/05）
+
+范围：turn coordinator、MessageTree 投影、workspace/evidence read model、bounded dispatch、
+BreathCycle lifecycle reporter。
+
+退出条件：
+
+- 第一方默认主体看不到 archived transcript capability；证据主体只能沿 pointer 只读；
+- 三种有界事件可投，夹带 transcript 的 mutation 零写入；
+- breath failure 主流可见、未生效、retry/user action 正确，并复用 MV-D09；
+- user/assistant 用户可见路径已切到 canonical stream，MessageTree 可从主流补投影。
+
+PR B 若超过一个可独立 review 的变更面，允许拆成 B1（turn + bounded events）、B2
+（workspace/evidence）、B3（lifecycle reporter）；它们仍共享同一个 master plan 和 writer。
+
+### PR C：reply routing 与总验收（预案，点 OS-06）
+
+范围：blocked index、reply router、真实派发 fixture、六灯总回归、文档收口。
+
+退出条件：
+
+- 显式 handle 各到各窗；唯一裸候选放行；多候选零投递并要求消歧；
+- 最近事件/focus/time 猜测 mutation 全转红；
+- 六灯全绿后才更新 `session-api.md` 的“方向未定”；
+- #84 关闭前给出测试命令、commit/PR 与仍未接真实 frontend 的诚实说明。
+
+## 13. 测试矩阵
+
+| 灯 | 主测试 | 失败注入 | 必须转红的 mutation |
+|---|---|---|---|
+| OS-01 | real host + A/B + offline C | 交换 A/B 到达序 | 同 id/seq 改 payload；viewport 自建权威流 |
+| OS-02 | child process kill/restart | write 前；rename 后 receipt 前 | same key/different body；attempted 当 delivered；delivered 推 authority head；同宿主双 writer |
+| OS-03 | production read models + principals | closure 与 archive 间中断 | 默认主体读 archive；evidence reader 可写；session.create 生成聊天史 |
+| OS-04 | production exact validator | 每种拒绝前后比 bytes | transcript/messages/context/extra key/free text/伪 host |
+| OS-05 | BreathCycle shared fixture | append/inject/swap failure | log-only；host/subject 颠倒；假 effective；失败后 announce 被吞 |
+| OS-06 | two live blocked workspaces | 派发失败、候选变化 | recent/focus/createdAt 猜路由；歧义仍投一窗 |
+
+测试层次：纯函数只测 parser/hash；store 测真实文件；OS-01/02/04/05/06 必须经过生产组合；
+OS-03 必须同时经过 capability 与 first-party structured read model。mock 直接返回期望对象不点灯。
+
+## 14. 风险、代价与回滚
+
+- **写入瓶颈**：单 writer 与全量 snapshot 会增加延迟和写放大。先测真实数据，不写魔法阈值；
+  接口隔离允许以后换 journal。
+- **双投影漂移**：stream 与 MessageTree/head 中途失败。以 stream 为真源、projection cursor
+  重放；内容不一致 fail-closed，不静默覆盖。
+- **能力误接**：现有 `session.list/history` 很容易被 frontend 当聊天栏。第一方 reader 使用
+  独立类型与端口，不让默认主体拿到 evidence reader。
+- **事件流拥挤**：过多 progress 会淹没对话。先保证语义有界；展示折叠属于 projection，
+  不能删除主流事件或改变排序。
+- **迁移风险**：旧节点与新主流无一一对应。v0 不把旧历史伪造为新 canonical event；如需
+  导入，必须有单独 migration schema、来源标记和重复运行测试。
+- **回滚**：每段 PR 可独立回退。PR A 未接用户面，不改变现行行为；PR B 切读前保留 feature
+  gate 与旧 control/evidence 口，出错时退回旧 user path，但不得把两条同时宣称为权威。
+
+## 15. 开工前检查与完成回执
+
+每段开始前：读最新 #84 thread 与 `acceptance/one-stream.md`，确认没有新裁定；记录 base
+commit；先写红测试和 mutation，再写生产实现。
+
+每段交付只报三类证据：
+
+1. 哪几盏灯由哪个测试真实点亮；
+2. 哪些 crash/mutation 被证明确实转红；
+3. 哪些能力仍未接、哪些成本仍未测。
+
+不以“文件写了”“接口存在”“测试对象能返回期望值”冒充完成。

--- a/src/one-stream/event-contract.ts
+++ b/src/one-stream/event-contract.ts
@@ -1,0 +1,343 @@
+import { createHash } from "node:crypto";
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { readonly [key: string]: JsonValue };
+
+export type CanonicalEventPurpose =
+  | "message"
+  | "progress"
+  | "blocked"
+  | "result"
+  | "closure"
+  | "lifecycle";
+
+export type EffectState =
+  | "not-applicable"
+  | "attempted"
+  | "rejected"
+  | "failed-not-effective"
+  | "committed-effective";
+
+export type RetryState = "not-applicable" | "automatic" | "awaiting-external" | "none";
+
+export type ActorKind = "resident" | "viewport" | "host" | "work" | "external";
+
+export interface EventActor {
+  readonly kind: ActorKind;
+  readonly id: string;
+}
+
+export interface EventViewport {
+  readonly windowId: string;
+  readonly generation: number;
+}
+
+export interface EventOrigin {
+  readonly reporter: EventActor;
+  readonly subject: EventActor;
+  readonly viewport: EventViewport | null;
+}
+
+export interface EventEffect {
+  readonly state: EffectState;
+  readonly requiresUserAction: boolean;
+  readonly retry: RetryState;
+}
+
+/**
+ * Low-level canonical draft. Viewports do not receive this port directly: later bounded adapters
+ * decide which payload shapes each producer is allowed to submit. The core still validates the
+ * authority envelope exactly so retries hash the complete semantics, not only display text.
+ */
+export interface CanonicalEventDraft {
+  readonly purpose: CanonicalEventPurpose;
+  readonly occurredAt: string;
+  readonly workRef: string | null;
+  readonly authoritySource: EventActor;
+  readonly origin: EventOrigin;
+  readonly effect: EventEffect;
+  readonly artifactRef: string | null;
+  readonly payload: JsonObject;
+}
+
+export interface CanonicalEvent extends CanonicalEventDraft {
+  readonly schemaVersion: 1;
+  readonly residentId: string;
+  readonly eventId: string;
+  readonly streamSeq: number;
+  readonly payloadHash: string;
+}
+
+export interface DeliveryReceipt {
+  readonly phase: "delivered";
+  readonly residentId: string;
+  readonly eventId: string;
+  readonly streamSeq: number;
+  readonly payloadHash: string;
+}
+
+const PURPOSES = new Set<CanonicalEventPurpose>([
+  "message",
+  "progress",
+  "blocked",
+  "result",
+  "closure",
+  "lifecycle",
+]);
+const EFFECT_STATES = new Set<EffectState>([
+  "not-applicable",
+  "attempted",
+  "rejected",
+  "failed-not-effective",
+  "committed-effective",
+]);
+const RETRY_STATES = new Set<RetryState>([
+  "not-applicable",
+  "automatic",
+  "awaiting-external",
+  "none",
+]);
+const ACTOR_KINDS = new Set<ActorKind>(["resident", "viewport", "host", "work", "external"]);
+
+const DRAFT_KEYS = [
+  "artifactRef",
+  "authoritySource",
+  "effect",
+  "occurredAt",
+  "origin",
+  "payload",
+  "purpose",
+  "workRef",
+] as const;
+const EVENT_KEYS = [
+  ...DRAFT_KEYS,
+  "eventId",
+  "payloadHash",
+  "residentId",
+  "schemaVersion",
+  "streamSeq",
+].sort();
+
+export class CanonicalEventContractError extends Error {
+  readonly code = "CANONICAL_EVENT_CONTRACT";
+  constructor(message: string) {
+    super(message);
+    this.name = "CanonicalEventContractError";
+  }
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new CanonicalEventContractError(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  name: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  if (
+    actual.length !== sortedExpected.length ||
+    actual.some((key, index) => key !== sortedExpected[index])
+  ) {
+    throw new CanonicalEventContractError(`${name} has unexpected fields`);
+  }
+}
+
+function nonEmptyString(value: unknown, name: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new CanonicalEventContractError(`${name} must be a non-empty string`);
+  }
+}
+
+function nullableString(value: unknown, name: string): asserts value is string | null {
+  if (value === null) return;
+  nonEmptyString(value, name);
+}
+
+function actor(value: unknown, name: string): asserts value is EventActor {
+  const candidate = record(value, name);
+  exactKeys(candidate, ["id", "kind"], name);
+  if (typeof candidate.kind !== "string" || !ACTOR_KINDS.has(candidate.kind as ActorKind)) {
+    throw new CanonicalEventContractError(`${name}.kind is invalid`);
+  }
+  nonEmptyString(candidate.id, `${name}.id`);
+}
+
+function viewport(value: unknown): asserts value is EventViewport | null {
+  if (value === null) return;
+  const candidate = record(value, "origin.viewport");
+  exactKeys(candidate, ["generation", "windowId"], "origin.viewport");
+  nonEmptyString(candidate.windowId, "origin.viewport.windowId");
+  if (!Number.isSafeInteger(candidate.generation) || (candidate.generation as number) < 1) {
+    throw new CanonicalEventContractError("origin.viewport.generation must be a positive integer");
+  }
+}
+
+function origin(value: unknown): asserts value is EventOrigin {
+  const candidate = record(value, "origin");
+  exactKeys(candidate, ["reporter", "subject", "viewport"], "origin");
+  actor(candidate.reporter, "origin.reporter");
+  actor(candidate.subject, "origin.subject");
+  viewport(candidate.viewport);
+}
+
+function effect(value: unknown): asserts value is EventEffect {
+  const candidate = record(value, "effect");
+  exactKeys(candidate, ["requiresUserAction", "retry", "state"], "effect");
+  if (typeof candidate.state !== "string" || !EFFECT_STATES.has(candidate.state as EffectState)) {
+    throw new CanonicalEventContractError("effect.state is invalid");
+  }
+  if (typeof candidate.requiresUserAction !== "boolean") {
+    throw new CanonicalEventContractError("effect.requiresUserAction must be boolean");
+  }
+  if (typeof candidate.retry !== "string" || !RETRY_STATES.has(candidate.retry as RetryState)) {
+    throw new CanonicalEventContractError("effect.retry is invalid");
+  }
+}
+
+function json(
+  value: unknown,
+  name: string,
+  ancestors: WeakSet<object>,
+): asserts value is JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new CanonicalEventContractError(`${name} contains a non-finite number`);
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new CanonicalEventContractError(`${name} is not JSON`);
+  }
+  if (ancestors.has(value)) {
+    throw new CanonicalEventContractError(`${name} contains a cycle`);
+  }
+  ancestors.add(value);
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) json(item, `${name}[${index}]`, ancestors);
+  } else {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new CanonicalEventContractError(`${name} must contain only plain objects`);
+    }
+    for (const [key, item] of Object.entries(value)) json(item, `${name}.${key}`, ancestors);
+  }
+  ancestors.delete(value);
+}
+
+export function assertCanonicalEventDraft(value: unknown): asserts value is CanonicalEventDraft {
+  const candidate = record(value, "draft");
+  exactKeys(candidate, DRAFT_KEYS, "draft");
+  if (
+    typeof candidate.purpose !== "string" ||
+    !PURPOSES.has(candidate.purpose as CanonicalEventPurpose)
+  ) {
+    throw new CanonicalEventContractError("draft.purpose is invalid");
+  }
+  nonEmptyString(candidate.occurredAt, "draft.occurredAt");
+  if (!Number.isFinite(Date.parse(candidate.occurredAt))) {
+    throw new CanonicalEventContractError("draft.occurredAt must be a parseable timestamp");
+  }
+  nullableString(candidate.workRef, "draft.workRef");
+  actor(candidate.authoritySource, "draft.authoritySource");
+  origin(candidate.origin);
+  effect(candidate.effect);
+  nullableString(candidate.artifactRef, "draft.artifactRef");
+  const payload = record(candidate.payload, "draft.payload");
+  json(payload, "draft.payload", new WeakSet());
+}
+
+export function assertCanonicalEvent(value: unknown): asserts value is CanonicalEvent {
+  const candidate = record(value, "event");
+  exactKeys(candidate, EVENT_KEYS, "event");
+  if (candidate.schemaVersion !== 1) {
+    throw new CanonicalEventContractError("event.schemaVersion is invalid");
+  }
+  nonEmptyString(candidate.residentId, "event.residentId");
+  nonEmptyString(candidate.eventId, "event.eventId");
+  if (!Number.isSafeInteger(candidate.streamSeq) || (candidate.streamSeq as number) < 1) {
+    throw new CanonicalEventContractError("event.streamSeq must be a positive integer");
+  }
+  nonEmptyString(candidate.payloadHash, "event.payloadHash");
+  const draft: Record<string, unknown> = {};
+  for (const key of DRAFT_KEYS) draft[key] = candidate[key];
+  assertCanonicalEventDraft(draft);
+}
+
+function stable(value: JsonValue): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stable(item)).join(",")}]`;
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stable(value[key] as JsonValue)}`)
+    .join(",")}}`;
+}
+
+export function stableJson(value: unknown): string {
+  json(value, "value", new WeakSet());
+  return stable(value as JsonValue);
+}
+
+function sha256(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export function normalizeDraft(value: unknown): CanonicalEventDraft {
+  assertCanonicalEventDraft(value);
+  return JSON.parse(stableJson(value)) as CanonicalEventDraft;
+}
+
+export function hashSubmission(residentId: string, draft: CanonicalEventDraft): string {
+  nonEmptyString(residentId, "residentId");
+  return sha256(stableJson({ draft, residentId }));
+}
+
+type EventWithoutHash = Omit<CanonicalEvent, "payloadHash">;
+
+export function hashCanonicalEvent(event: EventWithoutHash): string {
+  return sha256(stableJson(event));
+}
+
+export function buildCanonicalEvent(input: {
+  residentId: string;
+  eventId: string;
+  streamSeq: number;
+  draft: CanonicalEventDraft;
+}): CanonicalEvent {
+  nonEmptyString(input.residentId, "residentId");
+  nonEmptyString(input.eventId, "eventId");
+  if (!Number.isSafeInteger(input.streamSeq) || input.streamSeq < 1) {
+    throw new CanonicalEventContractError("streamSeq must be a positive integer");
+  }
+  const unsigned: EventWithoutHash = {
+    schemaVersion: 1,
+    residentId: input.residentId,
+    eventId: input.eventId,
+    streamSeq: input.streamSeq,
+    ...normalizeDraft(input.draft),
+  };
+  return { ...unsigned, payloadHash: hashCanonicalEvent(unsigned) };
+}
+
+export function verifyCanonicalEvent(event: CanonicalEvent): void {
+  assertCanonicalEvent(event);
+  const { payloadHash, ...unsigned } = event;
+  if (hashCanonicalEvent(unsigned) !== payloadHash) {
+    throw new CanonicalEventContractError(`payload hash mismatch for ${event.eventId}`);
+  }
+}
+
+export function cloneEvent(event: CanonicalEvent): CanonicalEvent {
+  return structuredClone(event);
+}
+
+export function cloneReceipt(receipt: DeliveryReceipt): DeliveryReceipt {
+  return { ...receipt };
+}

--- a/src/one-stream/index.ts
+++ b/src/one-stream/index.ts
@@ -1,0 +1,46 @@
+export {
+  CanonicalEventContractError,
+  assertCanonicalEvent,
+  assertCanonicalEventDraft,
+  buildCanonicalEvent,
+  cloneEvent,
+  hashCanonicalEvent,
+  hashSubmission,
+  normalizeDraft,
+  stableJson,
+  verifyCanonicalEvent,
+} from "./event-contract.ts";
+export type {
+  ActorKind,
+  CanonicalEvent,
+  CanonicalEventDraft,
+  CanonicalEventPurpose,
+  DeliveryReceipt,
+  EffectState,
+  EventActor,
+  EventEffect,
+  EventOrigin,
+  EventViewport,
+  JsonObject,
+  JsonPrimitive,
+  JsonValue,
+  RetryState,
+} from "./event-contract.ts";
+export { CanonicalStreamProjection, ProjectionIntegrityError } from "./projection.ts";
+export {
+  CanonicalStreamStore,
+  IdempotencyConflictError,
+  StreamNotFoundError,
+} from "./store.ts";
+export type { CanonicalStreamReadPort } from "./store.ts";
+export {
+  CanonicalStreamWriter,
+  WriterClosedError,
+  WriterOwnershipError,
+} from "./writer.ts";
+export type {
+  CanonicalEventSubmission,
+  CanonicalStreamWriterOptions,
+  WriterCheckpoint,
+  WriterCheckpointName,
+} from "./writer.ts";

--- a/src/one-stream/projection.ts
+++ b/src/one-stream/projection.ts
@@ -1,0 +1,59 @@
+import { type CanonicalEvent, cloneEvent, verifyCanonicalEvent } from "./event-contract.ts";
+import type { CanonicalStreamReadPort } from "./store.ts";
+
+export class ProjectionIntegrityError extends Error {
+  readonly code = "PROJECTION_INTEGRITY";
+  constructor(message: string) {
+    super(message);
+    this.name = "ProjectionIntegrityError";
+  }
+}
+
+export class CanonicalStreamProjection {
+  readonly #readPort: CanonicalStreamReadPort;
+  readonly #residentId: string;
+  readonly #events: CanonicalEvent[] = [];
+  #cursor = 0;
+
+  constructor(readPort: CanonicalStreamReadPort, residentId: string) {
+    this.#readPort = readPort;
+    this.#residentId = residentId;
+  }
+
+  get cursor(): number {
+    return this.#cursor;
+  }
+
+  async pull(): Promise<CanonicalEvent[]> {
+    const incoming = this.#readPort.eventsAfter(this.#residentId, this.#cursor);
+    const verified: CanonicalEvent[] = [];
+    let expected = this.#cursor + 1;
+    try {
+      for (const event of incoming) {
+        verifyCanonicalEvent(event);
+        if (event.residentId !== this.#residentId) {
+          throw new ProjectionIntegrityError("projection received an event for another resident");
+        }
+        if (event.streamSeq !== expected) {
+          throw new ProjectionIntegrityError(
+            `projection sequence gap: expected ${expected}, got ${event.streamSeq}`,
+          );
+        }
+        verified.push(cloneEvent(event));
+        expected += 1;
+      }
+    } catch (error) {
+      if (error instanceof ProjectionIntegrityError) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ProjectionIntegrityError(message);
+    }
+
+    this.#events.push(...verified);
+    if (verified.length > 0) this.#cursor = verified.at(-1)?.streamSeq ?? this.#cursor;
+    return verified.map(cloneEvent);
+  }
+
+  snapshot(): CanonicalEvent[] {
+    return this.#events.map(cloneEvent);
+  }
+}

--- a/src/one-stream/store.ts
+++ b/src/one-stream/store.ts
@@ -1,0 +1,386 @@
+import {
+  closeSync,
+  fchmodSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  type CanonicalEvent,
+  type CanonicalEventDraft,
+  type DeliveryReceipt,
+  assertCanonicalEvent,
+  buildCanonicalEvent,
+  cloneEvent,
+  cloneReceipt,
+  hashSubmission,
+  verifyCanonicalEvent,
+} from "./event-contract.ts";
+
+const SCHEMA_VERSION = 1;
+const FILE_SUFFIX = ".stream.json";
+
+interface IdempotencyRecord {
+  readonly idempotencyKey: string;
+  readonly requestHash: string;
+  readonly receipt: DeliveryReceipt;
+}
+
+interface StreamRecord {
+  readonly schemaVersion: 1;
+  readonly residentId: string;
+  readonly nextSeq: number;
+  readonly events: CanonicalEvent[];
+  readonly idempotency: IdempotencyRecord[];
+}
+
+interface ResidentStream {
+  readonly residentId: string;
+  readonly events: CanonicalEvent[];
+  readonly idempotency: Map<string, IdempotencyRecord>;
+  nextSeq: number;
+}
+
+export interface CanonicalStreamReadPort {
+  eventsAfter(residentId: string, afterSeq: number): CanonicalEvent[];
+}
+
+export class StreamNotFoundError extends Error {
+  readonly code = "STREAM_NOT_FOUND";
+  constructor(residentId: string) {
+    super(`no canonical stream for resident: ${residentId}`);
+    this.name = "StreamNotFoundError";
+  }
+}
+
+export class IdempotencyConflictError extends Error {
+  readonly code = "IDEMPOTENCY_CONFLICT";
+  constructor(residentId: string, idempotencyKey: string) {
+    super(`idempotency key reused with different content: ${residentId}/${idempotencyKey}`);
+    this.name = "IdempotencyConflictError";
+  }
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  name: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new Error(`${name} has unexpected fields`);
+  }
+}
+
+function object(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function positiveInteger(value: unknown, name: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value as number;
+}
+
+function nonEmptyString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function parseReceipt(value: unknown): DeliveryReceipt {
+  const candidate = object(value, "delivery receipt");
+  exactKeys(
+    candidate,
+    ["eventId", "payloadHash", "phase", "residentId", "streamSeq"],
+    "delivery receipt",
+  );
+  if (candidate.phase !== "delivered") throw new Error("delivery receipt phase is invalid");
+  return {
+    phase: "delivered",
+    residentId: nonEmptyString(candidate.residentId, "receipt.residentId"),
+    eventId: nonEmptyString(candidate.eventId, "receipt.eventId"),
+    streamSeq: positiveInteger(candidate.streamSeq, "receipt.streamSeq"),
+    payloadHash: nonEmptyString(candidate.payloadHash, "receipt.payloadHash"),
+  };
+}
+
+function parseRecord(value: unknown, file: string): StreamRecord {
+  const candidate = object(value, `stream snapshot ${file}`);
+  exactKeys(
+    candidate,
+    ["events", "idempotency", "nextSeq", "residentId", "schemaVersion"],
+    `stream snapshot ${file}`,
+  );
+  if (candidate.schemaVersion !== SCHEMA_VERSION) {
+    throw new Error(`unsupported stream schema in ${file}`);
+  }
+  const residentId = nonEmptyString(candidate.residentId, "snapshot.residentId");
+  const nextSeq = positiveInteger(candidate.nextSeq, "snapshot.nextSeq");
+  if (!Array.isArray(candidate.events) || !Array.isArray(candidate.idempotency)) {
+    throw new Error(`stream snapshot arrays are invalid in ${file}`);
+  }
+  const events = candidate.events.map((value, index) => {
+    assertCanonicalEvent(value);
+    verifyCanonicalEvent(value);
+    if (value.residentId !== residentId) {
+      throw new Error(`event resident mismatch in ${file}`);
+    }
+    if (value.streamSeq !== index + 1) {
+      throw new Error(`stream sequence is not contiguous in ${file}`);
+    }
+    return cloneEvent(value);
+  });
+  if (nextSeq !== events.length + 1) {
+    throw new Error(`nextSeq does not follow stream head in ${file}`);
+  }
+
+  const eventById = new Map(events.map((event) => [event.eventId, event]));
+  if (eventById.size !== events.length) throw new Error(`duplicate eventId in ${file}`);
+  const seenKeys = new Set<string>();
+  const seenReceiptEvents = new Set<string>();
+  const idempotency = candidate.idempotency.map((value) => {
+    const row = object(value, "idempotency record");
+    exactKeys(row, ["idempotencyKey", "receipt", "requestHash"], "idempotency record");
+    const idempotencyKey = nonEmptyString(row.idempotencyKey, "idempotencyKey");
+    if (seenKeys.has(idempotencyKey)) throw new Error(`duplicate idempotency key in ${file}`);
+    seenKeys.add(idempotencyKey);
+    const requestHash = nonEmptyString(row.requestHash, "requestHash");
+    const receipt = parseReceipt(row.receipt);
+    const event = eventById.get(receipt.eventId);
+    if (
+      event === undefined ||
+      receipt.residentId !== residentId ||
+      receipt.streamSeq !== event.streamSeq ||
+      receipt.payloadHash !== event.payloadHash
+    ) {
+      throw new Error(`idempotency receipt is not bound to its event in ${file}`);
+    }
+    if (seenReceiptEvents.has(receipt.eventId)) {
+      throw new Error(`multiple idempotency records target one event in ${file}`);
+    }
+    seenReceiptEvents.add(receipt.eventId);
+    const eventDraft: CanonicalEventDraft = {
+      purpose: event.purpose,
+      occurredAt: event.occurredAt,
+      workRef: event.workRef,
+      authoritySource: event.authoritySource,
+      origin: event.origin,
+      effect: event.effect,
+      artifactRef: event.artifactRef,
+      payload: event.payload,
+    };
+    if (requestHash !== hashSubmission(residentId, eventDraft)) {
+      throw new Error(`idempotency request hash does not match its event in ${file}`);
+    }
+    return { idempotencyKey, requestHash, receipt };
+  });
+  if (idempotency.length !== events.length) {
+    throw new Error(`stream event/idempotency count mismatch in ${file}`);
+  }
+  return { schemaVersion: 1, residentId, nextSeq, events, idempotency };
+}
+
+export class CanonicalStreamStore implements CanonicalStreamReadPort {
+  readonly #streams = new Map<string, ResidentStream>();
+  readonly #dataDir: string | null;
+  readonly #memoryScope = Symbol("in-memory-canonical-stream");
+
+  constructor(options: { dataDir?: string } = {}) {
+    this.#dataDir = options.dataDir === undefined ? null : resolve(options.dataDir);
+    if (this.#dataDir !== null) {
+      mkdirSync(this.#dataDir, { recursive: true });
+      this.#restore();
+    }
+  }
+
+  /** Same-process writer ownership key. It is not a cross-process lock. */
+  writerScope(): string | symbol {
+    return this.#dataDir ?? this.#memoryScope;
+  }
+
+  createStream(residentId: string): void {
+    this.#assertResidentId(residentId);
+    if (this.#streams.has(residentId))
+      throw new Error(`canonical stream already exists: ${residentId}`);
+    const stream: ResidentStream = {
+      residentId,
+      nextSeq: 1,
+      events: [],
+      idempotency: new Map(),
+    };
+    this.#persist(this.#record(stream));
+    this.#streams.set(residentId, stream);
+  }
+
+  has(residentId: string): boolean {
+    return this.#streams.has(residentId);
+  }
+
+  events(residentId: string): CanonicalEvent[] {
+    return this.#mustStream(residentId).events.map(cloneEvent);
+  }
+
+  eventsAfter(residentId: string, afterSeq: number): CanonicalEvent[] {
+    if (!Number.isSafeInteger(afterSeq) || afterSeq < 0) {
+      throw new Error("afterSeq must be a non-negative integer");
+    }
+    return this.#mustStream(residentId)
+      .events.filter((event) => event.streamSeq > afterSeq)
+      .map(cloneEvent);
+  }
+
+  receiptFor(
+    residentId: string,
+    idempotencyKey: string,
+    requestHash: string,
+  ): DeliveryReceipt | null {
+    const previous = this.#mustStream(residentId).idempotency.get(idempotencyKey);
+    if (previous === undefined) return null;
+    if (previous.requestHash !== requestHash) {
+      throw new IdempotencyConflictError(residentId, idempotencyKey);
+    }
+    return cloneReceipt(previous.receipt);
+  }
+
+  append(input: {
+    residentId: string;
+    idempotencyKey: string;
+    requestHash: string;
+    eventId: string;
+    draft: CanonicalEventDraft;
+  }): DeliveryReceipt {
+    const stream = this.#mustStream(input.residentId);
+    const previous = stream.idempotency.get(input.idempotencyKey);
+    if (previous !== undefined) {
+      if (previous.requestHash !== input.requestHash) {
+        throw new IdempotencyConflictError(input.residentId, input.idempotencyKey);
+      }
+      return cloneReceipt(previous.receipt);
+    }
+    if (!Number.isSafeInteger(stream.nextSeq) || stream.nextSeq >= Number.MAX_SAFE_INTEGER)
+      throw new Error("canonical stream sequence exhausted");
+    const event = buildCanonicalEvent({
+      residentId: input.residentId,
+      eventId: input.eventId,
+      streamSeq: stream.nextSeq,
+      draft: input.draft,
+    });
+    if (stream.events.some((existing) => existing.eventId === event.eventId)) {
+      throw new Error(`canonical event id collision: ${event.eventId}`);
+    }
+    const receipt: DeliveryReceipt = {
+      phase: "delivered",
+      residentId: event.residentId,
+      eventId: event.eventId,
+      streamSeq: event.streamSeq,
+      payloadHash: event.payloadHash,
+    };
+    const next: ResidentStream = {
+      residentId: stream.residentId,
+      nextSeq: stream.nextSeq + 1,
+      events: [...stream.events, event],
+      idempotency: new Map(stream.idempotency),
+    };
+    next.idempotency.set(input.idempotencyKey, {
+      idempotencyKey: input.idempotencyKey,
+      requestHash: input.requestHash,
+      receipt,
+    });
+    this.#persist(this.#record(next));
+    this.#streams.set(input.residentId, next);
+    return cloneReceipt(receipt);
+  }
+
+  #mustStream(residentId: string): ResidentStream {
+    const stream = this.#streams.get(residentId);
+    if (stream === undefined) throw new StreamNotFoundError(residentId);
+    return stream;
+  }
+
+  #assertResidentId(residentId: string): void {
+    if (!/^[a-z0-9-]+$/.test(residentId)) {
+      throw new Error(`resident id cannot be used as a stream filename: ${residentId}`);
+    }
+  }
+
+  #record(stream: ResidentStream): StreamRecord {
+    return {
+      schemaVersion: 1,
+      residentId: stream.residentId,
+      nextSeq: stream.nextSeq,
+      events: stream.events.map(cloneEvent),
+      idempotency: [...stream.idempotency.values()].map((entry) => ({
+        idempotencyKey: entry.idempotencyKey,
+        requestHash: entry.requestHash,
+        receipt: cloneReceipt(entry.receipt),
+      })),
+    };
+  }
+
+  #persist(record: StreamRecord): void {
+    if (this.#dataDir === null) return;
+    const finalPath = join(this.#dataDir, `${record.residentId}${FILE_SUFFIX}`);
+    const temporaryPath = `${finalPath}.tmp`;
+    let descriptor: number | null = null;
+    try {
+      descriptor = openSync(temporaryPath, "w", 0o600);
+      fchmodSync(descriptor, 0o600);
+      writeSync(descriptor, JSON.stringify(record));
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      descriptor = null;
+      renameSync(temporaryPath, finalPath);
+    } catch (error) {
+      if (descriptor !== null) {
+        try {
+          closeSync(descriptor);
+        } catch {
+          // Preserve the original write error.
+        }
+      }
+      try {
+        rmSync(temporaryPath, { force: true });
+      } catch {
+        // The write still fails loudly even if a malformed temporary target cannot be removed.
+      }
+      throw error;
+    }
+  }
+
+  #restore(): void {
+    if (this.#dataDir === null) return;
+    for (const file of readdirSync(this.#dataDir).sort()) {
+      if (!file.endsWith(FILE_SUFFIX)) continue;
+      const record = parseRecord(
+        JSON.parse(readFileSync(join(this.#dataDir, file), "utf8")) as unknown,
+        file,
+      );
+      this.#assertResidentId(record.residentId);
+      if (`${record.residentId}${FILE_SUFFIX}` !== file) {
+        throw new Error(`stream snapshot filename/resident mismatch: ${file}`);
+      }
+      if (this.#streams.has(record.residentId)) {
+        throw new Error(`duplicate resident stream snapshot: ${record.residentId}`);
+      }
+      this.#streams.set(record.residentId, {
+        residentId: record.residentId,
+        nextSeq: record.nextSeq,
+        events: record.events.map(cloneEvent),
+        idempotency: new Map(record.idempotency.map((entry) => [entry.idempotencyKey, entry])),
+      });
+    }
+  }
+}

--- a/src/one-stream/writer.ts
+++ b/src/one-stream/writer.ts
@@ -1,0 +1,129 @@
+import { randomUUID } from "node:crypto";
+import {
+  type CanonicalEventDraft,
+  type DeliveryReceipt,
+  hashSubmission,
+  normalizeDraft,
+} from "./event-contract.ts";
+import type { CanonicalStreamStore } from "./store.ts";
+
+export type WriterCheckpointName = "generated-before-write" | "durable-write-before-receipt";
+
+export interface WriterCheckpoint {
+  readonly name: WriterCheckpointName;
+  readonly residentId: string;
+  readonly idempotencyKey: string;
+  readonly eventId: string;
+}
+
+export interface CanonicalEventSubmission {
+  readonly residentId: string;
+  readonly idempotencyKey: string;
+  readonly draft: CanonicalEventDraft;
+}
+
+export interface CanonicalStreamWriterOptions {
+  readonly newEventId?: () => string;
+  readonly checkpoint?: (checkpoint: WriterCheckpoint) => Promise<void>;
+}
+
+export class WriterOwnershipError extends Error {
+  readonly code = "WRITER_OWNERSHIP_CONFLICT";
+  constructor() {
+    super("a canonical stream writer already owns this data root in the current process");
+    this.name = "WriterOwnershipError";
+  }
+}
+
+export class WriterClosedError extends Error {
+  readonly code = "WRITER_CLOSED";
+  constructor() {
+    super("canonical stream writer is closed");
+    this.name = "WriterClosedError";
+  }
+}
+
+const ownedScopes = new Set<string | symbol>();
+
+export class CanonicalStreamWriter {
+  readonly #store: CanonicalStreamStore;
+  readonly #scope: string | symbol;
+  readonly #newEventId: () => string;
+  readonly #checkpoint: (checkpoint: WriterCheckpoint) => Promise<void>;
+  readonly #queues = new Map<string, Promise<void>>();
+  #closed = false;
+
+  constructor(store: CanonicalStreamStore, options: CanonicalStreamWriterOptions = {}) {
+    this.#store = store;
+    this.#scope = store.writerScope();
+    if (ownedScopes.has(this.#scope)) throw new WriterOwnershipError();
+    ownedScopes.add(this.#scope);
+    this.#newEventId = options.newEventId ?? randomUUID;
+    this.#checkpoint = options.checkpoint ?? (async () => undefined);
+  }
+
+  submit(submission: CanonicalEventSubmission): Promise<DeliveryReceipt> {
+    if (this.#closed) return Promise.reject(new WriterClosedError());
+    if (submission.residentId.length === 0 || submission.idempotencyKey.length === 0) {
+      return Promise.reject(new Error("residentId and idempotencyKey must be non-empty"));
+    }
+    const draft = normalizeDraft(submission.draft);
+    const requestHash = hashSubmission(submission.residentId, draft);
+    return this.#enqueue(submission.residentId, async () => {
+      const previous = this.#store.receiptFor(
+        submission.residentId,
+        submission.idempotencyKey,
+        requestHash,
+      );
+      if (previous !== null) return previous;
+
+      const eventId = this.#newEventId();
+      if (eventId.length === 0) throw new Error("event id source returned an empty id");
+      await this.#checkpoint({
+        name: "generated-before-write",
+        residentId: submission.residentId,
+        idempotencyKey: submission.idempotencyKey,
+        eventId,
+      });
+      const receipt = this.#store.append({
+        residentId: submission.residentId,
+        idempotencyKey: submission.idempotencyKey,
+        requestHash,
+        eventId,
+        draft,
+      });
+      await this.#checkpoint({
+        name: "durable-write-before-receipt",
+        residentId: submission.residentId,
+        idempotencyKey: submission.idempotencyKey,
+        eventId,
+      });
+      return receipt;
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    await Promise.all([...this.#queues.values()]);
+    ownedScopes.delete(this.#scope);
+  }
+
+  #enqueue<T>(residentId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.#queues.get(residentId) ?? Promise.resolve();
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const marker = previous.then(
+      () => gate,
+      () => gate,
+    );
+    this.#queues.set(residentId, marker);
+
+    return previous.then(operation, operation).finally(() => {
+      release();
+      if (this.#queues.get(residentId) === marker) this.#queues.delete(residentId);
+    });
+  }
+}

--- a/tests/fixtures/one-stream-host.ts
+++ b/tests/fixtures/one-stream-host.ts
@@ -1,0 +1,117 @@
+import {
+  type CanonicalEventDraft,
+  CanonicalStreamProjection,
+  CanonicalStreamStore,
+  CanonicalStreamWriter,
+  type WriterCheckpointName,
+} from "../../src/one-stream/index.ts";
+
+const dataDir = process.env.MIST_ONE_STREAM_DIR;
+if (dataDir === undefined) throw new Error("MIST_ONE_STREAM_DIR is required");
+
+const haltAt = process.env.MIST_ONE_STREAM_HALT_AT as WriterCheckpointName | undefined;
+const store = new CanonicalStreamStore({ dataDir });
+const projections = new Map<string, CanonicalStreamProjection>();
+const writer = new CanonicalStreamWriter(store, {
+  checkpoint: async (checkpoint) => {
+    await send({ type: "checkpoint", name: checkpoint.name, residentId: checkpoint.residentId });
+    if (haltAt === checkpoint.name) {
+      process.kill(process.pid, "SIGKILL");
+    }
+  },
+});
+
+type Command = {
+  requestId?: string;
+  op?: string;
+  residentId?: string;
+  clientId?: string;
+  idempotencyKey?: string;
+  draft?: CanonicalEventDraft;
+  afterSeq?: number;
+};
+
+function send(message: unknown): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (process.send === undefined) {
+      reject(new Error("IPC channel is unavailable"));
+      return;
+    }
+    process.send(message, (error) => {
+      if (error === null) resolve();
+      else reject(error);
+    });
+  });
+}
+
+function required(value: string | undefined, name: string): string {
+  if (value === undefined || value.length === 0) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function handle(command: Command): Promise<unknown> {
+  switch (command.op) {
+    case "create": {
+      const residentId = required(command.residentId, "residentId");
+      store.createStream(residentId);
+      return { residentId };
+    }
+    case "submit":
+      if (command.draft === undefined) throw new Error("draft is required");
+      return writer.submit({
+        residentId: required(command.residentId, "residentId"),
+        idempotencyKey: required(command.idempotencyKey, "idempotencyKey"),
+        draft: command.draft,
+      });
+    case "events":
+      return store.eventsAfter(required(command.residentId, "residentId"), command.afterSeq ?? 0);
+    case "openProjection": {
+      const clientId = required(command.clientId, "clientId");
+      projections.set(
+        clientId,
+        new CanonicalStreamProjection(store, required(command.residentId, "residentId")),
+      );
+      return { clientId };
+    }
+    case "pullProjection": {
+      const clientId = required(command.clientId, "clientId");
+      const projection = projections.get(clientId);
+      if (projection === undefined) throw new Error(`unknown projection: ${clientId}`);
+      return projection.pull();
+    }
+    case "projectionSnapshot": {
+      const clientId = required(command.clientId, "clientId");
+      const projection = projections.get(clientId);
+      if (projection === undefined) throw new Error(`unknown projection: ${clientId}`);
+      return projection.snapshot();
+    }
+    case "stop":
+      await writer.close();
+      return "stopping";
+    default:
+      throw new Error(`unknown op: ${String(command.op)}`);
+  }
+}
+
+process.on("message", (message: Command) => {
+  void (async () => {
+    try {
+      const value = await handle(message);
+      await send({ requestId: message.requestId, ok: true, value });
+      if (message.op === "stop") process.disconnect?.();
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      await send({
+        requestId: message.requestId,
+        ok: false,
+        error: {
+          name: failure.name,
+          message: failure.message,
+          code: "code" in failure ? Reflect.get(failure, "code") : undefined,
+        },
+      });
+    }
+  })();
+});
+
+await send({ type: "ready", pid: process.pid });

--- a/tests/one-stream-core.test.ts
+++ b/tests/one-stream-core.test.ts
@@ -1,0 +1,196 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type CanonicalEvent,
+  type CanonicalEventDraft,
+  CanonicalStreamProjection,
+  type CanonicalStreamReadPort,
+  CanonicalStreamStore,
+  CanonicalStreamWriter,
+  IdempotencyConflictError,
+  ProjectionIntegrityError,
+  WriterOwnershipError,
+  normalizeDraft,
+} from "../src/one-stream/index.ts";
+
+const directories: string[] = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "mist-one-stream-core-"));
+  directories.push(directory);
+  return directory;
+}
+
+function draft(label: string): CanonicalEventDraft {
+  return {
+    purpose: "progress",
+    occurredAt: "2026-08-26T00:00:00.000Z",
+    workRef: "work-alpha",
+    authoritySource: { kind: "host", id: "mist-host" },
+    origin: {
+      reporter: { kind: "viewport", id: "viewport-a" },
+      subject: { kind: "work", id: "work-alpha" },
+      viewport: { windowId: "window-a", generation: 1 },
+    },
+    effect: {
+      state: "attempted",
+      requiresUserAction: false,
+      retry: "automatic",
+    },
+    artifactRef: null,
+    payload: { label, nested: { stable: true } },
+  };
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("canonical stream core", () => {
+  it("deduplicates an identical retry and rejects changed content without changing bytes", async () => {
+    const directory = temporaryDirectory();
+    const store = new CanonicalStreamStore({ dataDir: directory });
+    store.createStream("resident-a");
+    let sequence = 0;
+    const writer = new CanonicalStreamWriter(store, {
+      newEventId: () => {
+        sequence += 1;
+        return `event-${sequence}`;
+      },
+    });
+
+    const first = await writer.submit({
+      residentId: "resident-a",
+      idempotencyKey: "dispatch-1",
+      draft: draft("first"),
+    });
+    const retried = await writer.submit({
+      residentId: "resident-a",
+      idempotencyKey: "dispatch-1",
+      draft: draft("first"),
+    });
+
+    expect(retried).toEqual(first);
+    expect(store.events("resident-a")).toHaveLength(1);
+    expect(sequence).toBe(1);
+
+    const snapshotPath = join(directory, "resident-a.stream.json");
+    const before = readFileSync(snapshotPath, "utf8");
+    await expect(
+      writer.submit({
+        residentId: "resident-a",
+        idempotencyKey: "dispatch-1",
+        draft: draft("changed"),
+      }),
+    ).rejects.toBeInstanceOf(IdempotencyConflictError);
+    expect(readFileSync(snapshotPath, "utf8")).toBe(before);
+    expect(store.events("resident-a")).toHaveLength(1);
+
+    await writer.close();
+  });
+
+  it("keeps residents physically separate and restores contiguous stream state", async () => {
+    const directory = temporaryDirectory();
+    const firstStore = new CanonicalStreamStore({ dataDir: directory });
+    firstStore.createStream("resident-a");
+    firstStore.createStream("resident-b");
+    let sequence = 0;
+    const firstWriter = new CanonicalStreamWriter(firstStore, {
+      newEventId: () => {
+        sequence += 1;
+        return `event-${sequence}`;
+      },
+    });
+
+    await firstWriter.submit({
+      residentId: "resident-a",
+      idempotencyKey: "a-1",
+      draft: draft("A"),
+    });
+    await firstWriter.submit({
+      residentId: "resident-b",
+      idempotencyKey: "b-1",
+      draft: draft("B"),
+    });
+    await firstWriter.close();
+
+    const restored = new CanonicalStreamStore({ dataDir: directory });
+    expect(restored.events("resident-a").map((event) => event.payload)).toEqual([
+      { label: "A", nested: { stable: true } },
+    ]);
+    expect(restored.events("resident-b").map((event) => event.payload)).toEqual([
+      { label: "B", nested: { stable: true } },
+    ]);
+    expect(restored.eventsAfter("resident-a", 1)).toEqual([]);
+  });
+
+  it("allows only one writer for the same data root inside a host process", async () => {
+    const directory = temporaryDirectory();
+    const firstStore = new CanonicalStreamStore({ dataDir: directory });
+    firstStore.createStream("resident-a");
+    const firstWriter = new CanonicalStreamWriter(firstStore);
+    const secondStore = new CanonicalStreamStore({ dataDir: directory });
+
+    expect(() => new CanonicalStreamWriter(secondStore)).toThrow(WriterOwnershipError);
+
+    await firstWriter.close();
+    const replacement = new CanonicalStreamWriter(secondStore);
+    await replacement.close();
+  });
+
+  it("rejects a projection that preserves id and sequence but mutates payload", async () => {
+    const directory = temporaryDirectory();
+    const store = new CanonicalStreamStore({ dataDir: directory });
+    store.createStream("resident-a");
+    const writer = new CanonicalStreamWriter(store, { newEventId: () => "event-1" });
+    await writer.submit({
+      residentId: "resident-a",
+      idempotencyKey: "dispatch-1",
+      draft: draft("original"),
+    });
+    const original = store.events("resident-a")[0];
+    if (original === undefined) throw new Error("fixture event missing");
+    const mutated: CanonicalEvent = {
+      ...original,
+      payload: { label: "mutated", nested: { stable: true } },
+    };
+    const corruptReadPort: CanonicalStreamReadPort = {
+      eventsAfter: () => [mutated],
+    };
+    const projection = new CanonicalStreamProjection(corruptReadPort, "resident-a");
+
+    await expect(projection.pull()).rejects.toBeInstanceOf(ProjectionIntegrityError);
+    expect(projection.cursor).toBe(0);
+    expect(projection.snapshot()).toEqual([]);
+
+    await writer.close();
+  });
+
+  it("rejects extra authority-envelope fields and a tampered durable snapshot", async () => {
+    const withExtraField = { ...draft("original"), transcript: ["must not enter core"] };
+    expect(() => normalizeDraft(withExtraField)).toThrow("unexpected fields");
+
+    const directory = temporaryDirectory();
+    const store = new CanonicalStreamStore({ dataDir: directory });
+    store.createStream("resident-a");
+    const writer = new CanonicalStreamWriter(store, { newEventId: () => "event-1" });
+    await writer.submit({
+      residentId: "resident-a",
+      idempotencyKey: "dispatch-1",
+      draft: draft("original"),
+    });
+    await writer.close();
+
+    const snapshotPath = join(directory, "resident-a.stream.json");
+    const tampered = readFileSync(snapshotPath, "utf8").replace(
+      '"label":"original"',
+      '"label":"tampered"',
+    );
+    writeFileSync(snapshotPath, tampered);
+    expect(() => new CanonicalStreamStore({ dataDir: directory })).toThrow("payload hash mismatch");
+  });
+});

--- a/tests/one-stream-host.test.ts
+++ b/tests/one-stream-host.test.ts
@@ -1,0 +1,303 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  CanonicalEvent,
+  CanonicalEventDraft,
+  DeliveryReceipt,
+  WriterCheckpointName,
+} from "../src/one-stream/index.ts";
+
+type HostReply = {
+  requestId?: string;
+  type?: string;
+  pid?: number;
+  name?: WriterCheckpointName;
+  ok?: boolean;
+  value?: unknown;
+  error?: { name?: string; message?: string; code?: string };
+};
+
+const children: ChildProcess[] = [];
+const directories: string[] = [];
+const fixture = fileURLToPath(new URL("./fixtures/one-stream-host.ts", import.meta.url));
+let requestSequence = 0;
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "mist-one-stream-host-"));
+  directories.push(directory);
+  return directory;
+}
+
+function startHost(dataDir: string, haltAt?: WriterCheckpointName): ChildProcess {
+  const child = spawn(process.execPath, ["--import", "tsx", fixture], {
+    env: {
+      ...process.env,
+      MIST_ONE_STREAM_DIR: dataDir,
+      ...(haltAt === undefined ? {} : { MIST_ONE_STREAM_HALT_AT: haltAt }),
+    },
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.push(child);
+  return child;
+}
+
+function draft(label: string, viewportId: string): CanonicalEventDraft {
+  return {
+    purpose: "progress",
+    occurredAt: "2026-08-26T00:00:00.000Z",
+    workRef: `work-${label}`,
+    authoritySource: { kind: "host", id: "mist-host" },
+    origin: {
+      reporter: { kind: "viewport", id: viewportId },
+      subject: { kind: "work", id: `work-${label}` },
+      viewport: { windowId: viewportId, generation: 1 },
+    },
+    effect: {
+      state: "attempted",
+      requiresUserAction: false,
+      retry: "automatic",
+    },
+    artifactRef: null,
+    payload: { label },
+  };
+}
+
+function waitForReady(child: ChildProcess): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let stderr = "";
+    const timer = setTimeout(() => reject(new Error(`host startup timed out: ${stderr}`)), 10_000);
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    }
+    function onMessage(message: HostReply) {
+      if (message.type !== "ready" || typeof message.pid !== "number") return;
+      cleanup();
+      resolve(message.pid);
+    }
+    function onExit(code: number | null, signal: NodeJS.Signals | null) {
+      cleanup();
+      reject(new Error(`host exited ${String(code)}/${String(signal)} before ready: ${stderr}`));
+    }
+  });
+}
+
+function callHost<T>(child: ChildProcess, command: Record<string, unknown>): Promise<T> {
+  requestSequence += 1;
+  const requestId = `request-${requestSequence}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`host request timed out: ${requestId}`)),
+      5_000,
+    );
+    child.on("message", onMessage);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+    }
+    function onMessage(message: HostReply) {
+      if (message.requestId !== requestId) return;
+      cleanup();
+      if (message.ok === true) {
+        resolve(message.value as T);
+      } else {
+        reject(
+          new Error(`${message.error?.code ?? message.error?.name}: ${message.error?.message}`),
+        );
+      }
+    }
+    child.send?.({ ...command, requestId }, (error) => {
+      if (error === null) return;
+      cleanup();
+      reject(error);
+    });
+  });
+}
+
+async function stopHost(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  await callHost(child, { op: "stop" });
+  await exited;
+}
+
+async function submitUntilKilled(
+  child: ChildProcess,
+  checkpoint: WriterCheckpointName,
+  request: Record<string, unknown>,
+): Promise<void> {
+  requestSequence += 1;
+  const requestId = `doomed-${requestSequence}`;
+  const reached = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`checkpoint timed out: ${checkpoint}`)), 5_000);
+    child.on("message", onMessage);
+    function onMessage(message: HostReply) {
+      if (message.type !== "checkpoint" || message.name !== checkpoint) return;
+      clearTimeout(timer);
+      child.off("message", onMessage);
+      resolve();
+    }
+  });
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  child.send?.({ ...request, requestId });
+  await reached;
+  await exited;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    children.splice(0).map(async (child) => {
+      try {
+        await stopHost(child);
+      } catch {
+        child.kill();
+      }
+    }),
+  );
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("one canonical stream real host", () => {
+  it("orders concurrent viewport events once and gives all projections identical bytes", async () => {
+    const directory = temporaryDirectory();
+    const child = startHost(directory);
+    await waitForReady(child);
+
+    for (const [residentId, order] of [
+      ["resident-ab", ["A", "B"]],
+      ["resident-ba", ["B", "A"]],
+    ] as const) {
+      await callHost(child, { op: "create", residentId });
+      await callHost(child, {
+        op: "openProjection",
+        residentId,
+        clientId: `${residentId}-desktop`,
+      });
+      await callHost(child, { op: "openProjection", residentId, clientId: `${residentId}-mobile` });
+
+      const submissions = order.map((label) =>
+        callHost<DeliveryReceipt>(child, {
+          op: "submit",
+          residentId,
+          idempotencyKey: `${residentId}-${label}`,
+          draft: draft(label, `viewport-${label}`),
+        }),
+      );
+      await Promise.all(submissions);
+
+      const desktop = await callHost<CanonicalEvent[]>(child, {
+        op: "pullProjection",
+        clientId: `${residentId}-desktop`,
+      });
+      const mobile = await callHost<CanonicalEvent[]>(child, {
+        op: "pullProjection",
+        clientId: `${residentId}-mobile`,
+      });
+      await callHost(child, {
+        op: "openProjection",
+        residentId,
+        clientId: `${residentId}-offline`,
+      });
+      const offline = await callHost<CanonicalEvent[]>(child, {
+        op: "pullProjection",
+        clientId: `${residentId}-offline`,
+      });
+
+      expect(desktop).toEqual(mobile);
+      expect(mobile).toEqual(offline);
+      expect(desktop.map((event) => event.streamSeq)).toEqual([1, 2]);
+      expect(new Set(desktop.map((event) => event.eventId))).toHaveLength(2);
+      expect(desktop.map((event) => event.payloadHash)).toEqual(
+        mobile.map((event) => event.payloadHash),
+      );
+      expect(desktop.map((event) => event.payload)).toEqual(order.map((label) => ({ label })));
+    }
+
+    await stopHost(child);
+  });
+
+  for (const scenario of [
+    {
+      name: "generation before durable write",
+      checkpoint: "generated-before-write" as const,
+      expectedBeforeRetry: 0,
+    },
+    {
+      name: "durable write before delivery receipt",
+      checkpoint: "durable-write-before-receipt" as const,
+      expectedBeforeRetry: 1,
+    },
+  ]) {
+    it(`recovers ${scenario.name} without duplicate or false effect`, async () => {
+      const directory = temporaryDirectory();
+      const initializer = startHost(directory);
+      await waitForReady(initializer);
+      await callHost(initializer, { op: "create", residentId: "resident-a" });
+      await stopHost(initializer);
+
+      const doomed = startHost(directory, scenario.checkpoint);
+      await waitForReady(doomed);
+      await submitUntilKilled(doomed, scenario.checkpoint, {
+        op: "submit",
+        residentId: "resident-a",
+        idempotencyKey: "dispatch-1",
+        draft: draft("original", "viewport-a"),
+      });
+
+      const recovered = startHost(directory);
+      await waitForReady(recovered);
+      const beforeRetry = await callHost<CanonicalEvent[]>(recovered, {
+        op: "events",
+        residentId: "resident-a",
+      });
+      expect(beforeRetry).toHaveLength(scenario.expectedBeforeRetry);
+
+      const receipt = await callHost<DeliveryReceipt>(recovered, {
+        op: "submit",
+        residentId: "resident-a",
+        idempotencyKey: "dispatch-1",
+        draft: draft("original", "viewport-a"),
+      });
+      expect(receipt.phase).toBe("delivered");
+      expect(receipt).not.toHaveProperty("committedEffective");
+      expect(receipt).not.toHaveProperty("authorityHead");
+
+      const afterRetry = await callHost<CanonicalEvent[]>(recovered, {
+        op: "events",
+        residentId: "resident-a",
+      });
+      expect(afterRetry).toHaveLength(1);
+      expect(afterRetry[0]?.effect.state).toBe("attempted");
+      expect(afterRetry[0]?.eventId).toBe(receipt.eventId);
+
+      const snapshotPath = join(directory, "resident-a.stream.json");
+      const beforeConflict = readFileSync(snapshotPath, "utf8");
+      await expect(
+        callHost(recovered, {
+          op: "submit",
+          residentId: "resident-a",
+          idempotencyKey: "dispatch-1",
+          draft: draft("changed", "viewport-a"),
+        }),
+      ).rejects.toThrow("IDEMPOTENCY_CONFLICT");
+      expect(readFileSync(snapshotPath, "utf8")).toBe(beforeConflict);
+
+      await stopHost(recovered);
+    });
+  }
+});


### PR DESCRIPTION
Closes the first construction cut of #84.

This PR adds the resident-level canonical stream core required by OS-01 and OS-02:

- one host-owned writer assigns stable eventId and monotonic streamSeq
- per-resident durable snapshots with idempotency receipts
- identical retry returns the original receipt; changed-content retry fails closed
- desktop, mobile, and offline projections read the same verified event bytes
- subprocess fault injection covers generated-before-write and durable-write-before-receipt crashes
- delivery receipts remain separate from committed-effective business state

Evidence:
- npm run lint
- npm run typecheck
- npm test: 46 files passed, 3 skipped; 488 tests passed, 38 todo
- npm run acceptance: 6/6 foundation lights green
- OS-01/02 focused suite: 8/8 passed

This deliberately does not claim D9 complete. Message-turn wiring, MessageTree/head projection, first-party workspace/evidence views, lifecycle reporting, and reply routing remain OS-03 through OS-06.

Signed: Elio