### PR TITLE
feat: bound work events entering canonical stream

### DIFF
--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -61,7 +61,7 @@
   只读流水，不能续聊或写回。`session.create` 的成功回执是工作区已存在，不是“创建了一条
   新聊天”。这四项由协议响应和 first-party read model 的结构化结果判定，不靠肉眼看 UI。
 
-- [x] **OS-04 有界投递不夹带局部 transcript** [集成]：progress、blocked、result 三类
+- [ ] **OS-04 有界投递不夹带局部 transcript** [集成]：progress、blocked、result 三类
   合法 envelope 各投一次，来源 viewport、发生时刻、工作把手、权威产物指针与效果状态
   可核，三条均进入 canonical stream。随后在同类 payload 中夹带局部 transcript、消息数组
   或未声明的上下文正文，必被拒绝且主流字节不变；无类型自由文本同样不得借投递接口入流。

--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -61,11 +61,18 @@
   只读流水，不能续聊或写回。`session.create` 的成功回执是工作区已存在，不是“创建了一条
   新聊天”。这四项由协议响应和 first-party read model 的结构化结果判定，不靠肉眼看 UI。
 
-- [ ] **OS-04 有界投递不夹带局部 transcript** [集成]：progress、blocked、result 三类
+- [x] **OS-04 有界投递不夹带局部 transcript** [集成]：progress、blocked、result 三类
   合法 envelope 各投一次，来源 viewport、发生时刻、工作把手、权威产物指针与效果状态
   可核，三条均进入 canonical stream。随后在同类 payload 中夹带局部 transcript、消息数组
   或未声明的上下文正文，必被拒绝且主流字节不变；无类型自由文本同样不得借投递接口入流。
   来源字段只提供 provenance，不自动赋予 authority。
+
+  证据：`BoundedWorkEventPort` 是 viewport 面唯一的三类投递口；来源窗只能提交固定
+  envelope，authority source 由宿主组装时注入，不由窗自报。`tests/one-stream-host.test.ts`
+  启动真实子进程，逐类投递 progress / blocked / result，并核对三条进入同一本 durable
+  canonical stream；随后分别夹带 transcript、messages、context、伪造 authority source，
+  以及直接提交无类型字符串，五种输入均被拒且 snapshot 字节不变。临时移除 envelope
+  exact-key 闸时，专项稳定转红（非法 transcript 成为第 4 条事件）。
 
 - [ ] **OS-05 宿主失败必须外显且明确未生效** [集成]：模拟一次由宿主执行的生命周期
   动作失败（至少覆盖换气失败）。canonical stream 必须收到宿主签发的 typed user-visible

