### PR TITLE
feat: wire dispatch lifecycle triples (MV-B03)

### DIFF
--- a/acceptance/multi-viewport.md
+++ b/acceptance/multi-viewport.md
@@ -15,7 +15,7 @@
 
 - [x] **MV-B01 回执窗级归属**：两窗并行派发，互相的迟到回执在对方窗不被误杀；同窗换代后旧代回执被丢弃。断言四象限全对。[集成]
 - [x] **MV-B02 住户级无当前代际**：试图在住户级查询「当前 generation」的 API 不存在或显式报错。[单测]
-- [ ] **MV-B03 日志三元组**：派发、回执、丢弃事件的日志必带完整 `(residentId, windowId, generation)`；出现缺字段的日志本条变红。[集成]
+- [x] **MV-B03 日志三元组**：派发、回执、丢弃事件的日志必带完整 `(residentId, windowId, generation)`；出现缺字段的日志本条变红。[集成]（2026-09-04 墨衡勾：`tests/dispatch-logging-host.test.ts` 经真实 MistDriver 子进程调用 responder；成功链逐条产出 dispatch/receipt，回应在途时 kill 原窗则产出 dropped，三类事件均逐字段断言完整三元组与同一 dispatchId；迟到结果零落树。删任一三元组字段或旁路 SessionRegistry 回执，专项即红）
 
 ## C. 权威事实账与开工闸
 

--- a/acceptance/multi-viewport.md
+++ b/acceptance/multi-viewport.md
@@ -15,7 +15,7 @@
 
 - [x] **MV-B01 回执窗级归属**：两窗并行派发，互相的迟到回执在对方窗不被误杀；同窗换代后旧代回执被丢弃。断言四象限全对。[集成]
 - [x] **MV-B02 住户级无当前代际**：试图在住户级查询「当前 generation」的 API 不存在或显式报错。[单测]
-- [x] **MV-B03 日志三元组**：派发、回执、丢弃事件的日志必带完整 `(residentId, windowId, generation)`；出现缺字段的日志本条变红。[集成]（2026-09-04 墨安勾：`tests/dispatch-logging-host.test.ts` 经真实 MistDriver 子进程调用 responder；成功链逐条产出 dispatch/receipt，回应在途时 kill 原窗则产出 dropped，三类事件均逐字段断言完整三元组与同一 dispatchId；迟到结果零落树。删任一三元组字段或旁路 SessionRegistry 回执，专项即红）
+- [ ] **MV-B03 日志三元组**：派发、回执、丢弃事件的日志必带完整 `(residentId, windowId, generation)`；出现缺字段的日志本条变红。[集成]
 
 ## C. 权威事实账与开工闸
 

--- a/acceptance/multi-viewport.md
+++ b/acceptance/multi-viewport.md
@@ -15,7 +15,7 @@
 
 - [x] **MV-B01 回执窗级归属**：两窗并行派发，互相的迟到回执在对方窗不被误杀；同窗换代后旧代回执被丢弃。断言四象限全对。[集成]
 - [x] **MV-B02 住户级无当前代际**：试图在住户级查询「当前 generation」的 API 不存在或显式报错。[单测]
-- [x] **MV-B03 日志三元组**：派发、回执、丢弃事件的日志必带完整 `(residentId, windowId, generation)`；出现缺字段的日志本条变红。[集成]（2026-09-04 墨衡勾：`tests/dispatch-logging-host.test.ts` 经真实 MistDriver 子进程调用 responder；成功链逐条产出 dispatch/receipt，回应在途时 kill 原窗则产出 dropped，三类事件均逐字段断言完整三元组与同一 dispatchId；迟到结果零落树。删任一三元组字段或旁路 SessionRegistry 回执，专项即红）
+- [x] **MV-B03 日志三元组**：派发、回执、丢弃事件的日志必带完整 `(residentId, windowId, generation)`；出现缺字段的日志本条变红。[集成]（2026-09-04 墨安勾：`tests/dispatch-logging-host.test.ts` 经真实 MistDriver 子进程调用 responder；成功链逐条产出 dispatch/receipt，回应在途时 kill 原窗则产出 dropped，三类事件均逐字段断言完整三元组与同一 dispatchId；迟到结果零落树。删任一三元组字段或旁路 SessionRegistry 回执，专项即红）
 
 ## C. 权威事实账与开工闸
 

