### PR TITLE
test(session): MV-D10 换气不改窗身份——真宿主子进程集成判卷

### DIFF
--- a/tests/breath-host.test.ts
+++ b/tests/breath-host.test.ts
@@ -701,3 +701,138 @@ describe("猝死与流水残骸（real host subprocess）", () => {
     expect(debris[0]?.remnants?.some((remnant) => /同为 user/.test(remnant))).toBe(true);
   });
 });
+
+type Receipt = { residentId: string; windowId: string; generation: number; dispatchId: string };
+type Live = {
+  residentId: string;
+  windowId: string;
+  scopeId: string;
+  generation: number;
+  headId: string | null;
+} | null;
+type Letter = { title: string; windowId: string; residentId: string; generation: number };
+type Ctx = { notes: string[]; letter?: Letter };
+
+/**
+ * MV-D10 换气不改窗身份（real host subprocess）。
+ *
+ * 这一组走的是图纸 §4.1 的**换气**（BreathCycle.breathe：信落定 → 同一 windowId
+ * 换代），不是泳道 1 的 kill + 带 windowId 重开——tests/handover-letter.test.ts
+ * 那组只钉了「同 id 重开身份不变」这个更弱的性质，并明说 D10 要在真换气上重打。
+ *
+ * 判红样例两条都要被钉住：换气流程中重新签发 windowId；换气后旧 windowId 查不到该窗。
+ */
+describe("MV-D10 换气不改窗身份（real host subprocess）", () => {
+  it("windowId 逐字不变，只 generation + 1；旧 windowId 换气后仍解析到同一扇活窗", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const opened = await callHost<Opened>(child, { op: "open", residentId: "resident-d10" });
+    expect(opened.generation).toBe(1);
+
+    await callHost<Said>(child, { op: "say", windowId: opened.windowId, message: "换气前的一句" });
+    const before = await callHost<Live>(child, { op: "live", windowId: opened.windowId });
+    expect(before).not.toBeNull();
+
+    const breathed = await callHost<Opened>(child, {
+      op: "breathe",
+      windowId: opened.windowId,
+      draft: draft("D10 第一次换气", "身份不变只换代"),
+    });
+    // 逐字相等：不是「等价」，是同一串字节。
+    expect(breathed.windowId).toBe(opened.windowId);
+    expect(breathed.generation).toBe(opened.generation + 1);
+
+    // 旧 windowId 仍解析到活窗（判红样例二：换气后旧 windowId 查不到该窗）。
+    const after = await callHost<Live>(child, { op: "live", windowId: opened.windowId });
+    expect(after).not.toBeNull();
+    expect(after?.windowId).toBe(opened.windowId);
+    expect(after?.residentId).toBe(before?.residentId);
+    expect(after?.scopeId).toBe(before?.scopeId);
+    expect(after?.generation).toBe(2);
+    // 换气不是归档：同一 id 在归档簿里查不到「一扇死窗」。
+    const archived = await callHost<unknown>(child, { op: "archived", windowId: opened.windowId });
+    expect(archived).toBeNull();
+  });
+
+  it("换气前的派发回执换气后仍解析到同一扇窗：旧代回执按 generation 判旧，不是悬空", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d10b" });
+
+    const stale = await callHost<Receipt>(child, { op: "issueDispatch", windowId });
+    expect(stale).toMatchObject({ residentId: "resident-d10b", windowId, generation: 1 });
+    expect(await callHost<boolean>(child, { op: "belongsToActiveWindow", receipt: stale })).toBe(
+      true,
+    );
+
+    await callHost<Opened>(child, {
+      op: "breathe",
+      windowId,
+      draft: draft("D10 回执跨代", "回执按代际判旧"),
+    });
+
+    // 回执里的 windowId 换气后照样查得到窗——引用没有悬空。
+    const resolved = await callHost<Live>(child, { op: "live", windowId: stale.windowId });
+    expect(resolved?.windowId).toBe(windowId);
+    expect(resolved?.generation).toBe(2);
+    // 旧代回执被判旧（generation 不匹配），而不是「窗不存在」；新代回执立即有效。
+    expect(await callHost<boolean>(child, { op: "belongsToActiveWindow", receipt: stale })).toBe(
+      false,
+    );
+    const fresh = await callHost<Receipt>(child, { op: "issueDispatch", windowId });
+    expect(fresh.windowId).toBe(stale.windowId);
+    expect(fresh.generation).toBe(2);
+    expect(await callHost<boolean>(child, { op: "belongsToActiveWindow", receipt: fresh })).toBe(
+      true,
+    );
+  });
+
+  it("时间线锚点与外部绑定跨代仍指向同一扇窗；连续三次换气 id 不动、代际单调", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId: "resident-d10c" });
+    // 外部绑定：调用方拿到 windowId 当句柄，换气前配了阈值、开过回合。
+    await callHost(child, { op: "configureThreshold", windowId, tokens: 10_000 });
+    await callHost<Said>(child, { op: "say", windowId, message: "第一代的话" });
+
+    let generation = 1;
+    for (const title of ["D10 换气一", "D10 换气二", "D10 换气三"]) {
+      const breathed = await callHost<Opened>(child, {
+        op: "breathe",
+        windowId,
+        draft: draft(title, `第 ${generation} 代封缄`),
+      });
+      expect(breathed.windowId).toBe(windowId);
+      expect(breathed.generation).toBe(generation + 1);
+      generation = breathed.generation;
+
+      // 换气后阈值重新可配（新代尚无回合过闸），仍用同一个 windowId 句柄（MV-D02 的换代口径）。
+      await callHost(child, { op: "configureThreshold", windowId, tokens: 10_000 });
+      // 同一个句柄，换气后不重新 open、不重新登记，照常开工（外部绑定不悬空）。
+      const said = await callHost<Said>(child, {
+        op: "say",
+        windowId,
+        message: `第 ${generation} 代的话`,
+      });
+      expect(said.node.role).toBe("assistant");
+    }
+    expect(generation).toBe(4);
+
+    // 时间线锚点：每封信钉着同一 windowId 与写信那一代；新代 context 里的信指回同一扇窗。
+    const timeline = await callHost<Letter[]>(child, { op: "timeline" });
+    expect(timeline.map((letter) => letter.windowId)).toEqual([windowId, windowId, windowId]);
+    expect(timeline.map((letter) => letter.generation)).toEqual([1, 2, 3]);
+    expect(timeline.map((letter) => letter.title)).toEqual([
+      "D10 换气一",
+      "D10 换气二",
+      "D10 换气三",
+    ]);
+    const context = await callHost<Ctx>(child, { op: "context", windowId });
+    expect(context.letter?.windowId).toBe(windowId);
+    expect(context.letter?.generation).toBe(3);
+
+    // 全程只有一扇窗：归档簿里查不到它，活窗簿里它是第 4 代。
+    expect(await callHost<unknown>(child, { op: "archived", windowId })).toBeNull();
+    expect((await callHost<Live>(child, { op: "live", windowId }))?.generation).toBe(4);
+  });
+});