--- a/src/one-stream/bounded-work-events.ts
+++ b/src/one-stream/bounded-work-events.ts
@@ -1,0 +1,184 @@
+import type {
+  DeliveryReceipt,
+  EffectState,
+  EventActor,
+  EventEffect,
+  EventViewport,
+  RetryState,
+} from "./event-contract.ts";
+import type { CanonicalStreamWriter } from "./writer.ts";
+
+export type WorkEventPurpose = "progress" | "blocked" | "result";
+
+export interface BoundedWorkEventSubmission {
+  readonly residentId: string;
+  readonly idempotencyKey: string;
+  readonly purpose: WorkEventPurpose;
+  readonly occurredAt: string;
+  readonly workRef: string;
+  readonly artifactRef: string;
+  readonly source: EventViewport;
+  readonly effect: EventEffect;
+  readonly summary: string;
+}
+
+export interface BoundedWorkEventPortOptions {
+  /**
+   * Supplied by the trusted host composition root, never by the viewport payload.
+   * A source viewport proves provenance only; it does not appoint its own authority.
+   */
+  readonly authoritySource: EventActor;
+}
+
+export class BoundedWorkEventError extends Error {
+  readonly code = "BOUNDED_WORK_EVENT";
+  constructor(message: string) {
+    super(message);
+    this.name = "BoundedWorkEventError";
+  }
+}
+
+const INPUT_KEYS = [
+  "artifactRef",
+  "effect",
+  "idempotencyKey",
+  "occurredAt",
+  "purpose",
+  "residentId",
+  "source",
+  "summary",
+  "workRef",
+] as const;
+const SOURCE_KEYS = ["generation", "windowId"] as const;
+const EFFECT_KEYS = ["requiresUserAction", "retry", "state"] as const;
+const PURPOSES = new Set<WorkEventPurpose>(["progress", "blocked", "result"]);
+const EFFECT_STATES = new Set<EffectState>([
+  "not-applicable",
+  "attempted",
+  "rejected",
+  "failed-not-effective",
+  "committed-effective",
+]);
+const RETRY_STATES = new Set<RetryState>([
+  "not-applicable",
+  "automatic",
+  "awaiting-external",
+  "none",
+]);
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new BoundedWorkEventError(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  name: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new BoundedWorkEventError(`${name} has unexpected fields`);
+  }
+}
+
+function nonEmptyString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new BoundedWorkEventError(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function parseSource(value: unknown): EventViewport {
+  const source = record(value, "source");
+  exactKeys(source, SOURCE_KEYS, "source");
+  const windowId = nonEmptyString(source.windowId, "source.windowId");
+  if (!Number.isSafeInteger(source.generation) || (source.generation as number) < 1) {
+    throw new BoundedWorkEventError("source.generation must be a positive integer");
+  }
+  return { windowId, generation: source.generation as number };
+}
+
+function parseEffect(value: unknown): EventEffect {
+  const effect = record(value, "effect");
+  exactKeys(effect, EFFECT_KEYS, "effect");
+  if (typeof effect.state !== "string" || !EFFECT_STATES.has(effect.state as EffectState)) {
+    throw new BoundedWorkEventError("effect.state is invalid");
+  }
+  if (typeof effect.retry !== "string" || !RETRY_STATES.has(effect.retry as RetryState)) {
+    throw new BoundedWorkEventError("effect.retry is invalid");
+  }
+  if (typeof effect.requiresUserAction !== "boolean") {
+    throw new BoundedWorkEventError("effect.requiresUserAction must be boolean");
+  }
+  return {
+    state: effect.state as EffectState,
+    retry: effect.retry as RetryState,
+    requiresUserAction: effect.requiresUserAction,
+  };
+}
+
+function parseSubmission(value: unknown): BoundedWorkEventSubmission {
+  const input = record(value, "work event submission");
+  exactKeys(input, INPUT_KEYS, "work event submission");
+  if (typeof input.purpose !== "string" || !PURPOSES.has(input.purpose as WorkEventPurpose)) {
+    throw new BoundedWorkEventError("purpose must be progress, blocked, or result");
+  }
+  const occurredAt = nonEmptyString(input.occurredAt, "occurredAt");
+  if (!Number.isFinite(Date.parse(occurredAt))) {
+    throw new BoundedWorkEventError("occurredAt must be a parseable timestamp");
+  }
+  return {
+    residentId: nonEmptyString(input.residentId, "residentId"),
+    idempotencyKey: nonEmptyString(input.idempotencyKey, "idempotencyKey"),
+    purpose: input.purpose as WorkEventPurpose,
+    occurredAt,
+    workRef: nonEmptyString(input.workRef, "workRef"),
+    artifactRef: nonEmptyString(input.artifactRef, "artifactRef"),
+    source: parseSource(input.source),
+    effect: parseEffect(input.effect),
+    summary: nonEmptyString(input.summary, "summary"),
+  };
+}
+
+/**
+ * The only viewport-facing write port for progress, blocked, and result events.
+ * It converts a closed envelope into the lower-level canonical draft. Local transcript,
+ * message arrays, arbitrary context, and caller-selected authority have no input slot.
+ */
+export class BoundedWorkEventPort {
+  readonly #writer: CanonicalStreamWriter;
+  readonly #authoritySource: EventActor;
+
+  constructor(writer: CanonicalStreamWriter, options: BoundedWorkEventPortOptions) {
+    this.#writer = writer;
+    // The canonical writer validates this actor together with every completed draft. Keeping
+    // it outside the viewport-facing submission is the authority boundary that matters here.
+    this.#authoritySource = Object.freeze(structuredClone(options.authoritySource));
+  }
+
+  submit(value: unknown): Promise<DeliveryReceipt> {
+    const input = parseSubmission(value);
+    return this.#writer.submit({
+      residentId: input.residentId,
+      idempotencyKey: input.idempotencyKey,
+      draft: {
+        purpose: input.purpose,
+        occurredAt: input.occurredAt,
+        workRef: input.workRef,
+        authoritySource: this.#authoritySource,
+        origin: {
+          reporter: { kind: "viewport", id: input.source.windowId },
+          subject: { kind: "work", id: input.workRef },
+          viewport: input.source,
+        },
+        effect: input.effect,
+        artifactRef: input.artifactRef,
+        payload: { summary: input.summary },
+      },
+    });
+  }
+}

