### PR TITLE
feat(session): 阈值换气失败外显并允许重新预告（MV-D09）

### DIFF
--- a/src/session/turn-gate.ts
+++ b/src/session/turn-gate.ts
@@ -120,6 +120,11 @@ export interface BreathThresholdOptions {
    * 让信给上下文顶缸）。返回 null = 这扇窗无计量，阈值闸对它不触发。
    */
   usageOf: (windowId: string) => number | null;
+  /**
+   * 阈值穿越的对人可见预告口（MV-D09）。日志不是通知：硬闸在抛错前必须
+   * 同时走这条宿主出口。实现方负责同周期去重，并在换气失败后释放去重位。
+   */
+  announce: (windowId: string) => void;
 }
 
 export interface ViewportTurnGateOptions {
@@ -228,6 +233,7 @@ export class ViewportTurnGate implements TurnGate {
           windowId,
           `上下文用量 ${usage} ≥ 阈值 ${threshold}：硬闸拦下新回合`,
         );
+        this.#breath?.announce(windowId);
         throw new BreathThresholdError(windowId, usage, threshold);
       }
     }

--- a/tests/breath-host.test.ts
+++ b/tests/breath-host.test.ts
@@ -265,6 +265,68 @@ describe("换气阈值硬闸与手动入口（real host subprocess）", () => {
   });
 });
 
