### PR TITLE
feat: split workspace and evidence capabilities

### DIFF
--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -61,6 +61,15 @@
   只读流水，不能续聊或写回。`session.create` 的成功回执是工作区已存在，不是“创建了一条
   新聊天”。这四项由协议响应和 first-party read model 的结构化结果判定，不靠肉眼看 UI。
 
+  证据：`FirstPartyResidentView` 只投影 canonical stream 与仍活着的 workspace handle，接口不含
+  archive/history/resume；`WorkspaceLifecycleOwner` 先写 durable closure request，再归档窗，
+  最后写 committed-effective result，两个间隙都可按同一幂等键 reconcile。显式授权的
+  `EvidenceViewportReader` 只能拿 canonical result eventId，沿其中绑定的 artifactRef 与
+  viewport identity 调只读 `MessageTreeViewportHistory`；无权主体、closure intent 或裸 windowId
+  都不能成为读取入口。`tests/one-stream-workspace.test.ts` 用真实 SessionRegistry、MessageTree
+  分支与 canonical writer 验证两扇活窗、关一扇后入口消失、另一扇仍活、证据分支只读以及
+  closure-delivered 后猝死再对账。
+
 - [ ] **OS-04 有界投递不夹带局部 transcript** [集成]：progress、blocked、result 三类
   合法 envelope 各投一次，来源 viewport、发生时刻、工作把手、权威产物指针与效果状态
   可核，三条均进入 canonical stream。随后在同类 payload 中夹带局部 transcript、消息数组

--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -63,13 +63,16 @@
 
   证据：`FirstPartyResidentView` 只投影 canonical stream 与仍活着的 workspace handle，接口不含
   archive/history/resume；`WorkspaceLifecycleOwner` 先写 durable closure request，再归档窗，
-  最后写 committed-effective result，两个间隙都可按同一幂等键 reconcile。`EvidenceAuthority`
-  只认宿主签发的对象身份，不把一段可伪造的 capability 字符串当授权；获授权的
-  `EvidenceViewportReader` 只能拿 canonical result eventId，沿其中绑定的 artifactRef 与
-  viewport identity 调只读 `MessageTreeViewportHistory`；无权主体、closure intent 或裸 windowId
-  都不能成为读取入口。`tests/one-stream-workspace.test.ts` 用真实 SessionRegistry、MessageTree
-  分支与 canonical writer 验证两扇活窗、关一扇后入口消失、另一扇仍活、证据分支只读以及
-  closure-delivered 后猝死再对账。
+  最后写 committed-effective result，两个间隙都可按同一幂等键 reconcile；closure 同时保存
+  host 恢复归档所需的 scope/head 快照，因此 file-backed stream 与 SessionRegistry 一起重建后也
+  能闭合第一段间隙。用户面的 `create` 只收 context 与可选 scope，不能传 windowId/headId 重开
+  归档窗。`EvidenceAuthority` 只认宿主签发的对象身份，不把一段可伪造的 capability 字符串当
+  授权；`EvidenceViewportReader` 还会核 closure/result 都由同一 host 签发，并逐项配对
+  workRef、artifactRef、operationId、subject 与 viewport identity，不相干 result 不能压掉待恢复
+  closure，viewport 自签的事件对也不能解锁历史。获授权的 reader 只能拿 canonical result
+  eventId 调只读 `MessageTreeViewportHistory`；无权主体、closure intent 或裸 windowId 都不能成为
+  读取入口。`tests/one-stream-workspace.test.ts` 用真实 file store、SessionRegistry、MessageTree
+  分支与 canonical writer 验证两扇活窗、两处 crash recovery 以及上述三支反例。
 
 - [ ] **OS-04 有界投递不夹带局部 transcript** [集成]：progress、blocked、result 三类
   合法 envelope 各投一次，来源 viewport、发生时刻、工作把手、权威产物指针与效果状态

--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -72,7 +72,9 @@
   closure，viewport 自签的事件对也不能解锁历史。获授权的 reader 只能拿 canonical result
   eventId 调只读 `MessageTreeViewportHistory`；无权主体、closure intent 或裸 windowId 都不能成为
   读取入口。`tests/one-stream-workspace.test.ts` 用真实 file store、SessionRegistry、MessageTree
-  分支与 canonical writer 验证两扇活窗、两处 crash recovery 以及上述三支反例。
+  分支与 canonical writer 验证两扇活窗、两处 crash recovery 以及上述三支反例；另走完
+  generation 1 关闭、同窗合法重开 generation 2、closure-delivered 后宿主死亡、全量重建并
+  reconcile 的链路，证明 journal replay 不会拿旧代 archive 冒充当前代。
 
 - [ ] **OS-04 有界投递不夹带局部 transcript** [集成]：progress、blocked、result 三类
   合法 envelope 各投一次，来源 viewport、发生时刻、工作把手、权威产物指针与效果状态

--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -63,7 +63,8 @@
 
   证据：`FirstPartyResidentView` 只投影 canonical stream 与仍活着的 workspace handle，接口不含
   archive/history/resume；`WorkspaceLifecycleOwner` 先写 durable closure request，再归档窗，
-  最后写 committed-effective result，两个间隙都可按同一幂等键 reconcile。显式授权的
+  最后写 committed-effective result，两个间隙都可按同一幂等键 reconcile。`EvidenceAuthority`
+  只认宿主签发的对象身份，不把一段可伪造的 capability 字符串当授权；获授权的
   `EvidenceViewportReader` 只能拿 canonical result eventId，沿其中绑定的 artifactRef 与
   viewport identity 调只读 `MessageTreeViewportHistory`；无权主体、closure intent 或裸 windowId
   都不能成为读取入口。`tests/one-stream-workspace.test.ts` 用真实 SessionRegistry、MessageTree