--- a/src/one-stream/index.ts
+++ b/src/one-stream/index.ts
@@ -10,6 +10,12 @@ export {
   stableJson,
   verifyCanonicalEvent,
 } from "./event-contract.ts";
+export { BoundedWorkEventError, BoundedWorkEventPort } from "./bounded-work-events.ts";
+export type {
+  BoundedWorkEventPortOptions,
+  BoundedWorkEventSubmission,
+  WorkEventPurpose,
+} from "./bounded-work-events.ts";
 export type {
   ActorKind,
   CanonicalEvent,

--- a/tests/fixtures/one-stream-host.ts
+++ b/tests/fixtures/one-stream-host.ts
@@ -1,4 +1,5 @@
 import {
+  BoundedWorkEventPort,
   type CanonicalEventDraft,
   CanonicalStreamProjection,
   CanonicalStreamStore,
@@ -20,6 +21,9 @@ const writer = new CanonicalStreamWriter(store, {
     }
   },
 });
+const workEvents = new BoundedWorkEventPort(writer, {
+  authoritySource: { kind: "host", id: "mist-host" },
+});
 
 type Command = {
   requestId?: string;
@@ -28,6 +32,7 @@ type Command = {
   clientId?: string;
   idempotencyKey?: string;
   draft?: CanonicalEventDraft;
+  workEvent?: unknown;
   afterSeq?: number;
 };
 
@@ -63,6 +68,8 @@ async function handle(command: Command): Promise<unknown> {
         idempotencyKey: required(command.idempotencyKey, "idempotencyKey"),
         draft: command.draft,
       });