--- a/tests/fixtures/breath-host.ts
+++ b/tests/fixtures/breath-host.ts
@@ -36,8 +36,8 @@ import {
 } from "../../src/session/handover-letter.ts";
 import {
   type ActiveWindow,
-  type OpenOptions,
   type DispatchReceipt,
+  type OpenOptions,
   SessionRegistry,
 } from "../../src/session/session-registry.ts";
 import { type TurnGateEvent, ViewportTurnGate } from "../../src/session/turn-gate.ts";

--- a/tests/fixtures/breath-host.ts
+++ b/tests/fixtures/breath-host.ts
@@ -2,7 +2,7 @@
  * 换气集成宿主：子进程里装配生产件——SessionRegistry、MessageTreeStore +
  * Service、ViewportTurnGate（接阈值计量口）、BreathCycle（接流水卫生检查），
  * 父进程经 IPC 驱动，覆盖验收清单 D 区的 [集成] 半格
- * （MV-D01/D02/D04 后半/D07/D07b/D09）。
+ * （MV-D01/D02/D04 后半/D07/D07b/D09/D10）。
  *
  * 形状仿 turn-gate-host.ts。关键装配口径：
  *
@@ -37,6 +37,7 @@ import {
 import {
   type ActiveWindow,
   type OpenOptions,
+  type DispatchReceipt,
   SessionRegistry,
 } from "../../src/session/session-registry.ts";
 import { type TurnGateEvent, ViewportTurnGate } from "../../src/session/turn-gate.ts";
@@ -187,6 +188,9 @@ type HostCommand = {
     | "canonicalEvents"
     | "failNextAppend"
     | "failNextSwap"
+    | "live"
+    | "issueDispatch"
+    | "belongsToActiveWindow"
     | "stop";
   residentId?: string;
   windowId?: string;
@@ -196,6 +200,7 @@ type HostCommand = {
   tokens?: number;
   draft?: LetterDraft;
   debris?: unknown[];
+  receipt?: DispatchReceipt;
 };
 
 function requireString(value: string | undefined, field: string): string {
@@ -361,6 +366,24 @@ async function execute(command: HostCommand): Promise<unknown> {
     case "failNextSwap":
       registry.failNextReopen();
       return null;
+    case "live": {
+      // MV-D10 的解析口：按 windowId 查活窗。换气后旧 windowId 必须仍能查到——
+      // 查不到就是判红样例「换气后旧 windowId 查不到该窗」。
+      const window = registry.get(requireString(command.windowId, "windowId"));
+      if (window === undefined) return null;
+      return {
+        residentId: window.residentId,
+        windowId: window.windowId,
+        scopeId: window.scopeId,
+        generation: window.generation,
+        headId: window.headId,
+      };
+    }
+    case "issueDispatch":
+      return registry.issueDispatch(requireString(command.windowId, "windowId"));
+    case "belongsToActiveWindow":
+      if (command.receipt === undefined) throw new Error("missing receipt");
+      return registry.belongsToActiveWindow(command.receipt);
     case "stop":
       await canonicalWriter.close();
       return null;


### PR DESCRIPTION
## 一件事

**MV-D10 换气不改窗身份**——补 `[集成]` 判卷证据（真实宿主子进程），不改生产逻辑。Refs #81。

## 为什么只有测试

`BreathCycle.breathe` 的换代路径（`kill(windowId)` → `open(residentId, {windowId})`，同一同步区）已由 #117 落地，`tests/breath-cycle.test.ts` 有单元级 D10。但清单口径是 `[集成]` 由真宿主子进程判；`tests/handover-letter.test.ts` 的 D10 组自己注明只钉了「同 id 重开身份不变」这个更弱的性质、要在真换气上重打。这张 PR 就是那次重打。

## 改动

- `tests/fixtures/breath-host.ts`：新增三个 IPC 口 `live`（按 windowId 查活窗）、`issueDispatch`、`belongsToActiveWindow`，把注册表的解析面暴露给父进程。
- `tests/breath-host.test.ts`：新增 describe「MV-D10 换气不改窗身份（real host subprocess）」三条：
  1. `windowId` 逐字不变、只 `generation + 1`；换气后旧 `windowId` 仍解析到活窗、归档簿里查不到（判红样例二）。
  2. 换气前签发的派发回执，换气后其 `windowId` 仍查得到窗；旧代回执由 `belongsToActiveWindow` 按 generation 判旧，不是「窗不存在」；新代回执立即有效。
  3. 时间线锚点（三封信各钉 `(windowId, generation=1/2/3)`，新代 context.letter 指回同窗）与外部绑定（调用方拿 `windowId` 当句柄：换气后不重 open、不重登记，`configureThreshold` / `say` 照常）跨三次换气仍指向同一扇窗，代际 1→4 单调。

「外部绑定」仓内没有具名类型，我按 `docs/design/session-api.md` 的 `sessionId = windowId` 句柄语义解释：换气前缓存的 windowId 换气后必须仍可用。验收席若另有口径请指出。

## 验证

- `npm run lint` 绿、`npm run typecheck` 绿、`npm test` 483 passed / 38 todo（base 480，+3）。
- 变异探针三支，D10 三条全部转红（探针未入库）：
  - M1 换气流程中重新签发 `windowId`（`open` 不传 windowId）→ 3/3 红
  - M2 重开不递增 `generation` → 3/3 红
  - M3 `kill` 后不重开（旧 id 查不到）→ 3/3 红

## 不做的

- 清单 `acceptance/multi-viewport.md` **未勾**，留给验收席按惯例点灯。
- D09 我已在 #81 楼下释放给别家，本 PR 不碰。