--- a/src/one-stream/index.ts
+++ b/src/one-stream/index.ts
@@ -49,6 +49,7 @@ export {
 export type {
   CloseWorkspaceReceipt,
   CloseWorkspaceRequest,
+  CreateWorkspaceOptions,
   EvidencePrincipal,
   EvidenceReadRequest,
   EvidenceViewportRecord,

--- a/src/one-stream/index.ts
+++ b/src/one-stream/index.ts
@@ -38,6 +38,26 @@ export {
   WriterClosedError,
   WriterOwnershipError,
 } from "./writer.ts";
+export {
+  EvidenceViewportReader,
+  FirstPartyResidentView,
+  MessageTreeViewportHistory,
+  WorkspaceCapabilityError,
+  WorkspaceLifecycleOwner,
+} from "./workspace-read-model.ts";
+export type {
+  CloseWorkspaceReceipt,
+  CloseWorkspaceRequest,
+  EvidencePrincipal,
+  EvidenceReadRequest,
+  EvidenceViewportRecord,
+  FirstPartyResidentSnapshot,
+  ViewportEvidenceBinding,
+  ViewportHistoryReadPort,
+  WorkspaceCreatedReceipt,
+  WorkspaceHandle,
+  WorkspaceLifecycleOptions,
+} from "./workspace-read-model.ts";
 export type {
   CanonicalEventSubmission,
   CanonicalStreamWriterOptions,

--- a/src/one-stream/index.ts
+++ b/src/one-stream/index.ts
@@ -39,6 +39,7 @@ export {
   WriterOwnershipError,
 } from "./writer.ts";
 export {
+  EvidenceAuthority,
   EvidenceViewportReader,
   FirstPartyResidentView,
   MessageTreeViewportHistory,

--- a/src/one-stream/workspace-read-model.ts
+++ b/src/one-stream/workspace-read-model.ts
@@ -1,11 +1,6 @@
 import type { HistoryNode } from "../../acceptance/driver.ts";
 import type { MessageTreeStore } from "../message-tree/store.ts";
-import type {
-  ActiveWindow,
-  ArchivedWindow,
-  OpenOptions,
-  SessionRegistry,
-} from "../session/session-registry.ts";
+import type { ActiveWindow, ArchivedWindow, SessionRegistry } from "../session/session-registry.ts";
 import type { CanonicalEvent, DeliveryReceipt, EventActor } from "./event-contract.ts";
 import type { CanonicalStreamReadPort } from "./store.ts";
 import type { CanonicalStreamWriter } from "./writer.ts";
@@ -20,6 +15,11 @@ export interface WorkspaceHandle {
 export interface WorkspaceCreatedReceipt {
   readonly phase: "workspace-created";
   readonly handle: WorkspaceHandle;
+}
+
+export interface CreateWorkspaceOptions<TContext> {
+  readonly context: TContext;
+  readonly scopeId?: string;
 }
 
 export interface FirstPartyResidentSnapshot {
@@ -130,6 +130,67 @@ function closureEventId(event: CanonicalEvent): string | null {
   return typeof value === "string" ? value : null;
 }
 
+function operationId(event: CanonicalEvent): string | null {
+  const value = event.payload.operationId;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function sameActor(left: EventActor, right: EventActor): boolean {
+  return left.kind === right.kind && left.id === right.id;
+}
+
+function hostIssued(event: CanonicalEvent): boolean {
+  return (
+    event.authoritySource.kind === "host" &&
+    event.origin.reporter.kind === "host" &&
+    sameActor(event.authoritySource, event.origin.reporter)
+  );
+}
+
+function viewportSubjectMatches(event: CanonicalEvent): boolean {
+  return (
+    event.origin.viewport !== null &&
+    event.origin.subject.kind === "viewport" &&
+    event.origin.subject.id === event.origin.viewport.windowId
+  );
+}
+
+function authoritativeClosureRequest(event: CanonicalEvent): boolean {
+  return (
+    event.purpose === "closure" &&
+    event.effect.state === "attempted" &&
+    event.effect.requiresUserAction === false &&
+    event.effect.retry === "automatic" &&
+    closurePhase(event) === "requested" &&
+    event.workRef !== null &&
+    event.artifactRef !== null &&
+    operationId(event) !== null &&
+    hostIssued(event) &&
+    viewportSubjectMatches(event)
+  );
+}
+
+function authoritativeClosurePair(requested: CanonicalEvent, result: CanonicalEvent): boolean {
+  return (
+    authoritativeClosureRequest(requested) &&
+    result.purpose === "result" &&
+    result.effect.state === "committed-effective" &&
+    result.effect.requiresUserAction === false &&
+    result.effect.retry === "none" &&
+    closurePhase(result) === "closed" &&
+    closureEventId(result) === requested.eventId &&
+    result.residentId === requested.residentId &&
+    result.workRef === requested.workRef &&
+    result.artifactRef === requested.artifactRef &&
+    operationId(result) === operationId(requested) &&
+    hostIssued(result) &&
+    viewportSubjectMatches(result) &&
+    sameActor(result.authoritySource, requested.authoritySource) &&
+    result.origin.viewport?.windowId === requested.origin.viewport?.windowId &&
+    result.origin.viewport?.generation === requested.origin.viewport?.generation
+  );
+}
+
 function sameWindow(
   window: Pick<ActiveWindow<unknown> | ArchivedWindow, "residentId" | "windowId" | "generation">,
   event: CanonicalEvent,
@@ -191,15 +252,30 @@ export class WorkspaceLifecycleOwner<TContext> {
     this.#checkpoint = options.checkpoint;
   }
 
-  create(residentId: string, options: OpenOptions<TContext>): WorkspaceCreatedReceipt {
+  create(residentId: string, options: CreateWorkspaceOptions<TContext>): WorkspaceCreatedReceipt {
     nonEmpty(residentId, "residentId");
-    const window = this.#sessions.open(residentId, options);
+    const keys = Object.keys(options).sort();
+    if (
+      keys.length < 1 ||
+      keys.length > 2 ||
+      keys[0] !== "context" ||
+      (keys.length === 2 && keys[1] !== "scopeId")
+    ) {
+      throw new WorkspaceCapabilityError(
+        "first-party workspace create accepts only context and optional scopeId",
+      );
+    }
+    const window = this.#sessions.open(residentId, {
+      context: options.context,
+      ...(options.scopeId === undefined ? {} : { scopeId: options.scopeId }),
+    });
     return Object.freeze({ phase: "workspace-created", handle: handle(window) });
   }
 
   async close(request: CloseWorkspaceRequest): Promise<CloseWorkspaceReceipt> {
     this.#assertRequest(request);
-    const requested = await this.#submitRequested(request);
+    const snapshot = this.#workspaceSnapshot(request);
+    const requested = await this.#submitRequested(request, snapshot);
     await this.#checkpoint?.("closure-delivered");
     const archived = this.#archiveExact(request);
     await this.#checkpoint?.("workspace-archived");
@@ -210,21 +286,11 @@ export class WorkspaceLifecycleOwner<TContext> {
   async reconcile(residentId: string): Promise<CloseWorkspaceReceipt[]> {
     nonEmpty(residentId, "residentId");
     const events = this.#stream.eventsAfter(residentId, 0);
-    const completed = new Set(
-      events
-        .filter((event) => event.purpose === "result" && closurePhase(event) === "closed")
-        .map(closureEventId)
-        .filter((eventId): eventId is string => eventId !== null),
-    );
     const recovered: CloseWorkspaceReceipt[] = [];
     for (const event of events) {
       if (
-        event.purpose !== "closure" ||
-        closurePhase(event) !== "requested" ||
-        completed.has(event.eventId) ||
-        event.origin.viewport === null ||
-        event.workRef === null ||
-        event.artifactRef === null
+        !authoritativeClosureRequest(event) ||
+        events.some((candidate) => authoritativeClosurePair(event, candidate))
       ) {
         continue;
       }
@@ -232,17 +298,21 @@ export class WorkspaceLifecycleOwner<TContext> {
       if (typeof summary !== "string") {
         throw new WorkspaceCapabilityError(`closure ${event.eventId} has no summary`);
       }
+      const viewport = event.origin.viewport;
+      if (viewport === null) {
+        throw new WorkspaceCapabilityError(`closure ${event.eventId} has no viewport`);
+      }
       const request: CloseWorkspaceRequest = {
         residentId,
-        windowId: event.origin.viewport.windowId,
-        generation: event.origin.viewport.generation,
-        workRef: event.workRef,
-        artifactRef: event.artifactRef,
+        windowId: viewport.windowId,
+        generation: viewport.generation,
+        workRef: nonEmpty(event.workRef, "closure workRef"),
+        artifactRef: nonEmpty(event.artifactRef, "closure artifactRef"),
         idempotencyKey: nonEmpty(event.payload.operationId, "closure operationId"),
         occurredAt: event.occurredAt,
         summary,
       };
-      const archived = this.#archiveExact(request);
+      const archived = this.#archiveExact(request, event);
       const effective = await this.#submitEffective(request, event.eventId);
       recovered.push({
         requested: {
@@ -278,6 +348,15 @@ export class WorkspaceLifecycleOwner<TContext> {
     }
   }
 
+  #workspaceSnapshot(request: CloseWorkspaceRequest): ActiveWindow<TContext> | ArchivedWindow {
+    const current =
+      this.#sessions.get(request.windowId) ?? this.#sessions.getArchived(request.windowId);
+    if (current === undefined || !sameWindow(current, this.#eventShape(request))) {
+      throw new WorkspaceCapabilityError("workspace identity does not match the requested closure");
+    }
+    return current;
+  }
+
   #eventShape(request: CloseWorkspaceRequest): CanonicalEvent {
     return {
       schemaVersion: 1,
@@ -300,7 +379,10 @@ export class WorkspaceLifecycleOwner<TContext> {
     };
   }
 
-  async #submitRequested(request: CloseWorkspaceRequest): Promise<DeliveryReceipt> {
+  async #submitRequested(
+    request: CloseWorkspaceRequest,
+    snapshot: ActiveWindow<TContext> | ArchivedWindow,
+  ): Promise<DeliveryReceipt> {
     return this.#writer.submit({
       residentId: request.residentId,
       idempotencyKey: `${request.idempotencyKey}:requested`,
@@ -317,24 +399,44 @@ export class WorkspaceLifecycleOwner<TContext> {
         effect: { state: "attempted", requiresUserAction: false, retry: "automatic" },
         artifactRef: request.artifactRef,
         payload: {
+          headId: snapshot.headId,
           operationId: request.idempotencyKey,
           phase: "requested",
+          scopeId: snapshot.scopeId,
           summary: request.summary,
         },
       },
     });
   }
 
-  #archiveExact(request: CloseWorkspaceRequest): ArchivedWindow {
+  #archiveExact(request: CloseWorkspaceRequest, closure?: CanonicalEvent): ArchivedWindow {
     const live = this.#sessions.get(request.windowId);
     if (live !== undefined && !sameWindow(live, this.#eventShape(request))) {
       throw new WorkspaceCapabilityError("refusing to archive a different workspace generation");
     }
     const archived = this.#sessions.kill(request.windowId);
-    if (archived === undefined || !sameWindow(archived, this.#eventShape(request))) {
-      throw new WorkspaceCapabilityError("closure points to a missing or mismatched workspace");
+    if (archived !== undefined) {
+      if (!sameWindow(archived, this.#eventShape(request))) {
+        throw new WorkspaceCapabilityError("closure points to a mismatched workspace");
+      }
+      return archived;
     }
-    return archived;
+    if (closure === undefined) {
+      throw new WorkspaceCapabilityError("closure points to a missing workspace");
+    }
+    const scopeId = nonEmpty(closure.payload.scopeId, "closure scopeId");
+    const rawHeadId = closure.payload.headId;
+    if (rawHeadId !== null && (typeof rawHeadId !== "string" || rawHeadId.length === 0)) {
+      throw new WorkspaceCapabilityError("closure headId must be null or a non-empty string");
+    }
+    return this.#sessions.recoverArchived({
+      residentId: request.residentId,
+      windowId: request.windowId,
+      generation: request.generation,
+      scopeId,
+      headId: rawHeadId,
+      archived: true,
+    });
   }
 
   async #submitEffective(
@@ -434,6 +536,8 @@ export class EvidenceViewportReader {
       event.purpose !== "result" ||
       event.effect.state !== "committed-effective" ||
       closurePhase(event) !== "closed" ||
+      !hostIssued(event) ||
+      !viewportSubjectMatches(event) ||
       event.origin.viewport === null ||
       event.artifactRef === null
     ) {
@@ -441,16 +545,7 @@ export class EvidenceViewportReader {
     }
     const requestedEventId = closureEventId(event);
     const requested = events.find((candidate) => candidate.eventId === requestedEventId);
-    if (
-      requested === undefined ||
-      requested.purpose !== "closure" ||
-      requested.effect.state !== "attempted" ||
-      closurePhase(requested) !== "requested" ||
-      requested.workRef !== event.workRef ||
-      requested.artifactRef !== event.artifactRef ||
-      requested.origin.viewport?.windowId !== event.origin.viewport.windowId ||
-      requested.origin.viewport.generation !== event.origin.viewport.generation
-    ) {
+    if (requested === undefined || !authoritativeClosurePair(requested, event)) {
       throw new WorkspaceCapabilityError("result event does not bind to its closure request");
     }
     const binding: ViewportEvidenceBinding = {

--- a/src/one-stream/workspace-read-model.ts
+++ b/src/one-stream/workspace-read-model.ts
@@ -1,0 +1,453 @@
+import type { HistoryNode } from "../../acceptance/driver.ts";
+import type { MessageTreeStore } from "../message-tree/store.ts";
+import type {
+  ActiveWindow,
+  ArchivedWindow,
+  OpenOptions,
+  SessionRegistry,
+} from "../session/session-registry.ts";
+import type { CanonicalEvent, DeliveryReceipt, EventActor } from "./event-contract.ts";
+import type { CanonicalStreamReadPort } from "./store.ts";
+import type { CanonicalStreamWriter } from "./writer.ts";
+
+export interface WorkspaceHandle {
+  readonly kind: "workspace";
+  readonly windowId: string;
+  readonly generation: number;
+  readonly scopeId: string;
+}
+
+export interface WorkspaceCreatedReceipt {
+  readonly phase: "workspace-created";
+  readonly handle: WorkspaceHandle;
+}
+
+export interface FirstPartyResidentSnapshot {
+  readonly residentId: string;
+  readonly canonicalEvents: readonly CanonicalEvent[];
+  readonly activeWorkspaces: readonly WorkspaceHandle[];
+}
+
+export interface EvidencePrincipal {
+  readonly principalId: string;
+  readonly capability: "viewport-evidence:read";
+}
+
+export interface EvidenceReadRequest {
+  readonly residentId: string;
+  readonly resultEventId: string;
+}
+
+export interface ViewportEvidenceBinding {
+  readonly residentId: string;
+  readonly windowId: string;
+  readonly generation: number;
+  readonly artifactRef: string;
+}
+
+export interface ViewportHistoryReadPort {
+  read(binding: ViewportEvidenceBinding): readonly HistoryNode[];
+}
+
+export interface EvidenceViewportRecord extends ViewportEvidenceBinding {
+  readonly resultEventId: string;
+  readonly history: readonly HistoryNode[];
+}
+
+export interface CloseWorkspaceRequest {
+  readonly residentId: string;
+  readonly windowId: string;
+  readonly generation: number;
+  readonly workRef: string;
+  readonly artifactRef: string;
+  readonly idempotencyKey: string;
+  readonly occurredAt: string;
+  readonly summary: string;
+}
+
+export interface CloseWorkspaceReceipt {
+  readonly requested: DeliveryReceipt;
+  readonly effective: DeliveryReceipt;
+  readonly archived: ArchivedWindow;
+}
+
+export interface WorkspaceLifecycleOptions {
+  readonly authoritySource: EventActor;
+  readonly checkpoint?: (name: "closure-delivered" | "workspace-archived") => void | Promise<void>;
+}
+
+export class WorkspaceCapabilityError extends Error {
+  readonly code = "WORKSPACE_CAPABILITY";
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkspaceCapabilityError";
+  }
+}
+
+function nonEmpty(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new WorkspaceCapabilityError(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function handle<TContext>(window: ActiveWindow<TContext>): WorkspaceHandle {
+  return Object.freeze({
+    kind: "workspace",
+    windowId: window.windowId,
+    generation: window.generation,
+    scopeId: window.scopeId,
+  });
+}
+
+function closurePhase(event: CanonicalEvent): string | null {
+  const phase = event.payload.phase;
+  return typeof phase === "string" ? phase : null;
+}
+
+function closureEventId(event: CanonicalEvent): string | null {
+  const value = event.payload.closureEventId;
+  return typeof value === "string" ? value : null;
+}
+
+function sameWindow(
+  window: Pick<ActiveWindow<unknown> | ArchivedWindow, "residentId" | "windowId" | "generation">,
+  event: CanonicalEvent,
+): boolean {
+  return (
+    event.residentId === window.residentId &&
+    event.origin.viewport?.windowId === window.windowId &&
+    event.origin.viewport.generation === window.generation
+  );
+}
+
+/**
+ * P1-conformant user read model: one canonical stream plus live workspaces only.
+ * It deliberately has no history, archive, resume, or write method.
+ */
+export class FirstPartyResidentView<TContext> {
+  readonly #stream: CanonicalStreamReadPort;
+  readonly #sessions: SessionRegistry<TContext>;
+
+  constructor(stream: CanonicalStreamReadPort, sessions: SessionRegistry<TContext>) {
+    this.#stream = stream;
+    this.#sessions = sessions;
+  }
+
+  snapshot(residentId: string): FirstPartyResidentSnapshot {
+    nonEmpty(residentId, "residentId");
+    return Object.freeze({
+      residentId,
+      canonicalEvents: Object.freeze(this.#stream.eventsAfter(residentId, 0)),
+      activeWorkspaces: Object.freeze(this.#sessions.windowsOf(residentId).map(handle)),
+    });
+  }
+}
+
+/**
+ * Host-owned lifecycle coordinator. A durable closure request is written before the
+ * workspace disappears; the effective result is written only after archive succeeds.
+ * Reconciliation can finish either crash gap idempotently.
+ */
+export class WorkspaceLifecycleOwner<TContext> {
+  readonly #writer: CanonicalStreamWriter;
+  readonly #stream: CanonicalStreamReadPort;
+  readonly #sessions: SessionRegistry<TContext>;
+  readonly #authoritySource: EventActor;
+  readonly #checkpoint:
+    | ((name: "closure-delivered" | "workspace-archived") => void | Promise<void>)
+    | undefined;
+
+  constructor(
+    writer: CanonicalStreamWriter,
+    stream: CanonicalStreamReadPort,
+    sessions: SessionRegistry<TContext>,
+    options: WorkspaceLifecycleOptions,
+  ) {
+    this.#writer = writer;
+    this.#stream = stream;
+    this.#sessions = sessions;
+    this.#authoritySource = structuredClone(options.authoritySource);
+    this.#checkpoint = options.checkpoint;
+  }
+
+  create(residentId: string, options: OpenOptions<TContext>): WorkspaceCreatedReceipt {
+    nonEmpty(residentId, "residentId");
+    const window = this.#sessions.open(residentId, options);
+    return Object.freeze({ phase: "workspace-created", handle: handle(window) });
+  }
+
+  async close(request: CloseWorkspaceRequest): Promise<CloseWorkspaceReceipt> {
+    this.#assertRequest(request);
+    const requested = await this.#submitRequested(request);
+    await this.#checkpoint?.("closure-delivered");
+    const archived = this.#archiveExact(request);
+    await this.#checkpoint?.("workspace-archived");
+    const effective = await this.#submitEffective(request, requested.eventId);
+    return { requested, effective, archived };
+  }
+
+  async reconcile(residentId: string): Promise<CloseWorkspaceReceipt[]> {
+    nonEmpty(residentId, "residentId");
+    const events = this.#stream.eventsAfter(residentId, 0);
+    const completed = new Set(
+      events
+        .filter((event) => event.purpose === "result" && closurePhase(event) === "closed")
+        .map(closureEventId)
+        .filter((eventId): eventId is string => eventId !== null),
+    );
+    const recovered: CloseWorkspaceReceipt[] = [];
+    for (const event of events) {
+      if (
+        event.purpose !== "closure" ||
+        closurePhase(event) !== "requested" ||
+        completed.has(event.eventId) ||
+        event.origin.viewport === null ||
+        event.workRef === null ||
+        event.artifactRef === null
+      ) {
+        continue;
+      }
+      const summary = event.payload.summary;
+      if (typeof summary !== "string") {
+        throw new WorkspaceCapabilityError(`closure ${event.eventId} has no summary`);
+      }
+      const request: CloseWorkspaceRequest = {
+        residentId,
+        windowId: event.origin.viewport.windowId,
+        generation: event.origin.viewport.generation,
+        workRef: event.workRef,
+        artifactRef: event.artifactRef,
+        idempotencyKey: nonEmpty(event.payload.operationId, "closure operationId"),
+        occurredAt: event.occurredAt,
+        summary,
+      };
+      const archived = this.#archiveExact(request);
+      const effective = await this.#submitEffective(request, event.eventId);
+      recovered.push({
+        requested: {
+          phase: "delivered",
+          residentId,
+          eventId: event.eventId,
+          streamSeq: event.streamSeq,
+          payloadHash: event.payloadHash,
+        },
+        effective,
+        archived,
+      });
+    }
+    return recovered;
+  }
+
+  #assertRequest(request: CloseWorkspaceRequest): void {
+    for (const [name, value] of Object.entries(request)) {
+      if (name === "generation") continue;
+      nonEmpty(value, name);
+    }
+    if (!Number.isSafeInteger(request.generation) || request.generation < 1) {
+      throw new WorkspaceCapabilityError("generation must be a positive integer");
+    }
+    if (!Number.isFinite(Date.parse(request.occurredAt))) {
+      throw new WorkspaceCapabilityError("occurredAt must be a parseable timestamp");
+    }
+    const live = this.#sessions.get(request.windowId);
+    const archived = this.#sessions.getArchived(request.windowId);
+    const current = live ?? archived;
+    if (current === undefined || !sameWindow(current, this.#eventShape(request))) {
+      throw new WorkspaceCapabilityError("workspace identity does not match the requested closure");
+    }
+  }
+
+  #eventShape(request: CloseWorkspaceRequest): CanonicalEvent {
+    return {
+      schemaVersion: 1,
+      residentId: request.residentId,
+      eventId: "validation-only",
+      streamSeq: 1,
+      payloadHash: "validation-only",
+      purpose: "closure",
+      occurredAt: request.occurredAt,
+      workRef: request.workRef,
+      authoritySource: this.#authoritySource,
+      origin: {
+        reporter: this.#authoritySource,
+        subject: { kind: "viewport", id: request.windowId },
+        viewport: { windowId: request.windowId, generation: request.generation },
+      },
+      effect: { state: "attempted", requiresUserAction: false, retry: "automatic" },
+      artifactRef: request.artifactRef,
+      payload: {},
+    };
+  }
+
+  async #submitRequested(request: CloseWorkspaceRequest): Promise<DeliveryReceipt> {
+    return this.#writer.submit({
+      residentId: request.residentId,
+      idempotencyKey: `${request.idempotencyKey}:requested`,
+      draft: {
+        purpose: "closure",
+        occurredAt: request.occurredAt,
+        workRef: request.workRef,
+        authoritySource: this.#authoritySource,
+        origin: {
+          reporter: this.#authoritySource,
+          subject: { kind: "viewport", id: request.windowId },
+          viewport: { windowId: request.windowId, generation: request.generation },
+        },
+        effect: { state: "attempted", requiresUserAction: false, retry: "automatic" },
+        artifactRef: request.artifactRef,
+        payload: {
+          operationId: request.idempotencyKey,
+          phase: "requested",
+          summary: request.summary,
+        },
+      },
+    });
+  }
+
+  #archiveExact(request: CloseWorkspaceRequest): ArchivedWindow {
+    const live = this.#sessions.get(request.windowId);
+    if (live !== undefined && !sameWindow(live, this.#eventShape(request))) {
+      throw new WorkspaceCapabilityError("refusing to archive a different workspace generation");
+    }
+    const archived = this.#sessions.kill(request.windowId);
+    if (archived === undefined || !sameWindow(archived, this.#eventShape(request))) {
+      throw new WorkspaceCapabilityError("closure points to a missing or mismatched workspace");
+    }
+    return archived;
+  }
+
+  async #submitEffective(
+    request: CloseWorkspaceRequest,
+    requestedEventId: string,
+  ): Promise<DeliveryReceipt> {
+    return this.#writer.submit({
+      residentId: request.residentId,
+      idempotencyKey: `${request.idempotencyKey}:effective`,
+      draft: {
+        purpose: "result",
+        occurredAt: request.occurredAt,
+        workRef: request.workRef,
+        authoritySource: this.#authoritySource,
+        origin: {
+          reporter: this.#authoritySource,
+          subject: { kind: "viewport", id: request.windowId },
+          viewport: { windowId: request.windowId, generation: request.generation },
+        },
+        effect: { state: "committed-effective", requiresUserAction: false, retry: "none" },
+        artifactRef: request.artifactRef,
+        payload: {
+          closureEventId: requestedEventId,
+          operationId: request.idempotencyKey,
+          phase: "closed",
+          summary: request.summary,
+        },
+      },
+    });
+  }
+}
+
+/** Read-only adapter that reconstructs exactly one archived viewport branch from MessageTree. */
+export class MessageTreeViewportHistory implements ViewportHistoryReadPort {
+  readonly #tree: MessageTreeStore;
+  readonly #sessions: SessionRegistry<unknown>;
+
+  constructor(tree: MessageTreeStore, sessions: SessionRegistry<unknown>) {
+    this.#tree = tree;
+    this.#sessions = sessions;
+  }
+
+  read(binding: ViewportEvidenceBinding): readonly HistoryNode[] {
+    const archived = this.#sessions.getArchived(binding.windowId);
+    if (
+      archived === undefined ||
+      archived.residentId !== binding.residentId ||
+      archived.generation !== binding.generation
+    ) {
+      throw new WorkspaceCapabilityError("evidence pointer is not bound to this archived viewport");
+    }
+    if (archived.headId === null) return Object.freeze([]);
+    const byId = new Map(this.#tree.history(binding.residentId).map((node) => [node.id, node]));
+    const branch: HistoryNode[] = [];
+    let cursor: string | null = archived.headId;
+    const seen = new Set<string>();
+    while (cursor !== null) {
+      if (seen.has(cursor)) throw new WorkspaceCapabilityError("viewport history contains a cycle");
+      seen.add(cursor);
+      const node = byId.get(cursor);
+      if (node === undefined)
+        throw new WorkspaceCapabilityError("viewport head is missing from history");
+      branch.push(structuredClone(node));
+      cursor = node.parentId;
+    }
+    return Object.freeze(branch.reverse());
+  }
+}
+
+/** Explicitly authorized evidence surface. It can read only through a canonical result pointer. */
+export class EvidenceViewportReader {
+  readonly #stream: CanonicalStreamReadPort;
+  readonly #history: ViewportHistoryReadPort;
+
+  constructor(
+    stream: CanonicalStreamReadPort,
+    history: ViewportHistoryReadPort,
+    principal: EvidencePrincipal,
+  ) {
+    if (
+      principal.capability !== "viewport-evidence:read" ||
+      typeof principal.principalId !== "string" ||
+      principal.principalId.trim().length === 0
+    ) {
+      throw new WorkspaceCapabilityError("explicit evidence principal is required");
+    }
+    this.#stream = stream;
+    this.#history = history;
+  }
+
+  read(request: EvidenceReadRequest): EvidenceViewportRecord {
+    const keys = Object.keys(request).sort();
+    if (keys.length !== 2 || keys[0] !== "residentId" || keys[1] !== "resultEventId") {
+      throw new WorkspaceCapabilityError("evidence read accepts only a canonical result pointer");
+    }
+    nonEmpty(request.residentId, "residentId");
+    nonEmpty(request.resultEventId, "resultEventId");
+    const events = this.#stream.eventsAfter(request.residentId, 0);
+    const event = events.find((candidate) => candidate.eventId === request.resultEventId);
+    if (
+      event === undefined ||
+      event.purpose !== "result" ||
+      event.effect.state !== "committed-effective" ||
+      closurePhase(event) !== "closed" ||
+      event.origin.viewport === null ||
+      event.artifactRef === null
+    ) {
+      throw new WorkspaceCapabilityError("result event is not an authoritative closure pointer");
+    }
+    const requestedEventId = closureEventId(event);
+    const requested = events.find((candidate) => candidate.eventId === requestedEventId);
+    if (
+      requested === undefined ||
+      requested.purpose !== "closure" ||
+      requested.effect.state !== "attempted" ||
+      closurePhase(requested) !== "requested" ||
+      requested.workRef !== event.workRef ||
+      requested.artifactRef !== event.artifactRef ||
+      requested.origin.viewport?.windowId !== event.origin.viewport.windowId ||
+      requested.origin.viewport.generation !== event.origin.viewport.generation
+    ) {
+      throw new WorkspaceCapabilityError("result event does not bind to its closure request");
+    }
+    const binding: ViewportEvidenceBinding = {
+      residentId: request.residentId,
+      windowId: event.origin.viewport.windowId,
+      generation: event.origin.viewport.generation,
+      artifactRef: event.artifactRef,
+    };
+    return Object.freeze({
+      ...binding,
+      resultEventId: event.eventId,
+      history: this.#history.read(binding),
+    });
+  }
+}

--- a/src/one-stream/workspace-read-model.ts
+++ b/src/one-stream/workspace-read-model.ts
@@ -84,6 +84,26 @@ export class WorkspaceCapabilityError extends Error {
   }
 }
 
+/** Host-side issuer. A matching string is not authority; the exact issued token is. */
+export class EvidenceAuthority {
+  readonly #issued = new WeakSet<object>();
+
+  issue(principalId: string): EvidencePrincipal {
+    const principal = Object.freeze({
+      principalId: nonEmpty(principalId, "principalId"),
+      capability: "viewport-evidence:read" as const,
+    });
+    this.#issued.add(principal);
+    return principal;
+  }
+
+  assert(principal: EvidencePrincipal): void {
+    if (typeof principal !== "object" || principal === null || !this.#issued.has(principal)) {
+      throw new WorkspaceCapabilityError("host-issued evidence principal is required");
+    }
+  }
+}
+
 function nonEmpty(value: unknown, name: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new WorkspaceCapabilityError(`${name} must be a non-empty string`);
@@ -392,15 +412,10 @@ export class EvidenceViewportReader {
   constructor(
     stream: CanonicalStreamReadPort,
     history: ViewportHistoryReadPort,
+    authority: EvidenceAuthority,
     principal: EvidencePrincipal,
   ) {
-    if (
-      principal.capability !== "viewport-evidence:read" ||
-      typeof principal.principalId !== "string" ||
-      principal.principalId.trim().length === 0
-    ) {
-      throw new WorkspaceCapabilityError("explicit evidence principal is required");
-    }
+    authority.assert(principal);
     this.#stream = stream;
     this.#history = history;
   }

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -26,6 +26,7 @@ const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 export const WINDOW_ARCHIVED = "WINDOW_ARCHIVED" as const;
 export const WINDOW_REOPEN_INVALID = "WINDOW_REOPEN_INVALID" as const;
+export const WINDOW_ARCHIVE_RECOVERY_INVALID = "WINDOW_ARCHIVE_RECOVERY_INVALID" as const;
 
 export class WindowArchivedError extends Error {
   readonly code = WINDOW_ARCHIVED;
@@ -40,6 +41,14 @@ export class WindowReopenError extends Error {
   constructor(windowId: string, reason: string) {
     super(`${WINDOW_REOPEN_INVALID}: ${windowId}: ${reason}`);
     this.name = "WindowReopenError";
+  }
+}
+
+export class WindowArchiveRecoveryError extends Error {
+  readonly code = WINDOW_ARCHIVE_RECOVERY_INVALID;
+  constructor(windowId: string, reason: string) {
+    super(`${WINDOW_ARCHIVE_RECOVERY_INVALID}: ${windowId}: ${reason}`);
+    this.name = "WindowArchiveRecoveryError";
   }
 }
 
@@ -441,6 +450,65 @@ export class SessionRegistry<TContext> {
     this.#active.delete(windowId);
     this.#archived.set(windowId, archived);
     return cloneArchivedWindow(archived);
+  }
+
+  /**
+   * Finish a host-owned close operation after restart. The caller must supply the exact durable
+   * snapshot recorded before the active window disappeared; this method cannot invent or resume
+   * an active context. It only restores the archived evidence record for the latest issued
+   * generation of an already-known window identity.
+   */
+  recoverArchived(window: ArchivedWindow): ArchivedWindow {
+    if (
+      window.archived !== true ||
+      typeof window.residentId !== "string" ||
+      window.residentId.length === 0 ||
+      typeof window.windowId !== "string" ||
+      window.windowId.length === 0 ||
+      typeof window.scopeId !== "string" ||
+      window.scopeId.length === 0 ||
+      !Number.isSafeInteger(window.generation) ||
+      window.generation < 1
+    ) {
+      throw new WindowArchiveRecoveryError(window.windowId, "archive snapshot is invalid");
+    }
+    const existing = this.#archived.get(window.windowId);
+    if (existing !== undefined) {
+      if (
+        existing.residentId !== window.residentId ||
+        existing.scopeId !== window.scopeId ||
+        existing.generation !== window.generation ||
+        existing.headId !== window.headId ||
+        window.archived !== true
+      ) {
+        throw new WindowArchiveRecoveryError(window.windowId, "archive snapshot mismatch");
+      }
+      return cloneArchivedWindow(existing);
+    }
+    if (this.#active.has(window.windowId)) {
+      throw new WindowArchiveRecoveryError(window.windowId, "window is still active");
+    }
+    const identity = this.#windowIdentity.get(window.windowId);
+    if (
+      identity === undefined ||
+      identity.residentId !== window.residentId ||
+      identity.scopeId !== window.scopeId
+    ) {
+      throw new WindowArchiveRecoveryError(window.windowId, "window identity mismatch");
+    }
+    if (this.#lastGeneration.get(window.windowId) !== window.generation) {
+      throw new WindowArchiveRecoveryError(window.windowId, "generation is not the latest issued");
+    }
+    if (
+      window.headId !== null &&
+      (typeof window.headId !== "string" || window.headId.length === 0)
+    ) {
+      throw new WindowArchiveRecoveryError(window.windowId, "headId is invalid");
+    }
+    const recovered = cloneArchivedWindow({ ...window, archived: true });
+    this.#appendArchive(recovered);
+    this.#archived.set(recovered.windowId, recovered);
+    return cloneArchivedWindow(recovered);
   }
 
   /** 杀掉一位住户的全部活窗（MV-A03 后半）。 */

--- a/src/session/session-registry.ts
+++ b/src/session/session-registry.ts
@@ -220,6 +220,12 @@ export class SessionRegistry<TContext> {
           `window generation is not increasing at line ${index + 1}: ${window.windowId}`,
         );
       }
+      if (record.type === "window_opened") {
+        // Runtime open() removes the prior archived generation before this generation becomes
+        // active. Journal replay must project the same state: after a later open, an older
+        // archive is historical evidence, not the current archived state of this windowId.
+        this.#archived.delete(window.windowId);
+      }
       if (record.type === "window_archived") {
         const previousArchiveGeneration = this.#archived.get(window.windowId)?.generation ?? 0;
         if (
@@ -309,30 +315,37 @@ export class SessionRegistry<TContext> {
     return time + this.#ulidRandom.map((digit) => ULID_ALPHABET.charAt(digit)).join("");
   }
 
-  #requireArchivedForReopen(residentId: string, scopeId: string, windowId: string): ArchivedWindow {
+  #requireArchivedForReopen(residentId: string, scopeId: string, windowId: string): void {
+    if (this.#active.has(windowId)) {
+      throw new WindowReopenError(windowId, "target is still active");
+    }
     const archived = this.#archived.get(windowId);
-    if (archived === undefined) {
-      throw new WindowReopenError(windowId, "target is not an archived window");
+    const identity = this.#windowIdentity.get(windowId);
+    const knownResidentId = archived?.residentId ?? identity?.residentId;
+    const knownScopeId = archived?.scopeId ?? identity?.scopeId;
+    if (knownResidentId === undefined || this.#lastGeneration.get(windowId) === undefined) {
+      throw new WindowReopenError(windowId, "target is not a known stopped window");
     }
-    if (archived.residentId !== residentId) {
+    if (knownResidentId !== residentId) {
       throw new WindowReopenError(
         windowId,
-        `resident mismatch: archived=${archived.residentId}, requested=${residentId}`,
+        `resident mismatch: known=${knownResidentId}, requested=${residentId}`,
       );
     }
-    if (archived.scopeId !== scopeId) {
+    if (knownScopeId !== scopeId) {
       throw new WindowReopenError(
         windowId,
-        `scope mismatch: archived=${archived.scopeId}, requested=${scopeId}`,
+        `scope mismatch: known=${knownScopeId}, requested=${scopeId}`,
       );
     }
-    return archived;
   }
 
   /**
    * 开一扇窗。同一 residentId 连开两次得到两扇不同的窗，各自 generation=1，
    * 两窗皆活；旧语义「重复 open 原地换代」不再存在（MV-A01）。
-   * 给 windowId 时是按同一身份重开一扇已归档的窗，起新一代（#66 B5）。
+   * 给 windowId 时是按同一身份重开一扇已停止的窗，起新一代（#66 B5）。同一进程的
+   * 活窗不能重开；宿主重启后，journal 中只有 opened 但没有 archived 的最新代也视为已停止，
+   * 继续发下一代而不复活旧 active context。
    */
   open(residentId: string, options: OpenOptions<TContext>): ActiveWindow<TContext> {
     const scopeId = options.scopeId ?? PRIVATE_SCOPE;

--- a/tests/one-stream-workspace.test.ts
+++ b/tests/one-stream-workspace.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { MessageTreeService, MessageTreeStore } from "../src/message-tree/index.ts";
 import {
@@ -12,14 +15,24 @@ import {
 } from "../src/one-stream/index.ts";
 import { SessionRegistry } from "../src/session/session-registry.ts";
 
-function assembly(checkpoint?: (name: "closure-delivered" | "workspace-archived") => void) {
-  const store = new CanonicalStreamStore();
+function assembly(
+  options: {
+    checkpoint?: (name: "closure-delivered" | "workspace-archived") => void;
+    dataDir?: string;
+    archivePath?: string;
+  } = {},
+) {
+  const store = new CanonicalStreamStore(
+    options.dataDir === undefined ? {} : { dataDir: options.dataDir },
+  );
   store.createStream("resident-a");
   const writer = new CanonicalStreamWriter(store);
-  const sessions = new SessionRegistry<null>();
+  const sessions = new SessionRegistry<null>(
+    options.archivePath === undefined ? {} : { archivePath: options.archivePath },
+  );
   const lifecycle = new WorkspaceLifecycleOwner(writer, store, sessions, {
     authoritySource: { kind: "host", id: "mist-host" },
-    ...(checkpoint === undefined ? {} : { checkpoint }),
+    ...(options.checkpoint === undefined ? {} : { checkpoint: options.checkpoint }),
   });
   const tree = new MessageTreeStore();
   tree.createRoom("resident-a");
@@ -123,8 +136,10 @@ describe("OS-03 workspace and evidence capability split", () => {
 
   it("reconciles a crash after durable closure without hiding a live workspace first", async () => {
     let crash = true;
-    const { store, writer, sessions, lifecycle } = assembly((name) => {
-      if (crash && name === "closure-delivered") throw new Error("simulated crash");
+    const { store, writer, sessions, lifecycle } = assembly({
+      checkpoint: (name) => {
+        if (crash && name === "closure-delivered") throw new Error("simulated crash");
+      },
     });
     const opened = lifecycle.create("resident-a", { context: null });
     const request = {
@@ -156,8 +171,10 @@ describe("OS-03 workspace and evidence capability split", () => {
 
   it("reconciles a crash after archive without creating a second result", async () => {
     let crash = true;
-    const { store, writer, sessions, lifecycle } = assembly((name) => {
-      if (crash && name === "workspace-archived") throw new Error("simulated post-archive crash");
+    const { store, writer, sessions, lifecycle } = assembly({
+      checkpoint: (name) => {
+        if (crash && name === "workspace-archived") throw new Error("simulated post-archive crash");
+      },
     });
     const opened = lifecycle.create("resident-a", { context: null });
     const request = {
@@ -182,6 +199,235 @@ describe("OS-03 workspace and evidence capability split", () => {
       "result",
     ]);
     expect(await lifecycle.reconcile("resident-a")).toEqual([]);
+    await writer.close();
+  });
+
+  it("reconciles a durable closure after stream and session registry restart", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mist-workspace-recovery-"));
+    const dataDir = join(root, "stream");
+    const archivePath = join(root, "sessions", "archive.jsonl");
+    try {
+      const first = assembly({
+        dataDir,
+        archivePath,
+        checkpoint: (name) => {
+          if (name === "closure-delivered") throw new Error("simulated host death");
+        },
+      });
+      const opened = first.lifecycle.create("resident-a", { context: null, scopeId: "project" });
+      const reply = await first.service.say(
+        "resident-a",
+        "persist-this-head",
+        opened.handle.windowId,
+      );
+      await expect(
+        first.lifecycle.close({
+          residentId: "resident-a",
+          windowId: opened.handle.windowId,
+          generation: opened.handle.generation,
+          workRef: "work-restart",
+          artifactRef: "evidence:restart",
+          idempotencyKey: "close-restart",
+          occurredAt: "2026-09-04T08:03:00.000Z",
+          summary: "recover after a new host starts",
+        }),
+      ).rejects.toThrow("simulated host death");
+      await first.writer.close();
+
+      const restoredStore = new CanonicalStreamStore({ dataDir });
+      const restoredWriter = new CanonicalStreamWriter(restoredStore);
+      const restoredSessions = new SessionRegistry<null>({ archivePath });
+      expect(restoredSessions.get(opened.handle.windowId)).toBeUndefined();
+      expect(restoredSessions.getArchived(opened.handle.windowId)).toBeUndefined();
+      const restoredLifecycle = new WorkspaceLifecycleOwner(
+        restoredWriter,
+        restoredStore,
+        restoredSessions,
+        { authoritySource: { kind: "host", id: "mist-host" } },
+      );
+
+      const recovered = await restoredLifecycle.reconcile("resident-a");
+      expect(recovered).toHaveLength(1);
+      expect(restoredSessions.getArchived(opened.handle.windowId)).toMatchObject({
+        residentId: "resident-a",
+        generation: opened.handle.generation,
+        scopeId: "project",
+        headId: reply.id,
+      });
+      expect(restoredStore.eventsAfter("resident-a", 0).map((event) => event.purpose)).toEqual([
+        "closure",
+        "result",
+      ]);
+      expect(await restoredLifecycle.reconcile("resident-a")).toEqual([]);
+      await restoredWriter.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps first-party create from reopening or appending to an archived workspace", async () => {
+    const { writer, sessions, lifecycle } = assembly();
+    const opened = lifecycle.create("resident-a", { context: null });
+    await lifecycle.close({
+      residentId: "resident-a",
+      windowId: opened.handle.windowId,
+      generation: opened.handle.generation,
+      workRef: "work-no-resume",
+      artifactRef: "evidence:no-resume",
+      idempotencyKey: "close-no-resume",
+      occurredAt: "2026-09-04T08:04:00.000Z",
+      summary: "must stay archived",
+    });
+
+    expect(() =>
+      lifecycle.create("resident-a", {
+        context: null,
+        windowId: opened.handle.windowId,
+        headId: sessions.getArchived(opened.handle.windowId)?.headId,
+      } as never),
+    ).toThrow(/accepts only context and optional scopeId/);
+    expect(sessions.isArchived(opened.handle.windowId)).toBe(true);
+    expect(sessions.windowsOf("resident-a")).toEqual([]);
+    await writer.close();
+  });
+
+  it("does not let an unrelated result suppress closure reconciliation", async () => {
+    let crash = true;
+    const { store, writer, sessions, lifecycle } = assembly({
+      checkpoint: (name) => {
+        if (crash && name === "closure-delivered") throw new Error("simulated crash");
+      },
+    });
+    const opened = lifecycle.create("resident-a", { context: null });
+    await expect(
+      lifecycle.close({
+        residentId: "resident-a",
+        windowId: opened.handle.windowId,
+        generation: opened.handle.generation,
+        workRef: "work-real",
+        artifactRef: "evidence:real",
+        idempotencyKey: "close-real",
+        occurredAt: "2026-09-04T08:05:00.000Z",
+        summary: "real closure",
+      }),
+    ).rejects.toThrow("simulated crash");
+    const closure = store.eventsAfter("resident-a", 0)[0];
+    await writer.submit({
+      residentId: "resident-a",
+      idempotencyKey: "unrelated-result",
+      draft: {
+        purpose: "result",
+        occurredAt: "2026-09-04T08:05:01.000Z",
+        workRef: "different-work",
+        authoritySource: { kind: "host", id: "mist-host" },
+        origin: {
+          reporter: { kind: "host", id: "mist-host" },
+          subject: { kind: "viewport", id: opened.handle.windowId },
+          viewport: {
+            windowId: opened.handle.windowId,
+            generation: opened.handle.generation,
+          },
+        },
+        effect: { state: "committed-effective", requiresUserAction: false, retry: "none" },
+        artifactRef: "evidence:different",
+        payload: {
+          closureEventId: closure?.eventId ?? "missing",
+          operationId: "different-operation",
+          phase: "closed",
+          summary: "not the matching result",
+        },
+      },
+    });
+
+    crash = false;
+    expect(await lifecycle.reconcile("resident-a")).toHaveLength(1);
+    expect(sessions.isArchived(opened.handle.windowId)).toBe(true);
+    expect(
+      store
+        .eventsAfter("resident-a", 0)
+        .filter((event) => event.purpose === "result" && event.workRef === "work-real"),
+    ).toHaveLength(1);
+    await writer.close();
+  });
+
+  it("rejects viewport-issued closure pairs as evidence authority", async () => {
+    const { store, writer, sessions, lifecycle, tree } = assembly();
+    const opened = lifecycle.create("resident-a", { context: null });
+    await lifecycle.close({
+      residentId: "resident-a",
+      windowId: opened.handle.windowId,
+      generation: opened.handle.generation,
+      workRef: "work-authority",
+      artifactRef: "evidence:authority",
+      idempotencyKey: "close-authority",
+      occurredAt: "2026-09-04T08:06:00.000Z",
+      summary: "real host closure",
+    });
+    const viewportActor = { kind: "viewport" as const, id: opened.handle.windowId };
+    const fakeClosure = await writer.submit({
+      residentId: "resident-a",
+      idempotencyKey: "fake-closure",
+      draft: {
+        purpose: "closure",
+        occurredAt: "2026-09-04T08:06:01.000Z",
+        workRef: "work-authority",
+        authoritySource: viewportActor,
+        origin: {
+          reporter: viewportActor,
+          subject: viewportActor,
+          viewport: {
+            windowId: opened.handle.windowId,
+            generation: opened.handle.generation,
+          },
+        },
+        effect: { state: "attempted", requiresUserAction: false, retry: "automatic" },
+        artifactRef: "evidence:authority",
+        payload: {
+          headId: null,
+          operationId: "fake-close",
+          phase: "requested",
+          scopeId: "private",
+          summary: "viewport tries to self-authorize",
+        },
+      },
+    });
+    const fakeResult = await writer.submit({
+      residentId: "resident-a",
+      idempotencyKey: "fake-result",
+      draft: {
+        purpose: "result",
+        occurredAt: "2026-09-04T08:06:02.000Z",
+        workRef: "work-authority",
+        authoritySource: viewportActor,
+        origin: {
+          reporter: viewportActor,
+          subject: viewportActor,
+          viewport: {
+            windowId: opened.handle.windowId,
+            generation: opened.handle.generation,
+          },
+        },
+        effect: { state: "committed-effective", requiresUserAction: false, retry: "none" },
+        artifactRef: "evidence:authority",
+        payload: {
+          closureEventId: fakeClosure.eventId,
+          operationId: "fake-close",
+          phase: "closed",
+          summary: "viewport tries to unlock evidence",
+        },
+      },
+    });
+    const authority = new EvidenceAuthority();
+    const evidence = new EvidenceViewportReader(
+      store,
+      new MessageTreeViewportHistory(tree, sessions),
+      authority,
+      authority.issue("auditor-a"),
+    );
+
+    expect(() =>
+      evidence.read({ residentId: "resident-a", resultEventId: fakeResult.eventId }),
+    ).toThrow(/not an authoritative closure pointer/);
     await writer.close();
   });
 });

--- a/tests/one-stream-workspace.test.ts
+++ b/tests/one-stream-workspace.test.ts
@@ -3,6 +3,7 @@ import { MessageTreeService, MessageTreeStore } from "../src/message-tree/index.
 import {
   CanonicalStreamStore,
   CanonicalStreamWriter,
+  EvidenceAuthority,
   EvidenceViewportReader,
   FirstPartyResidentView,
   MessageTreeViewportHistory,
@@ -74,18 +75,25 @@ describe("OS-03 workspace and evidence capability split", () => {
       ),
     ).toBe(true);
 
+    const authority = new EvidenceAuthority();
     expect(
       () =>
-        new EvidenceViewportReader(store, new MessageTreeViewportHistory(tree, sessions), {
-          principalId: "first-party-user",
-          capability: "wrong" as "viewport-evidence:read",
-        }),
+        new EvidenceViewportReader(
+          store,
+          new MessageTreeViewportHistory(tree, sessions),
+          authority,
+          {
+            principalId: "first-party-user",
+            capability: "viewport-evidence:read",
+          },
+        ),
     ).toThrow(WorkspaceCapabilityError);
 
     const evidence = new EvidenceViewportReader(
       store,
       new MessageTreeViewportHistory(tree, sessions),
-      { principalId: "auditor-a", capability: "viewport-evidence:read" },
+      authority,
+      authority.issue("auditor-a"),
     );
     expect(
       evidence.read({ residentId: "resident-a", resultEventId: closed.effective.eventId }),

--- a/tests/one-stream-workspace.test.ts
+++ b/tests/one-stream-workspace.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { MessageTreeService, MessageTreeStore } from "../src/message-tree/index.ts";
+import {
+  CanonicalStreamStore,
+  CanonicalStreamWriter,
+  EvidenceViewportReader,
+  FirstPartyResidentView,
+  MessageTreeViewportHistory,
+  WorkspaceCapabilityError,
+  WorkspaceLifecycleOwner,
+} from "../src/one-stream/index.ts";
+import { SessionRegistry } from "../src/session/session-registry.ts";
+
+function assembly(checkpoint?: (name: "closure-delivered" | "workspace-archived") => void) {
+  const store = new CanonicalStreamStore();
+  store.createStream("resident-a");
+  const writer = new CanonicalStreamWriter(store);
+  const sessions = new SessionRegistry<null>();
+  const lifecycle = new WorkspaceLifecycleOwner(writer, store, sessions, {
+    authoritySource: { kind: "host", id: "mist-host" },
+    ...(checkpoint === undefined ? {} : { checkpoint }),
+  });
+  const tree = new MessageTreeStore();
+  tree.createRoom("resident-a");
+  const service = new MessageTreeService(
+    tree,
+    {
+      getHead: (windowId) => sessions.getHead(windowId),
+      setHead: (windowId, headId) => sessions.setHead(windowId, headId),
+    },
+    { assistantReply: (_residentId, message) => `reply:${message}` },
+  );
+  return { store, writer, sessions, lifecycle, tree, service };
+}
+
+describe("OS-03 workspace and evidence capability split", () => {
+  it("shows only live workspaces to first party and reads an archived branch only by result pointer", async () => {
+    const { store, writer, sessions, lifecycle, tree, service } = assembly();
+    const first = lifecycle.create("resident-a", { context: null, scopeId: "private" });
+    const second = lifecycle.create("resident-a", { context: null, scopeId: "project" });
+    await service.say("resident-a", "first-window", first.handle.windowId);
+    await service.say("resident-a", "second-window", second.handle.windowId);
+
+    const firstParty = new FirstPartyResidentView(store, sessions);
+    expect(firstParty.snapshot("resident-a").activeWorkspaces).toEqual([
+      first.handle,
+      second.handle,
+    ]);
+    expect(first.phase).toBe("workspace-created");
+    expect(first).not.toHaveProperty("chat");
+    expect(first).not.toHaveProperty("history");
+
+    const closed = await lifecycle.close({
+      residentId: "resident-a",
+      windowId: first.handle.windowId,
+      generation: first.handle.generation,
+      workRef: "work-first",
+      artifactRef: "evidence:first-window",
+      idempotencyKey: "close-first",
+      occurredAt: "2026-09-04T08:00:00.000Z",
+      summary: "first workspace archived",
+    });
+
+    const visible = firstParty.snapshot("resident-a");
+    expect(visible.activeWorkspaces).toEqual([second.handle]);
+    expect(visible.activeWorkspaces).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ windowId: first.handle.windowId })]),
+    );
+    expect(visible).not.toHaveProperty("archivedWorkspaces");
+    expect(visible).not.toHaveProperty("history");
+    expect(
+      visible.canonicalEvents.some(
+        (event) => event.eventId === closed.effective.eventId && event.purpose === "result",
+      ),
+    ).toBe(true);
+
+    expect(
+      () =>
+        new EvidenceViewportReader(store, new MessageTreeViewportHistory(tree, sessions), {
+          principalId: "first-party-user",
+          capability: "wrong" as "viewport-evidence:read",
+        }),
+    ).toThrow(WorkspaceCapabilityError);
+
+    const evidence = new EvidenceViewportReader(
+      store,
+      new MessageTreeViewportHistory(tree, sessions),
+      { principalId: "auditor-a", capability: "viewport-evidence:read" },
+    );
+    expect(
+      evidence.read({ residentId: "resident-a", resultEventId: closed.effective.eventId }),
+    ).toMatchObject({
+      windowId: first.handle.windowId,
+      generation: 1,
+      artifactRef: "evidence:first-window",
+      history: [
+        { role: "user", content: "first-window" },
+        { role: "assistant", content: "reply:first-window" },
+      ],
+    });
+    expect(() =>
+      evidence.read({ residentId: "resident-a", resultEventId: closed.requested.eventId }),
+    ).toThrow(/not an authoritative closure pointer/);
+    expect(() =>
+      evidence.read({
+        residentId: "resident-a",
+        resultEventId: closed.effective.eventId,
+        windowId: first.handle.windowId,
+      } as never),
+    ).toThrow(/only a canonical result pointer/);
+    expect(evidence).not.toHaveProperty("write");
+    expect(evidence).not.toHaveProperty("resume");
+    await writer.close();
+  });
+
+  it("reconciles a crash after durable closure without hiding a live workspace first", async () => {
+    let crash = true;
+    const { store, writer, sessions, lifecycle } = assembly((name) => {
+      if (crash && name === "closure-delivered") throw new Error("simulated crash");
+    });
+    const opened = lifecycle.create("resident-a", { context: null });
+    const request = {
+      residentId: "resident-a",
+      windowId: opened.handle.windowId,
+      generation: opened.handle.generation,
+      workRef: "work-recovery",
+      artifactRef: "evidence:recovery",
+      idempotencyKey: "close-recovery",
+      occurredAt: "2026-09-04T08:01:00.000Z",
+      summary: "recover closure",
+    } as const;
+
+    await expect(lifecycle.close(request)).rejects.toThrow("simulated crash");
+    expect(sessions.isActive(opened.handle.windowId)).toBe(true);
+    expect(store.eventsAfter("resident-a", 0).map((event) => event.purpose)).toEqual(["closure"]);
+
+    crash = false;
+    const recovered = await lifecycle.reconcile("resident-a");
+    expect(recovered).toHaveLength(1);
+    expect(sessions.isArchived(opened.handle.windowId)).toBe(true);
+    expect(store.eventsAfter("resident-a", 0).map((event) => event.purpose)).toEqual([
+      "closure",
+      "result",
+    ]);
+    expect(await lifecycle.reconcile("resident-a")).toEqual([]);
+    await writer.close();
+  });
+});

--- a/tests/one-stream-workspace.test.ts
+++ b/tests/one-stream-workspace.test.ts
@@ -153,4 +153,35 @@ describe("OS-03 workspace and evidence capability split", () => {
     expect(await lifecycle.reconcile("resident-a")).toEqual([]);
     await writer.close();
   });
+
+  it("reconciles a crash after archive without creating a second result", async () => {
+    let crash = true;
+    const { store, writer, sessions, lifecycle } = assembly((name) => {
+      if (crash && name === "workspace-archived") throw new Error("simulated post-archive crash");
+    });
+    const opened = lifecycle.create("resident-a", { context: null });
+    const request = {
+      residentId: "resident-a",
+      windowId: opened.handle.windowId,
+      generation: opened.handle.generation,
+      workRef: "work-post-archive-recovery",
+      artifactRef: "evidence:post-archive-recovery",
+      idempotencyKey: "close-post-archive-recovery",
+      occurredAt: "2026-09-04T08:02:00.000Z",
+      summary: "recover result after archive",
+    } as const;
+
+    await expect(lifecycle.close(request)).rejects.toThrow("simulated post-archive crash");
+    expect(sessions.isArchived(opened.handle.windowId)).toBe(true);
+    expect(store.eventsAfter("resident-a", 0).map((event) => event.purpose)).toEqual(["closure"]);
+
+    crash = false;
+    expect(await lifecycle.reconcile("resident-a")).toHaveLength(1);
+    expect(store.eventsAfter("resident-a", 0).map((event) => event.purpose)).toEqual([
+      "closure",
+      "result",
+    ]);
+    expect(await lifecycle.reconcile("resident-a")).toEqual([]);
+    await writer.close();
+  });
 });

--- a/tests/one-stream-workspace.test.ts
+++ b/tests/one-stream-workspace.test.ts
@@ -265,6 +265,88 @@ describe("OS-03 workspace and evidence capability split", () => {
     }
   });
 
+  it("reconciles the latest generation after an archived window was reopened and the host died", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mist-workspace-multigen-recovery-"));
+    const dataDir = join(root, "stream");
+    const archivePath = join(root, "sessions", "archive.jsonl");
+    let crash = false;
+    try {
+      const first = assembly({
+        dataDir,
+        archivePath,
+        checkpoint: (name) => {
+          if (crash && name === "closure-delivered") throw new Error("simulated host death");
+        },
+      });
+      const generationOne = first.lifecycle.create("resident-a", {
+        context: null,
+        scopeId: "project",
+      });
+      const firstClose = await first.lifecycle.close({
+        residentId: "resident-a",
+        windowId: generationOne.handle.windowId,
+        generation: generationOne.handle.generation,
+        workRef: "work-generation-one",
+        artifactRef: "evidence:generation-one",
+        idempotencyKey: "close-generation-one",
+        occurredAt: "2026-09-04T08:03:10.000Z",
+        summary: "close generation one",
+      });
+      const archivedGenerationOne = first.sessions.getArchived(generationOne.handle.windowId);
+      expect(archivedGenerationOne).toBeDefined();
+      const generationTwo = first.sessions.open("resident-a", {
+        windowId: generationOne.handle.windowId,
+        scopeId: "project",
+        headId: archivedGenerationOne?.headId ?? null,
+        context: null,
+      });
+      expect(generationTwo.generation).toBe(2);
+
+      crash = true;
+      await expect(
+        first.lifecycle.close({
+          residentId: "resident-a",
+          windowId: generationTwo.windowId,
+          generation: generationTwo.generation,
+          workRef: "work-generation-two",
+          artifactRef: "evidence:generation-two",
+          idempotencyKey: "close-generation-two",
+          occurredAt: "2026-09-04T08:03:20.000Z",
+          summary: "recover generation two after restart",
+        }),
+      ).rejects.toThrow("simulated host death");
+      await first.writer.close();
+
+      const restoredStore = new CanonicalStreamStore({ dataDir });
+      const restoredWriter = new CanonicalStreamWriter(restoredStore);
+      const restoredSessions = new SessionRegistry<null>({ archivePath });
+      expect(restoredSessions.getArchived(generationTwo.windowId)).toBeUndefined();
+      const restoredLifecycle = new WorkspaceLifecycleOwner(
+        restoredWriter,
+        restoredStore,
+        restoredSessions,
+        { authoritySource: { kind: "host", id: "mist-host" } },
+      );
+
+      const recovered = await restoredLifecycle.reconcile("resident-a");
+      expect(recovered).toHaveLength(1);
+      expect(recovered[0]?.requested.eventId).not.toBe(firstClose.requested.eventId);
+      expect(restoredSessions.getArchived(generationTwo.windowId)).toMatchObject({
+        residentId: "resident-a",
+        windowId: generationTwo.windowId,
+        generation: 2,
+        scopeId: "project",
+      });
+      expect(
+        restoredStore.eventsAfter("resident-a", 0).filter((event) => event.purpose === "result"),
+      ).toHaveLength(2);
+      expect(await restoredLifecycle.reconcile("resident-a")).toEqual([]);
+      await restoredWriter.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps first-party create from reopening or appending to an archived workspace", async () => {
     const { writer, sessions, lifecycle } = assembly();
     const opened = lifecycle.create("resident-a", { context: null });


### PR DESCRIPTION
Implements OS-03 of #84.

This PR separates the first-party workspace view from the evidence surface:

- FirstPartyResidentView exposes the one canonical stream and live workspace handles only; it has no archive/history/resume API
- first-party create accepts only context and optional scopeId; callers cannot supply windowId or headId to resume an archived branch
- WorkspaceLifecycleOwner writes a durable closure request before removing the navigator entry, including the exact scope/head snapshot required for restart recovery
- a rebuilt file-backed CanonicalStreamStore and SessionRegistry can finish the closure, restore the archived evidence record, and emit committed-effective exactly once
- journal replay removes stale archived generations when a later window_opened record appears, matching live open semantics
- a host can legally reopen a stopped identity after restart without allowing a same-process active-window reopen
- completion requires a fully paired host-issued closure/result: workRef, artifactRef, operationId, subject, viewport, authority, generation, and effect semantics must all match
- EvidenceViewportReader requires an exact host-issued principal and accepts only that authoritative canonical result pointer
- MessageTreeViewportHistory reconstructs the archived branch read-only from its archived head

Fresh evidence on head dc332f7, rebased onto main 0c40540:

- focused workspace: 1 file / 8 tests passed
- focused session, host, and workspace: 3 files / 26 tests passed
- full suite: 48 files passed, 3 skipped; 500 tests passed, 38 todo
- lint, typecheck, and acceptance 6/6 all green
- five reviewer-shaped mutations each turn the matching test red: disable restart archive recovery; restore raw OpenOptions passthrough; match results by closureEventId only; accept viewport authority; retain stale archived generation during journal replay
- the existing evidence-principal bypass mutation remains covered by the first focused test

The OS-03 light remains unchecked for the independent reviewer.