+    case "submitWorkEvent":
+      return workEvents.submit(command.workEvent);
     case "events":
       return store.eventsAfter(required(command.residentId, "residentId"), command.afterSeq ?? 0);
     case "openProjection": {

--- a/tests/one-stream-host.test.ts
+++ b/tests/one-stream-host.test.ts
@@ -173,6 +173,86 @@ afterEach(async () => {
 });
 
 describe("one canonical stream real host", () => {
+  it("accepts only bounded work events and leaves the stream unchanged on rejected context", async () => {
+    const directory = temporaryDirectory();
+    const child = startHost(directory);
+    await waitForReady(child);
+    const residentId = "resident-bounded";
+    await callHost(child, { op: "create", residentId });
+
+    const purposes = ["progress", "blocked", "result"] as const;
+    for (const [index, purpose] of purposes.entries()) {
+      const receipt = await callHost<DeliveryReceipt>(child, {
+        op: "submitWorkEvent",
+        workEvent: {
+          residentId,
+          idempotencyKey: `work-${purpose}`,
+          purpose,
+          occurredAt: `2026-08-26T00:00:0${index}.000Z`,
+          workRef: "work-alpha",
+          artifactRef: `artifact:${purpose}`,
+          source: { windowId: "window-a", generation: 1 },
+          effect: {
+            state: purpose === "result" ? "committed-effective" : "attempted",
+            requiresUserAction: purpose === "blocked",
+            retry: purpose === "blocked" ? "awaiting-external" : "none",
+          },
+          summary: `${purpose} summary`,
+        },
+      });
+      expect(receipt.phase).toBe("delivered");
+    }
+
+    const legalEvents = await callHost<CanonicalEvent[]>(child, { op: "events", residentId });
+    expect(legalEvents.map((event) => event.purpose)).toEqual(purposes);
+    expect(legalEvents.map((event) => event.origin.viewport)).toEqual([
+      { windowId: "window-a", generation: 1 },
+      { windowId: "window-a", generation: 1 },
+      { windowId: "window-a", generation: 1 },
+    ]);
+    expect(legalEvents.map((event) => event.workRef)).toEqual([
+      "work-alpha",
+      "work-alpha",
+      "work-alpha",
+    ]);
+    expect(legalEvents.map((event) => event.artifactRef)).toEqual([
+      "artifact:progress",
+      "artifact:blocked",
+      "artifact:result",
+    ]);
+    expect(legalEvents.every((event) => event.authoritySource.id === "mist-host")).toBe(true);
+
+    const snapshotPath = join(directory, `${residentId}.stream.json`);
+    const beforeRejected = readFileSync(snapshotPath, "utf8");
+    const base = {
+      residentId,
+      idempotencyKey: "work-invalid",
+      purpose: "progress",
+      occurredAt: "2026-08-26T00:00:04.000Z",
+      workRef: "work-alpha",
+      artifactRef: "artifact:progress",
+      source: { windowId: "window-a", generation: 1 },
+      effect: { state: "attempted", requiresUserAction: false, retry: "none" },
+      summary: "legal summary",
+    };
+
+    for (const workEvent of [
+      { ...base, transcript: ["local turn"] },
+      { ...base, messages: [{ role: "user", content: "local turn" }] },
+      { ...base, context: "local context" },
+      { ...base, authoritySource: { kind: "viewport", id: "window-a" } },
+      "untyped free text",
+    ]) {
+      await expect(callHost(child, { op: "submitWorkEvent", workEvent })).rejects.toThrow(
+        "BOUNDED_WORK_EVENT",
+      );
+      expect(readFileSync(snapshotPath, "utf8")).toBe(beforeRejected);
+    }
+
+    expect(await callHost<CanonicalEvent[]>(child, { op: "events", residentId })).toHaveLength(3);
+    await stopHost(child);
+  });
+
   it("orders concurrent viewport events once and gives all projections identical bytes", async () => {
     const directory = temporaryDirectory();
     const child = startHost(directory);

--- a/tests/one-stream-host.test.ts
+++ b/tests/one-stream-host.test.ts
@@ -240,6 +240,8 @@ describe("one canonical stream real host", () => {
       { ...base, transcript: ["local turn"] },
       { ...base, messages: [{ role: "user", content: "local turn" }] },
       { ...base, context: "local context" },
+      { ...base, source: { ...base.source, transcript: "nested local transcript" } },
+      { ...base, effect: { ...base.effect, context: "nested local context" } },
       { ...base, authoritySource: { kind: "viewport", id: "window-a" } },
       "untyped free text",
     ]) {


### PR DESCRIPTION
## Scope

Closes OS-04 only: progress, blocked, and result events enter the canonical stream through one closed viewport-facing envelope.

This is a stacked PR on #133. Do not merge it before #133; once #133 lands, the base will be retargeted to main.

## What changed

- add BoundedWorkEventPort as the only viewport-facing work-event write port
- keep authoritySource in trusted host composition, outside viewport input
- require workRef, artifactRef, source window/generation, occurredAt, effect state, and a bounded summary
- reject transcript, messages, context, caller-selected authority, extra fields, and raw free text before any stream write
- mark OS-04 green with concrete evidence

## Evidence

- focused: 2 files, 9 tests passed
- full suite: 46 files passed, 3 skipped; 489 tests passed, 38 todo
- lint, typecheck, acceptance: green
- real child-process host writes all three legal event types to one durable stream
- each rejected payload leaves the stream snapshot byte-identical
- mutation probe: removing the outer exact-key gate makes the OS-04 test fail because transcript-bearing input becomes stream event 4

## Boundary

No OS-03 workspace/evidence projection, OS-05 lifecycle reporting, or OS-06 reply routing in this PR. No MessageTree transcript is migrated into the canonical stream.