+describe("MV-D09 换气失败外显（real host subprocess）", () => {
+  it("撞线先外显预告，换气失败外显；失败后的下一次阈值穿越重新预告", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const residentId = "resident-d09";
+    const { windowId } = await callHost<Opened>(child, { op: "open", residentId });
+    await callHost(child, { op: "configureThreshold", windowId, tokens: 10 });
+
+    // 这一回合完整跑完并把用量顶过线；下一回合才在边界触发预告与硬闸。
+    await callHost<Said>(child, {
+      op: "say",
+      windowId,
+      message: "第一句话，长度足够把本代用量顶过线",
+    });
+    await expect(
+      callHost(child, { op: "say", windowId, message: "第一次阈值穿越" }),
+    ).rejects.toThrow(/BREATH_THRESHOLD_REACHED/);
+
+    const firstCrossing = await callHost<Notice[]>(child, { op: "notices" });
+    expect(firstCrossing.filter((notice) => notice.kind === "announced")).toEqual([
+      expect.objectContaining({ windowId, generation: 1 }),
+    ]);
+
+    // 在真实子进程的时间线写口注入失败：失败必须走对人可见通知，窗仍在原代。
+    await callHost(child, {
+      op: "setAppendFailure",
+      reason: "timeline write rejected",
+    });
+    await expect(
+      callHost(child, {
+        op: "breathe",
+        windowId,
+        draft: draft("D09 失败外显", "时间线写入失败"),
+      }),
+    ).rejects.toThrow(/BREATH_CYCLE_FAILED\[append\]/);
+
+    const afterFailure = await callHost<Notice[]>(child, { op: "notices" });
+    expect(afterFailure.at(-1)).toMatchObject({
+      kind: "failed",
+      windowId,
+      generation: 1,
+      stage: "append",
+      windowRecovered: true,
+    });
+
+    // 失败必须清掉“本周期已预告”：用量仍过线，下一次穿越要再次送到人眼前。
+    await expect(
+      callHost(child, { op: "say", windowId, message: "失败后的第二次阈值穿越" }),
+    ).rejects.toThrow(/BREATH_THRESHOLD_REACHED/);
+    const secondCrossing = await callHost<Notice[]>(child, { op: "notices" });
+    expect(secondCrossing.filter((notice) => notice.kind === "announced")).toEqual([
+      expect.objectContaining({ windowId, generation: 1 }),
+      expect.objectContaining({ windowId, generation: 1 }),
+    ]);
+
+    // 两次被硬闸拦下的输入都没有落树；日志事件不能冒充上述人可见通知。
+    expect(await callHost<HistoryNode[]>(child, { op: "history", residentId })).toHaveLength(2);
+    const events = await callHost<GateEvent[]>(child, { op: "events" });
+    expect(events.filter((event) => event.event === "threshold_reached")).toHaveLength(2);
+  });
+});
+
 describe("猝死与流水残骸（real host subprocess）", () => {
   it("MV-D07 猝死不自动注入：新代无猝死窗流水，归档查询可达", async () => {
     const child = startHost();

--- a/tests/fixtures/breath-host.ts
+++ b/tests/fixtures/breath-host.ts
@@ -2,7 +2,7 @@
  * 换气集成宿主：子进程里装配生产件——SessionRegistry、MessageTreeStore +
  * Service、ViewportTurnGate（接阈值计量口）、BreathCycle（接流水卫生检查），
  * 父进程经 IPC 驱动，覆盖验收清单 D 区的 [集成] 半格
- * （MV-D01/D02/D04 后半/D07/D07b）。
+ * （MV-D01/D02/D04 后半/D07/D07b/D09）。
  *
  * 形状仿 turn-gate-host.ts。关键装配口径：
  *
@@ -11,6 +11,8 @@
  *   不进新代的用量核算与卫生检查（MV-D07：猝死窗流水不自动注入）。
  * - 上下文用量计（MV-D01/D04）：口径 = 本代流水 + 在途 notes，**不含交接信**
  *   （D8 补记二）。信经 injectLetter 进 context.letter，用量计不看它。
+ * - 阈值闸的 announce 口直连 BreathCycle 的人可见通知口（MV-D09）：换气失败
+ *   清掉预告去重位后，仍然过线的下一回合会重新送出预告。
  * - 畸形残骸进不了 MessageTreeStore（契约闸会拒），所以畸形注入走 fixture
  *   自管的原始碎片带，叠在流水切片之上交给卫生检查——它模拟的是异源/
  *   崩溃写入留下的、绕过店内校验的流水。合法残骸（半截回合）用
@@ -42,6 +44,7 @@ const events: TurnGateEvent[] = [];
 const notices: BreathNotification[] = [];
 const timeline: SealedLetter[] = [];
 const debrisLog: string[] = [];
+let appendFailure: string | null = null;
 
 /** windowId → 本代流水的插入序起点。 */
 const boundaries = new Map<string, number>();
@@ -74,6 +77,22 @@ function usageOf(windowId: string): number | null {
   return flowTokens + noteTokens;
 }
 
+const cycle = new BreathCycle<Ctx>({
+  registry,
+  appendLetter: (letter) => {
+    if (appendFailure !== null) {
+      throw new Error(appendFailure);
+    }
+    timeline.push(letter);
+  },
+  injectLetter: (context, letter) => ({ ...context, letter }),
+  notify: (event) => {
+    notices.push(event);
+  },
+  flowOf: (window) => [...flowSlice(window), ...(rawDebris.get(window.windowId) ?? [])],
+  now: () => new Date().toISOString(),
+});
+
 const gate = new ViewportTurnGate(ledger, {
   logger: {
     log: (event) => {
@@ -81,7 +100,12 @@ const gate = new ViewportTurnGate(ledger, {
     },
   },
   generationOf: (windowId) => registry.get(windowId)?.generation ?? null,
-  breath: { usageOf },
+  breath: {
+    usageOf,
+    announce: (windowId) => {
+      cycle.announce(windowId);
+    },
+  },
 });
 
 let lastPrompt: string | null = null;
@@ -100,19 +124,6 @@ const service = new MessageTreeService(
   },
 );
 
-const cycle = new BreathCycle<Ctx>({
-  registry,
-  appendLetter: (letter) => {
-    timeline.push(letter);
-  },
-  injectLetter: (context, letter) => ({ ...context, letter }),
-  notify: (event) => {
-    notices.push(event);
-  },
-  flowOf: (window) => [...flowSlice(window), ...(rawDebris.get(window.windowId) ?? [])],
-  now: () => new Date().toISOString(),
-});
-
 type HostCommand = {
   requestId: string;
   op:
@@ -128,6 +139,7 @@ type HostCommand = {
     | "reopen"
     | "injectRemnant"
     | "injectDebris"
+    | "setAppendFailure"
     | "quarantineDebris"
     | "notices"
     | "events"
@@ -138,6 +150,7 @@ type HostCommand = {
   windowId?: string;
   message?: string;
   content?: string;
+  reason?: string;
   tokens?: number;
   draft?: LetterDraft;
   debris?: unknown[];
@@ -235,6 +248,9 @@ async function execute(command: HostCommand): Promise<unknown> {
     }
     case "injectDebris":
       rawDebris.set(requireString(command.windowId, "windowId"), command.debris ?? []);
+      return null;
+    case "setAppendFailure":
+      appendFailure = requireString(command.reason, "reason");
       return null;
     case "quarantineDebris": {
       const windowId = requireString(command.windowId, "windowId");


### PR DESCRIPTION
## 交付范围

仅交付 #81 的 MV-D09：换气失败必须有对人可见提示，且失败后的下一次阈值穿越能够重新预告。不触碰 D05、D10 或其他验收格。

## 根因与改动

- `ViewportTurnGate` 达到阈值时原本只有结构化日志与抛错，没有调用宿主的人可见通知口。
- 为 `BreathThresholdOptions` 增加必接的 `announce(windowId)`，在硬闸抛错前触发预告。
- 真实子进程宿主将该口直连 `BreathCycle.announce`；沿用 #105 已有的失败阶段通知与失败后释放预告去重位的契约。
- 新增真实宿主集成测试，覆盖首次预告、时间线写入失败的可见通知、失败后再次预告、被拒输入不落树，以及日志不能替代通知。

## TDD / 反例证据

- 红灯：未接 `announce` 前，D09 集成测试在首次可见预告处失败（实际通知为空）。
- 变异探针 1：移除阈值闸到 `announce` 的接线，测试回红。
- 变异探针 2：移除失败路径释放预告去重位，测试因第二次预告缺失回红。

## 验证

- D09 focused：1 passed
- 邻接套件：36 passed
- `npm run typecheck`：通过
- `npm run lint`：128 files clean
- `npm run acceptance`：6/6 true
- `npm test`：相关测试全部通过；总计 461 passed / 38 todo，另有 20 个失败全部集中在 `resident-self-repair-runner.test.ts`。该文件单独复跑仍因环境禁止 `spawn("ps", ...)` 返回 `EPERM` 并超时，未把它误报为本改动引入的失败。

MV-D09 验收勾选留给独立 reviewer。

Refs #81