--- a/src/acceptance-driver.ts
+++ b/src/acceptance-driver.ts
@@ -23,6 +23,7 @@ import type { BootPack, HarnessDriver, HistoryNode, MemoryEntry } from "../accep
 import { buildBootPack as assembleBootPack } from "./bootpack.ts";
 import {
   type AssistantReply,
+  type DispatchEventLogger,
   MessageTreeService,
   MessageTreeStore,
   type SessionHeadPort,
@@ -45,6 +46,8 @@ export interface CreateDriverOptions {
   factLedger?: FactLedger;
   /** 闸事件日志口；不给则事件落 no-op（ViewportTurnGate 的默认）。 */
   turnEventLogger?: TurnEventLogger;
+  /** 真正 responder 派发、成功回执与迟到丢弃的窗级事件日志（MV-B03）。 */
+  dispatchEventLogger?: DispatchEventLogger;
 }
 
 /**
@@ -118,6 +121,10 @@ class MistDriver implements HarnessDriver {
         assistantReply: options.reply ?? ((_residentId, message) => `收到：${message}`),
         // exactOptionalPropertyTypes 下不能显式塞 undefined：有闸才带这个键。
         ...(turnGate === null ? {} : { turnGate }),
+        dispatch: this.#sessions,
+        ...(options.dispatchEventLogger === undefined
+          ? {}
+          : { dispatchEventLogger: options.dispatchEventLogger }),
       },
     );
     this.#migration = createResidentMigrationService(this.#store, this.#messageTreeStore);

--- a/src/message-tree/index.ts
+++ b/src/message-tree/index.ts
@@ -3,14 +3,22 @@ export {
   NODE_UNAVAILABLE,
   nodeUnavailable,
 } from "./errors.ts";
-export { MessageTreeService } from "./service.ts";
+export {
+  DISPATCH_RESULT_DROPPED,
+  DispatchResultDroppedError,
+  MessageTreeService,
+} from "./service.ts";
 export type {
   AssistantReply,
+  DispatchEvent,
+  DispatchEventLogger,
+  DispatchLifecyclePort,
   MessageCommitBoundary,
   MessageTreeSayOptions,
   MessageTreeServiceOptions,
   SessionHeadPort,
   TurnGate,
   TurnPass,
+  WindowDispatchReceipt,
 } from "./service.ts";
 export { MessageTreeStore } from "./store.ts";

--- a/src/message-tree/service.ts
+++ b/src/message-tree/service.ts
@@ -20,6 +20,48 @@ export interface SessionHeadPort {
 export type AssistantReply = (residentId: string, message: string) => string | Promise<string>;
 
 /**
+ * 一次真实模型派发的窗级凭证。形状与 SessionRegistry.DispatchReceipt 一致，
+ * 但消息树只依赖这份窄端口，不反向拥有会话注册表。
+ */
+export interface WindowDispatchReceipt {
+  residentId: string;
+  windowId: string;
+  generation: number;
+  dispatchId: string;
+}
+
+/** 派发链三个可观察落点（MV-B03）；每一类都必须带完整窗三元组。 */
+export interface DispatchEvent extends WindowDispatchReceipt {
+  event: "dispatch" | "receipt" | "dropped";
+  detail: string;
+}
+
+export interface DispatchEventLogger {
+  log(event: DispatchEvent): void;
+}
+
+/**
+ * 会话层给真实 responder 的回执接缝：开工前签发，结果回来后按窗与代际验归属。
+ */
+export interface DispatchLifecyclePort {
+  issueDispatch(windowId: string): WindowDispatchReceipt;
+  belongsToActiveWindow(receipt: WindowDispatchReceipt): boolean;
+}
+
+export const DISPATCH_RESULT_DROPPED = "DISPATCH_RESULT_DROPPED" as const;
+
+/** 迟到结果被代际闸丢弃；响亮失败，调用方不得把它当成已落树回应。 */
+export class DispatchResultDroppedError extends Error {
+  readonly code = DISPATCH_RESULT_DROPPED;
+  constructor(receipt: WindowDispatchReceipt) {
+    super(
+      `${DISPATCH_RESULT_DROPPED}: ${receipt.residentId}/${receipt.windowId} generation=${receipt.generation} dispatch=${receipt.dispatchId}`,
+    );
+    this.name = "DispatchResultDroppedError";
+  }
+}
+
+/**
  * 一轮开工的通行凭证（开工闸的回件，图纸 docs/design/multi-viewport.md §3.2）。
  *
  * 闸在模型调用之前发凭证：contextPrefix 是本轮必须先进上下文的缺口条目，
@@ -53,6 +95,10 @@ export interface MessageTreeServiceOptions {
   assistantReply?: AssistantReply;
   /** 不接闸时行为与接闸前完全一致——既有路径一个字不变。 */
   turnGate?: TurnGate;
+  /** 不接派发端口时保留旧的直调 responder 行为，供纯消息树嵌入方使用。 */
+  dispatch?: DispatchLifecyclePort;
+  /** 派发事件日志口；不提供时只执行回执过滤，不产生日志。 */
+  dispatchEventLogger?: DispatchEventLogger;
 }
 
 /**
@@ -67,6 +113,8 @@ export interface MessageCommitBoundary {
 
 export interface MessageTreeSayOptions {
   readonly commitBoundary?: MessageCommitBoundary;
+  /** Caller-specific window authority; replaces the default port, never issues a second receipt. */
+  readonly dispatch?: DispatchLifecyclePort;
   /** Host-owned operation identity for crash-safe retry after tree commit but before outer receipt. */
   readonly idempotencyKey?: string;
 }
@@ -83,6 +131,8 @@ export class MessageTreeService {
   readonly #sessionHeads: SessionHeadPort;
   readonly #assistantReply: AssistantReply;
   readonly #turnGate: TurnGate | undefined;
+  readonly #dispatch: DispatchLifecyclePort | undefined;
+  readonly #dispatchEventLogger: DispatchEventLogger | undefined;
 
   constructor(
     store: MessageTreeStore,
@@ -93,6 +143,16 @@ export class MessageTreeService {
     this.#sessionHeads = sessionHeads;
     this.#assistantReply = options.assistantReply ?? echoReply;
     this.#turnGate = options.turnGate;
+    this.#dispatch = options.dispatch;
+    this.#dispatchEventLogger = options.dispatchEventLogger;
+  }
+
+  #logDispatch(
+    event: DispatchEvent["event"],
+    receipt: WindowDispatchReceipt,
+    detail: string,
+  ): void {
+    this.#dispatchEventLogger?.log({ event, ...receipt, detail });
   }
 
   /** 原子落 user + assistant；两节点都存在以后才允许推进会话 head。 */
@@ -151,8 +211,25 @@ export class MessageTreeService {
       pass !== undefined && pass.contextPrefix.length > 0
         ? [...pass.contextPrefix, message].join("\n\n")
         : message;
+    // Only a fresh responder call issues a receipt. Callers may narrow the authority port,
+    // but issuance and lifecycle logging stay here; committed replays bypass both.
+    const dispatch = options.dispatch ?? this.#dispatch;
+    const dispatchReceipt = dispatch?.issueDispatch(windowId);
+    if (dispatchReceipt !== undefined) {
+      this.#logDispatch("dispatch", dispatchReceipt, "responder 已开始处理本轮");
+    }
     const assistantContent = await this.#assistantReply(residentId, prompt);
     const commit = (): HistoryNode => {
+      // Check inside the final synchronous mutation, including any caller boundary. A stale
+      // result must be logged with its original dispatch ID before touching the tree or head.
+      if (
+        dispatchReceipt !== undefined &&
+        dispatch !== undefined &&
+        !dispatch.belongsToActiveWindow(dispatchReceipt)
+      ) {
+        this.#logDispatch("dropped", dispatchReceipt, "结果返回时原窗代际已不再活跃");
+        throw new DispatchResultDroppedError(dispatchReceipt);
+      }
       const pair =
         options.idempotencyKey === undefined
           ? this.#store.appendPair(residentId, message, assistantContent, parentId)
@@ -167,6 +244,9 @@ export class MessageTreeService {
       // 回执只在落树 + head 推进都成功之后发出：先 ack 后落树会让「已确认」
       // 覆盖「没送到」，回执丢失归传播机制的前提是先证明这轮真的开工了（MV-C05）。
       pass?.commit();
+      if (dispatchReceipt !== undefined) {
+        this.#logDispatch("receipt", dispatchReceipt, "回应已落树且窗 head 已推进");
+      }
       return pair.assistant;
     };
     return options.commitBoundary?.commit(commit) ?? commit();

--- a/src/one-stream/reply-router.ts
+++ b/src/one-stream/reply-router.ts
@@ -1,4 +1,4 @@
-import type { MessageTreeService } from "../message-tree/service.ts";
+import { DispatchResultDroppedError, type MessageTreeService } from "../message-tree/service.ts";
 import type { SessionRegistry } from "../session/session-registry.ts";
 import type { CanonicalEvent, EventActor, EventViewport } from "./event-contract.ts";
 import type { CanonicalStreamReadPort } from "./store.ts";
@@ -250,38 +250,50 @@ export class MessageTreeWorkspaceReplyDelivery implements WorkspaceReplyDelivery
   }
 
   async deliver(request: WorkspaceReplyDeliveryRequest): Promise<WorkspaceReplyDeliveryReceipt> {
-    let dispatch: ReturnType<SessionRegistry<unknown>["issueDispatch"]>;
-    try {
-      dispatch = this.#sessions.issueDispatch(request.viewport.windowId);
-    } catch {
-      throw new ReplyRouteError("REPLY_TARGET_STALE", "workspace changed before dispatch");
-    }
-    if (
-      dispatch.residentId !== request.residentId ||
-      dispatch.generation !== request.viewport.generation
-    ) {
-      throw new ReplyRouteError("REPLY_TARGET_STALE", "workspace changed before dispatch");
-    }
-    const assistant = await this.#service.say(
-      request.residentId,
-      request.text,
-      request.viewport.windowId,
-      {
+    const assertCurrentTarget = (): void => {
+      const window = this.#sessions.get(request.viewport.windowId);
+      if (
+        window === undefined ||
+        window.residentId !== request.residentId ||
+        window.generation !== request.viewport.generation
+      ) {
+        throw new ReplyRouteError("REPLY_TARGET_STALE", "workspace changed before delivery");
+      }
+    };
+    // Reject stale requests before say reads the head, including durable replays. Minting a
+    // dispatch receipt belongs to the service's fresh responder path, never to this preflight.
+    assertCurrentTarget();
+    let dispatched = false;
+    const assistant = await this.#service
+      .say(request.residentId, request.text, request.viewport.windowId, {
         idempotencyKey: `blocked-reply-delivery:${request.eventId}`,
+        dispatch: {
+          issueDispatch: (windowId) => {
+            assertCurrentTarget();
+            const receipt = this.#sessions.issueDispatch(windowId);
+            dispatched = true;
+            return receipt;
+          },
+          belongsToActiveWindow: (receipt) => this.#sessions.belongsToActiveWindow(receipt),
+        },
         commitBoundary: {
           commit: (mutation) => {
-            if (!this.#sessions.belongsToActiveWindow(dispatch)) {
-              throw new ReplyRouteError(
-                "REPLY_TARGET_STALE",
-                "workspace changed while the reply was in flight",
-              );
-            }
-            // No await occurs between this generation check and the synchronous tree/head commit.
+            // Fresh results are guarded and logged inside mutation by the service. A replay
+            // has no dispatch receipt, so validate its target here before repairing the head.
+            if (!dispatched) assertCurrentTarget();
             return mutation();
           },
         },
-      },
-    );
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DispatchResultDroppedError) {
+          throw new ReplyRouteError(
+            "REPLY_TARGET_STALE",
+            "workspace changed while the reply was in flight",
+          );
+        }
+        throw error;
+      });
     return Object.freeze({
       phase: "workspace-committed",
       residentId: request.residentId,

--- a/tests/dispatch-logging-host.test.ts
+++ b/tests/dispatch-logging-host.test.ts
@@ -1,0 +1,160 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type { HistoryNode } from "../acceptance/driver.ts";
+import { DISPATCH_RESULT_DROPPED, type DispatchEvent } from "../src/message-tree/index.ts";
+
+type HostReply = {
+  requestId?: string;
+  type?: string;
+  pid?: number;
+  ok?: boolean;
+  value?: unknown;
+  error?: { name?: string; message?: string; code?: string };
+};
+
+const children: ChildProcess[] = [];
+const fixture = fileURLToPath(new URL("./fixtures/dispatch-logging-host.ts", import.meta.url));
+
+function startHost(): ChildProcess {
+  const child = spawn(process.execPath, ["--import", "tsx", fixture], {
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.push(child);
+  return child;
+}
+
+function waitForReady(child: ChildProcess): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let stderr = "";
+    const timer = setTimeout(() => reject(new Error(`host startup timed out: ${stderr}`)), 10_000);
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    }
+    function onMessage(message: HostReply) {
+      if (message.type !== "ready" || typeof message.pid !== "number") return;
+      cleanup();
+      resolve(message.pid);
+    }
+    function onExit(code: number | null) {
+      cleanup();
+      reject(new Error(`host exited ${String(code)} before ready: ${stderr}`));
+    }
+  });
+}
+
+let requestSeq = 0;
+function callHost<T>(child: ChildProcess, command: Record<string, unknown>): Promise<T> {
+  requestSeq += 1;
+  const requestId = `request-${requestSeq}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`host request timed out: ${requestId}`)),
+      5_000,
+    );
+    child.on("message", onMessage);
+
+    function cleanup() {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+    }
+    function onMessage(message: HostReply) {
+      if (message.requestId !== requestId) return;
+      cleanup();
+      if (message.ok === true) {
+        resolve(message.value as T);
+      } else {
+        reject(
+          new Error(`${message.error?.code ?? message.error?.name}: ${message.error?.message}`),
+        );
+      }
+    }
+
+    child.send?.({ ...command, requestId }, (error) => {
+      if (error === null) return;
+      cleanup();
+      reject(error);
+    });
+  });
+}
+
+async function stopHost(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  await callHost(child, { op: "stop" });
+  await exited;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    children.splice(0).map(async (child) => {
+      try {
+        await stopHost(child);
+      } catch {
+        child.kill();
+      }
+    }),
+  );
+});
+
+describe("MV-B03 dispatch logging (real host subprocess)", () => {
+  it("logs complete triples for dispatch/receipt/drop and leaves a late result out of history", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const residentId = await callHost<string>(child, {
+      op: "createResident",
+      name: "placeholder-b03",
+    });
+
+    await callHost(child, { op: "holdNext" });
+    const pending = callHost(child, { op: "say", residentId, message: "会在返回前失去原窗" });
+
+    const started = await callHost<DispatchEvent[]>(child, { op: "events" });
+    expect(started).toHaveLength(1);
+    expect(started[0]?.event).toBe("dispatch");
+
+    await callHost(child, { op: "killSession", residentId });
+    await callHost(child, { op: "release" });
+    await expect(pending).rejects.toThrow(DISPATCH_RESULT_DROPPED);
+
+    const afterDrop = await callHost<DispatchEvent[]>(child, { op: "events" });
+    expect(afterDrop.map((event) => event.event)).toEqual(["dispatch", "dropped"]);
+    expect(afterDrop[1]).toMatchObject({
+      residentId,
+      windowId: afterDrop[0]?.windowId,
+      generation: afterDrop[0]?.generation,
+      dispatchId: afterDrop[0]?.dispatchId,
+    });
+    expect(await callHost<HistoryNode[]>(child, { op: "history", residentId })).toEqual([]);
+
+    await callHost(child, { op: "say", residentId, message: "新窗正常回合" });
+    const all = await callHost<DispatchEvent[]>(child, { op: "events" });
+    expect(all.map((event) => event.event)).toEqual(["dispatch", "dropped", "dispatch", "receipt"]);
+    expect(all[3]).toMatchObject({
+      residentId,
+      windowId: all[2]?.windowId,
+      generation: all[2]?.generation,
+      dispatchId: all[2]?.dispatchId,
+    });
+
+    // 三类事件逐字段验完整三元组；少任一字段，本条直接红。
+    for (const event of all) {
+      expect(event.residentId).toBe(residentId);
+      expect(event.windowId).toMatch(/^w_[0-9A-Z]{26}$/);
+      expect(event.generation).toBe(1);
+      expect(event.dispatchId).toMatch(/^dispatch-/);
+    }
+    expect(all[2]?.windowId).not.toBe(all[0]?.windowId);
+    expect(await callHost<HistoryNode[]>(child, { op: "history", residentId })).toHaveLength(2);
+  });
+});

--- a/tests/fixtures/dispatch-logging-host.ts
+++ b/tests/fixtures/dispatch-logging-host.ts
@@ -1,0 +1,103 @@
+/**
+ * MV-B03 集成宿主：真实 MistDriver → MessageTreeService → responder，父进程
+ * 通过 IPC 在 responder 在途时杀窗，验证派发、回执、丢弃三类日志。
+ */
+
+import { createDriver } from "../../src/acceptance-driver.ts";
+import type { DispatchEvent } from "../../src/message-tree/index.ts";
+
+const events: DispatchEvent[] = [];
+let holdNextReply = false;
+let releaseHeldReply: ((value: string) => void) | null = null;
+
+const driver = createDriver({
+  dispatchEventLogger: {
+    log: (event) => events.push(event),
+  },
+  reply: (_residentId, message) => {
+    if (!holdNextReply) return `回应：${message}`;
+    holdNextReply = false;
+    return new Promise<string>((resolve) => {
+      releaseHeldReply = resolve;
+    });
+  },
+});
+
+type HostCommand = {
+  requestId: string;
+  op:
+    | "createResident"
+    | "holdNext"
+    | "say"
+    | "killSession"
+    | "release"
+    | "events"
+    | "history"
+    | "stop";
+  residentId?: string;
+  name?: string;
+  message?: string;
+};
+
+function requireString(value: string | undefined, field: string): string {
+  if (value === undefined) throw new Error(`missing ${field}`);
+  return value;
+}
+
+async function execute(command: HostCommand): Promise<unknown> {
+  switch (command.op) {
+    case "createResident":
+      return driver.createResident(requireString(command.name, "name"));
+    case "holdNext":
+      if (releaseHeldReply !== null) throw new Error("a reply is already held");
+      holdNextReply = true;
+      return null;
+    case "say":
+      return driver.say(
+        requireString(command.residentId, "residentId"),
+        requireString(command.message, "message"),
+      );
+    case "killSession":
+      await driver.killSession(requireString(command.residentId, "residentId"));
+      return null;
+    case "release": {
+      const release = releaseHeldReply;
+      if (release === null) throw new Error("no reply is held");
+      releaseHeldReply = null;
+      release("迟到回应");
+      return null;
+    }
+    case "events":
+      return structuredClone(events);
+    case "history":
+      return driver.history(requireString(command.residentId, "residentId"));
+    case "stop":
+      return null;
+  }
+}
+
+process.on("message", (raw) => {
+  const command = raw as HostCommand;
+  void (async () => {
+    try {
+      const value = await execute(command);
+      process.send?.({ requestId: command.requestId, ok: true, value });
+      if (command.op === "stop") setImmediate(() => process.exit(0));
+    } catch (error) {
+      process.send?.({
+        requestId: command.requestId,
+        ok: false,
+        error: {
+          name: error instanceof Error ? error.name : "Error",
+          message: error instanceof Error ? error.message : String(error),
+          code:
+            typeof error === "object" && error !== null && "code" in error
+              ? String(error.code)
+              : undefined,
+        },
+      });
+    }
+  })();
+});
+
+process.send?.({ type: "ready", pid: process.pid });

--- a/tests/one-stream-reply-router.test.ts
+++ b/tests/one-stream-reply-router.test.ts
@@ -1,8 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import { MessageTreeService, MessageTreeStore } from "../src/message-tree/index.ts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type DispatchEvent,
+  MessageTreeService,
+  MessageTreeStore,
+} from "../src/message-tree/index.ts";
 import {
   BlockedReplyRouter,
   BoundedWorkEventPort,
@@ -30,6 +34,7 @@ async function assembly(
   const second = sessions.open("resident-a", { context: null });
   const tree = new MessageTreeStore();
   tree.createRoom("resident-a");
+  const dispatchEvents: DispatchEvent[] = [];
   const service = new MessageTreeService(
     tree,
     {
@@ -37,6 +42,8 @@ async function assembly(
       setHead: (windowId, headId) => sessions.setHead(windowId, headId),
     },
     {
+      dispatch: sessions,
+      dispatchEventLogger: { log: (event) => dispatchEvents.push(event) },
       assistantReply:
         options.assistantReply ??
         ((_residentId, message) => {
@@ -86,10 +93,69 @@ async function assembly(
     second,
     blocked,
     router,
+    dispatchEvents,
   };
 }
 
 describe("OS-06 canonical blocked reply routing", () => {
+  it("issues one receipt for a responder call and none for a committed replay", async () => {
+    const assistantReply = vi.fn((_residentId: string, message: string) => `reply:${message}`);
+    const { writer, sessions, first, blocked, delivery, tree, dispatchEvents } = await assembly({
+      assistantReply,
+    });
+    const issueDispatch = vi.spyOn(sessions, "issueDispatch");
+    const request = {
+      residentId: "resident-a",
+      text: "answer-once",
+      eventId: blocked[0]?.eventId ?? "missing-blocker",
+      workRef: "work-1",
+      viewport: { windowId: first.windowId, generation: first.generation },
+    };
+    const committed = await delivery.deliver(request);
+    expect(issueDispatch).toHaveBeenCalledTimes(1);
+    expect(dispatchEvents.map((event) => event.event)).toEqual(["dispatch", "receipt"]);
+    for (const event of dispatchEvents) {
+      expect(event).toMatchObject(issueDispatch.mock.results[0]?.value);
+    }
+
+    await expect(delivery.deliver(request)).resolves.toEqual(committed);
+    expect(issueDispatch).toHaveBeenCalledTimes(1);
+    expect(assistantReply).toHaveBeenCalledTimes(1);
+    expect(dispatchEvents).toHaveLength(2);
+    expect(tree.history("resident-a")).toHaveLength(2);
+
+    sessions.kill(first.windowId);
+    sessions.open("resident-a", { windowId: first.windowId, context: null });
+    await expect(delivery.deliver(request)).rejects.toMatchObject({ code: "REPLY_TARGET_STALE" });
+    expect(issueDispatch).toHaveBeenCalledTimes(1);
+    expect(sessions.getHead(first.windowId)).toBeNull();
+    expect(tree.history("resident-a")).toHaveLength(2);
+    await writer.close();
+  });
+
+  it("rejects an archived delivery before issuing a receipt or calling the responder", async () => {
+    const assistantReply = vi.fn(() => "must not run");
+    const { writer, sessions, first, delivery, tree, dispatchEvents } = await assembly({
+      assistantReply,
+    });
+    const issueDispatch = vi.spyOn(sessions, "issueDispatch");
+    sessions.kill(first.windowId);
+    await expect(
+      delivery.deliver({
+        residentId: "resident-a",
+        text: "stale",
+        eventId: "archived-blocker",
+        workRef: "work-1",
+        viewport: { windowId: first.windowId, generation: first.generation },
+      }),
+    ).rejects.toMatchObject({ code: "REPLY_TARGET_STALE" });
+    expect(issueDispatch).not.toHaveBeenCalled();
+    expect(assistantReply).not.toHaveBeenCalled();
+    expect(dispatchEvents).toEqual([]);
+    expect(tree.history("resident-a")).toEqual([]);
+    await writer.close();
+  });
+
   it("routes explicit handles exactly, allows one naked target, and never guesses among two", async () => {
     const { writer, sessions, tree, first, second, blocked, router } = await assembly();
     const before = JSON.stringify(tree.history("resident-a"));
@@ -438,7 +504,7 @@ describe("OS-06 canonical blocked reply routing", () => {
     const replyReleased = new Promise<void>((resolve) => {
       releaseReply = resolve;
     });
-    const { writer, sessions, tree, first, blocked, router } = await assembly({
+    const { writer, sessions, tree, first, blocked, router, dispatchEvents } = await assembly({
       assistantReply: async (_residentId, message) => {
         markStarted();
         await replyReleased;
@@ -446,6 +512,7 @@ describe("OS-06 canonical blocked reply routing", () => {
       },
     });
 
+    const issueDispatch = vi.spyOn(sessions, "issueDispatch");
     const inFlight = router.route({
       residentId: "resident-a",
       text: "old-generation",
@@ -461,6 +528,11 @@ describe("OS-06 canonical blocked reply routing", () => {
     releaseReply();
 
     await expect(inFlight).rejects.toMatchObject({ code: "REPLY_TARGET_STALE" });
+    expect(issueDispatch).toHaveBeenCalledTimes(1);
+    expect(dispatchEvents.map((event) => event.event)).toEqual(["dispatch", "dropped"]);
+    for (const event of dispatchEvents) {
+      expect(event).toMatchObject(issueDispatch.mock.results[0]?.value);
+    }
     expect(tree.history("resident-a")).toEqual([]);
     expect(sessions.getHead(first.windowId)).toBeNull();
     await writer.close();


### PR DESCRIPTION
一次 responder 调用现在只签发一份窗级回执，`dispatch`、`receipt`、`dropped` 使用同一个 `dispatchId` 和完整 `(residentId, windowId, generation)`。结果回来后在同步落树边界核验归属；原窗已关闭或换代时先记丢弃日志，树和 head 均不写入。

已重基到 `aab9c0ec3263891c6002c396b321cbbb5118c8ea`（含 #141）。`MessageTreeWorkspaceReplyDelivery` 复用 `MessageTreeService` 的唯一签发与校验路径，保留一窗流 `REPLY_TARGET_STALE` 错误契约、commit boundary、幂等落树和崩溃重放。已提交结果的重放不调用 responder、不签新 ID，也不把后续 head 倒退；失效目标仍被拒绝。

验证：
- `npm run lint`：147 files，无问题；`npm run typecheck`：通过。
- `npm test`：51 files passed / 3 skipped；536 passed / 38 todo / 0 failed，包含 message-tree、one-stream 全组及真实子进程 dispatch 宿主测试。
- `npm run acceptance`：6/6 绿。
- 回归先红后绿：仅解冲突时，新测试抓到每轮 `issueDispatch` 调用两次；修复后成功/迟到链均只调用一次，事件 ID 一致，已提交重放零新增签发，关闭后的结果零落树。

`acceptance/multi-viewport.md` 与当前 main 一致，MV-B03 保持未勾，等待独立复验；不沿用旧 head 的 APPROVE。未合并本 PR。

没有 logger 的嵌入方不产生日志；没有派发端口的纯消息树调用继续兼容。变更不涉及 canonical event 存储格式或历史数据迁移。回滚可 revert 本 PR 的最终合入提交；重基前分支及 PR 元数据显式备份在本地 `backups/mist-pr135-rebase-20260905-162052/`，原工作区保留。

Refs #79

——墨安
