### PR TITLE
feat: route blocked replies by canonical handles

### DIFF
--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -113,11 +113,14 @@
 
   证据：`BlockedReplyRouter` 的候选集只来自 canonical stream 中仍需回答的 blocked event 与
   SessionRegistry 当前活代；输入面只有 `replyToEventId`、`workRef` 或裸回复，没有 recent、
-  focus、createdAt、active tab 等猜测口。`MessageTreeWorkspaceReplyDelivery` 走真实
-  MessageTreeService 派发，只有 user/assistant 两节点落树并推进目标 head 后才返回
-  workspace-committed receipt，失败不标 resolved。`tests/one-stream-reply-router.test.ts` 同时
-  建两扇 blocked 窗：裸回复零投递并返回两个把手；显式 event/work 抵达第一窗；剩唯一候选后
-  裸回复抵达第二窗；陌生、冲突、失效把手与 responder 失败均不旁落另一窗。
+  focus、createdAt、active tab 等猜测口。成功投递后，宿主把 resolved receipt 写回同一条
+  canonical stream；router、port 与 stream store 从磁盘重建后仍能拒绝重复回复，同一 blocker
+  的并发回复也在首次派发前串行化。`MessageTreeWorkspaceReplyDelivery` 走真实
+  MessageTreeService 派发，并把签发的 generation receipt 带到 responder 返回后的同步
+  tree/head commit boundary；in-flight kill 后以同一 windowId 重开时，旧代回复响亮拒绝且
+  user/assistant 树与新代 head 都零写入。`tests/one-stream-reply-router.test.ts` 还同时建立两扇
+  blocked 窗：裸回复零投递并返回两个把手；显式 event/work 抵达第一窗；剩唯一候选后裸回复
+  抵达第二窗；陌生、冲突、失效把手与 responder 失败均不旁落另一窗。
 
 ## 变绿条件
 

--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -117,8 +117,10 @@
   canonical stream；router、port 与 stream store 从磁盘重建后仍能拒绝重复回复，同一 blocker
   的并发回复也在首次派发前串行化。若 workspace pair 已提交而 resolved receipt 尚未落盘，
   blocker event 派生的稳定投递键会在 MessageTree 自己的不可变节点中找回同一 pair；重建
-  tree/service/router 后只补 resolved receipt，不再调用 responder 或追加第二对节点。临时拔掉
-  该投递键时，这条 crash-gap 回归精准转红。`MessageTreeWorkspaceReplyDelivery` 走真实
+  tree/service/router 后只补 resolved receipt，不再调用 responder 或追加第二对节点。即使同窗
+  已继续一轮、当前 head 位于该 pair 的后继链上，恢复也只复用旧 pair 并保持新 head，不会
+  回退会话；若 head 属于别的分叉则继续 fail closed。临时拔掉投递键或后继链识别时，对应
+  crash-gap 回归均精准转红。`MessageTreeWorkspaceReplyDelivery` 走真实
   MessageTreeService 派发，并把签发的 generation receipt 带到 responder 返回后的同步
   tree/head commit boundary；in-flight kill 后以同一 windowId 重开时，旧代回复响亮拒绝且
   user/assistant 树与新代 head 都零写入。`tests/one-stream-reply-router.test.ts` 还同时建立两扇

--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -115,7 +115,10 @@
   SessionRegistry 当前活代；输入面只有 `replyToEventId`、`workRef` 或裸回复，没有 recent、
   focus、createdAt、active tab 等猜测口。成功投递后，宿主把 resolved receipt 写回同一条
   canonical stream；router、port 与 stream store 从磁盘重建后仍能拒绝重复回复，同一 blocker
-  的并发回复也在首次派发前串行化。`MessageTreeWorkspaceReplyDelivery` 走真实
+  的并发回复也在首次派发前串行化。若 workspace pair 已提交而 resolved receipt 尚未落盘，
+  blocker event 派生的稳定投递键会在 MessageTree 自己的不可变节点中找回同一 pair；重建
+  tree/service/router 后只补 resolved receipt，不再调用 responder 或追加第二对节点。临时拔掉
+  该投递键时，这条 crash-gap 回归精准转红。`MessageTreeWorkspaceReplyDelivery` 走真实
   MessageTreeService 派发，并把签发的 generation receipt 带到 responder 返回后的同步
   tree/head commit boundary；in-flight kill 后以同一 windowId 重开时，旧代回复响亮拒绝且
   user/assistant 树与新代 head 都零写入。`tests/one-stream-reply-router.test.ts` 还同时建立两扇

--- a/acceptance/one-stream.md
+++ b/acceptance/one-stream.md
@@ -111,6 +111,14 @@
   工作区均不得收到该回复。按最近事件、当前焦点、viewport 创建时间或模型推测偷偷分配，
   任一种都判红。
 
+  证据：`BlockedReplyRouter` 的候选集只来自 canonical stream 中仍需回答的 blocked event 与
+  SessionRegistry 当前活代；输入面只有 `replyToEventId`、`workRef` 或裸回复，没有 recent、
+  focus、createdAt、active tab 等猜测口。`MessageTreeWorkspaceReplyDelivery` 走真实
+  MessageTreeService 派发，只有 user/assistant 两节点落树并推进目标 head 后才返回
+  workspace-committed receipt，失败不标 resolved。`tests/one-stream-reply-router.test.ts` 同时
+  建两扇 blocked 窗：裸回复零投递并返回两个把手；显式 event/work 抵达第一窗；剩唯一候选后
+  裸回复抵达第二窗；陌生、冲突、失效把手与 responder 失败均不旁落另一窗。
+
 ## 变绿条件
 
 本页合入只代表判卷程序已写清，六盏默认保持未勾。实现 PR 必须给出相应的可重复测试，

--- a/src/message-tree/index.ts
+++ b/src/message-tree/index.ts
@@ -6,6 +6,8 @@ export {
 export { MessageTreeService } from "./service.ts";
 export type {
   AssistantReply,
+  MessageCommitBoundary,
+  MessageTreeSayOptions,
   MessageTreeServiceOptions,
   SessionHeadPort,
   TurnGate,

--- a/src/message-tree/service.ts
+++ b/src/message-tree/service.ts
@@ -55,6 +55,20 @@ export interface MessageTreeServiceOptions {
   turnGate?: TurnGate;
 }
 
+/**
+ * Optional final-commit boundary for callers whose authority can change while the responder is
+ * running. The boundary is entered after the awaited reply and wraps the synchronous tree append
+ * plus head advance, so a caller can revalidate a generation without leaving another await-sized
+ * race before the mutation.
+ */
+export interface MessageCommitBoundary {
+  commit<T>(mutation: () => T): T;
+}
+
+export interface MessageTreeSayOptions {
+  readonly commitBoundary?: MessageCommitBoundary;
+}
+
 const echoReply: AssistantReply = (_residentId, message) => message;
 
 /**
@@ -80,7 +94,12 @@ export class MessageTreeService {
   }
 
   /** 原子落 user + assistant；两节点都存在以后才允许推进会话 head。 */
-  async say(residentId: string, message: string, windowId: string): Promise<HistoryNode> {
+  async say(
+    residentId: string,
+    message: string,
+    windowId: string,
+    options: MessageTreeSayOptions = {},
+  ): Promise<HistoryNode> {
     // Store 的公开 API 刻意很窄；复用只读历史同时验证房间与会话 head，
     // 避免 stale/cross-room head 在最终落树失败前已经调用 responder，白花模型成本
     // 或触发外部副作用。appendPair 仍会在写入边界重验 parentId，不依赖这层代签。
@@ -98,12 +117,15 @@ export class MessageTreeService {
         ? [...pass.contextPrefix, message].join("\n\n")
         : message;
     const assistantContent = await this.#assistantReply(residentId, prompt);
-    const pair = this.#store.appendPair(residentId, message, assistantContent, parentId);
-    this.#sessionHeads.setHead(windowId, pair.assistant.id);
-    // 回执只在落树 + head 推进都成功之后发出：先 ack 后落树会让「已确认」
-    // 覆盖「没送到」，回执丢失归传播机制的前提是先证明这轮真的开工了（MV-C05）。
-    pass?.commit();
-    return pair.assistant;
+    const commit = (): HistoryNode => {
+      const pair = this.#store.appendPair(residentId, message, assistantContent, parentId);
+      this.#sessionHeads.setHead(windowId, pair.assistant.id);
+      // 回执只在落树 + head 推进都成功之后发出：先 ack 后落树会让「已确认」
+      // 覆盖「没送到」，回执丢失归传播机制的前提是先证明这轮真的开工了（MV-C05）。
+      pass?.commit();
+      return pair.assistant;
+    };
+    return options.commitBoundary?.commit(commit) ?? commit();
   }
 
   async history(residentId: string): Promise<HistoryNode[]> {

--- a/src/message-tree/service.ts
+++ b/src/message-tree/service.ts
@@ -115,11 +115,28 @@ export class MessageTreeService {
         ? null
         : this.#store.idempotentPair(residentId, options.idempotencyKey, message);
     if (replay !== null) {
-      if (parentId !== replay.user.parentId && parentId !== replay.assistant.id) {
+      const nodesById = new Map(roomHistory.map((node) => [node.id, node]));
+      let cursor = parentId;
+      let replayPrecedesCurrentHead = false;
+      while (cursor !== null) {
+        if (cursor === replay.assistant.id) {
+          replayPrecedesCurrentHead = true;
+          break;
+        }
+        cursor = nodesById.get(cursor)?.parentId ?? null;
+      }
+      if (
+        parentId !== replay.user.parentId &&
+        parentId !== replay.assistant.id &&
+        !replayPrecedesCurrentHead
+      ) {
         throw nodeUnavailable();
       }
       const commitReplay = (): HistoryNode => {
-        if (parentId !== replay.assistant.id) {
+        // If later turns already descend from this committed pair, the pair itself is the durable
+        // receipt. Reuse it without rewinding the live head; only the immediate post-crash shape
+        // (head still at the pair's former parent) needs its missing head advance repaired.
+        if (parentId === replay.user.parentId) {
           this.#sessionHeads.setHead(windowId, replay.assistant.id);
         }
         return replay.assistant;

--- a/src/message-tree/service.ts
+++ b/src/message-tree/service.ts
@@ -67,6 +67,8 @@ export interface MessageCommitBoundary {
 
 export interface MessageTreeSayOptions {
   readonly commitBoundary?: MessageCommitBoundary;
+  /** Host-owned operation identity for crash-safe retry after tree commit but before outer receipt. */
+  readonly idempotencyKey?: string;
 }
 
 const echoReply: AssistantReply = (_residentId, message) => message;
@@ -108,6 +110,22 @@ export class MessageTreeService {
     if (parentId !== null && !roomHistory.some((node) => node.id === parentId)) {
       throw nodeUnavailable();
     }
+    const replay =
+      options.idempotencyKey === undefined
+        ? null
+        : this.#store.idempotentPair(residentId, options.idempotencyKey, message);
+    if (replay !== null) {
+      if (parentId !== replay.user.parentId && parentId !== replay.assistant.id) {
+        throw nodeUnavailable();
+      }
+      const commitReplay = (): HistoryNode => {
+        if (parentId !== replay.assistant.id) {
+          this.#sessionHeads.setHead(windowId, replay.assistant.id);
+        }
+        return replay.assistant;
+      };
+      return options.commitBoundary?.commit(commitReplay) ?? commitReplay();
+    }
     // 开工闸在校验之后、模型调用之前：闸拒（抛错）时 responder 零调用、零写入。
     const pass = this.#turnGate?.beforeTurn(residentId, windowId);
     // 缺口条目只进发给模型的文本，不进落树的 user 节点——注入是上下文装配，
@@ -118,7 +136,16 @@ export class MessageTreeService {
         : message;
     const assistantContent = await this.#assistantReply(residentId, prompt);
     const commit = (): HistoryNode => {
-      const pair = this.#store.appendPair(residentId, message, assistantContent, parentId);
+      const pair =
+        options.idempotencyKey === undefined
+          ? this.#store.appendPair(residentId, message, assistantContent, parentId)
+          : this.#store.appendPairOnce(
+              residentId,
+              message,
+              assistantContent,
+              parentId,
+              options.idempotencyKey,
+            );
       this.#sessionHeads.setHead(windowId, pair.assistant.id);
       // 回执只在落树 + head 推进都成功之后发出：先 ack 后落树会让「已确认」
       // 覆盖「没送到」，回执丢失归传播机制的前提是先证明这轮真的开工了（MV-C05）。

--- a/src/message-tree/store.ts
+++ b/src/message-tree/store.ts
@@ -19,6 +19,7 @@
  * id 与时钟可注入，测试可完全确定性复现。
  */
 
+import { createHash } from "node:crypto";
 import type { HistoryNode } from "../../acceptance/driver.ts";
 import { MessageTreeError, nodeUnavailable } from "./errors.ts";
 
@@ -41,6 +42,18 @@ export interface MessageTreeStoreOptions {
 export interface AppendedPair {
   user: HistoryNode;
   assistant: HistoryNode;
+}
+
+function idempotentNodeId(residentId: string, idempotencyKey: string, role: "user" | "assistant") {
+  const digest = createHash("sha256")
+    .update("message-tree-pair/v1\0")
+    .update(residentId)
+    .update("\0")
+    .update(idempotencyKey)
+    .update("\0")
+    .update(role)
+    .digest("hex");
+  return `n_${digest}`;
 }
 
 export class MessageTreeStore {
@@ -88,6 +101,64 @@ export class MessageTreeStore {
     this.assertFreshIds(room, [user, assistant]);
     this.insert(room, user);
     this.insert(room, assistant);
+    return { user: { ...user }, assistant: { ...assistant } };
+  }
+
+  /**
+   * Idempotent host delivery for an operation that may be retried after the pair committed but its
+   * external receipt did not. The operation key deterministically names the two immutable nodes,
+   * so the receipt survives an export/import or store rebuild without a second mutable ledger.
+   * Existing complete pairs are replayed; partial or content-conflicting pairs fail loudly.
+   */
+  appendPairOnce(
+    residentId: string,
+    userContent: string,
+    assistantContent: string,
+    parentId: string | null,
+    idempotencyKey: string,
+  ): AppendedPair {
+    const previous = this.idempotentPair(residentId, idempotencyKey, userContent);
+    if (previous !== null) return previous;
+
+    const room = this.mustRoom(residentId);
+    const user = this.buildWithId(
+      idempotentNodeId(residentId, idempotencyKey, "user"),
+      parentId,
+      "user",
+      userContent,
+    );
+    const assistant = this.buildWithId(
+      idempotentNodeId(residentId, idempotencyKey, "assistant"),
+      user.id,
+      "assistant",
+      assistantContent,
+    );
+    this.assertFreshIds(room, [user, assistant]);
+    this.insert(room, user);
+    this.insert(room, assistant);
+    return { user: { ...user }, assistant: { ...assistant } };
+  }
+
+  /** Returns the immutable pair named by a host operation without invoking the responder again. */
+  idempotentPair(
+    residentId: string,
+    idempotencyKey: string,
+    userContent: string,
+  ): AppendedPair | null {
+    const room = this.mustRoom(residentId);
+    const user = room.nodes.get(idempotentNodeId(residentId, idempotencyKey, "user"));
+    const assistant = room.nodes.get(idempotentNodeId(residentId, idempotencyKey, "assistant"));
+    if (user === undefined && assistant === undefined) return null;
+    if (
+      user === undefined ||
+      assistant === undefined ||
+      user.role !== "user" ||
+      user.content !== userContent ||
+      assistant.role !== "assistant" ||
+      assistant.parentId !== user.id
+    ) {
+      throw new MessageTreeError("消息投递幂等键与既有节点冲突");
+    }
     return { user: { ...user }, assistant: { ...assistant } };
   }
 
@@ -245,8 +316,17 @@ export class MessageTreeStore {
   }
 
   private build(parentId: string | null, role: HistoryNode["role"], content: string): HistoryNode {
+    return this.buildWithId(this.newId(), parentId, role, content);
+  }
+
+  private buildWithId(
+    id: string,
+    parentId: string | null,
+    role: HistoryNode["role"],
+    content: string,
+  ): HistoryNode {
     return Object.freeze({
-      id: this.newId(),
+      id,
       parentId,
       role,
       content,

--- a/src/one-stream/index.ts
+++ b/src/one-stream/index.ts
@@ -68,10 +68,13 @@ export type {
 } from "./workspace-read-model.ts";
 export {
   BlockedReplyRouter,
+  CanonicalBlockedReplyResolutionPort,
   MessageTreeWorkspaceReplyDelivery,
   ReplyRouteError,
 } from "./reply-router.ts";
 export type {
+  BlockedReplyResolutionPort,
+  CanonicalBlockedReplyResolutionOptions,
   ReplyCandidate,
   ReplyRouteErrorCode,
   ReplyRouteRequest,

--- a/src/one-stream/index.ts
+++ b/src/one-stream/index.ts
@@ -66,6 +66,20 @@ export type {
   WorkspaceHandle,
   WorkspaceLifecycleOptions,
 } from "./workspace-read-model.ts";
+export {
+  BlockedReplyRouter,
+  MessageTreeWorkspaceReplyDelivery,
+  ReplyRouteError,
+} from "./reply-router.ts";
+export type {
+  ReplyCandidate,
+  ReplyRouteErrorCode,
+  ReplyRouteRequest,
+  ReplyRouteResult,
+  WorkspaceReplyDeliveryPort,
+  WorkspaceReplyDeliveryReceipt,
+  WorkspaceReplyDeliveryRequest,
+} from "./reply-router.ts";
 export type {
   CanonicalEventSubmission,
   CanonicalStreamWriterOptions,

--- a/src/one-stream/reply-router.ts
+++ b/src/one-stream/reply-router.ts
@@ -1,0 +1,279 @@
+import type { MessageTreeService } from "../message-tree/service.ts";
+import type { SessionRegistry } from "../session/session-registry.ts";
+import type { CanonicalEvent, EventViewport } from "./event-contract.ts";
+import type { CanonicalStreamReadPort } from "./store.ts";
+
+export interface ReplyRouteRequest {
+  readonly residentId: string;
+  readonly text: string;
+  readonly replyToEventId?: string;
+  readonly workRef?: string;
+}
+
+export interface ReplyCandidate {
+  readonly eventId: string;
+  readonly workRef: string;
+  readonly viewport: EventViewport;
+}
+
+export interface WorkspaceReplyDeliveryRequest extends ReplyCandidate {
+  readonly residentId: string;
+  readonly text: string;
+}
+
+export interface WorkspaceReplyDeliveryReceipt extends ReplyCandidate {
+  readonly phase: "workspace-committed";
+  readonly residentId: string;
+  readonly assistantNodeId: string;
+}
+
+export interface WorkspaceReplyDeliveryPort {
+  deliver(request: WorkspaceReplyDeliveryRequest): Promise<WorkspaceReplyDeliveryReceipt>;
+}
+
+export type ReplyRouteResult =
+  | {
+      readonly status: "routed";
+      readonly receipt: WorkspaceReplyDeliveryReceipt;
+    }
+  | {
+      readonly status: "no-target";
+    }
+  | {
+      readonly status: "disambiguation-required";
+      readonly candidates: readonly ReplyCandidate[];
+    };
+
+export type ReplyRouteErrorCode =
+  | "REPLY_ROUTE_CONTRACT"
+  | "REPLY_TARGET_UNKNOWN"
+  | "REPLY_TARGET_STALE"
+  | "REPLY_TARGET_AMBIGUOUS"
+  | "REPLY_TARGET_INCONSISTENT"
+  | "REPLY_TARGET_RESOLVED"
+  | "REPLY_RECEIPT_MISMATCH";
+
+export class ReplyRouteError extends Error {
+  readonly code: ReplyRouteErrorCode;
+  constructor(code: ReplyRouteErrorCode, message: string) {
+    super(`${code}: ${message}`);
+    this.name = "ReplyRouteError";
+    this.code = code;
+  }
+}
+
+function nonEmpty(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ReplyRouteError("REPLY_ROUTE_CONTRACT", `${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function parseRequest(value: unknown): ReplyRouteRequest {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ReplyRouteError("REPLY_ROUTE_CONTRACT", "reply request must be an object");
+  }
+  const input = value as Record<string, unknown>;
+  const allowed = new Set(["residentId", "text", "replyToEventId", "workRef"]);
+  if (Object.keys(input).some((key) => !allowed.has(key))) {
+    throw new ReplyRouteError("REPLY_ROUTE_CONTRACT", "reply request has unexpected fields");
+  }
+  const request: {
+    residentId: string;
+    text: string;
+    replyToEventId?: string;
+    workRef?: string;
+  } = {
+    residentId: nonEmpty(input.residentId, "residentId"),
+    text: nonEmpty(input.text, "text"),
+  };
+  if (input.replyToEventId !== undefined) {
+    request.replyToEventId = nonEmpty(input.replyToEventId, "replyToEventId");
+  }
+  if (input.workRef !== undefined) request.workRef = nonEmpty(input.workRef, "workRef");
+  return request;
+}
+
+function candidate(event: CanonicalEvent): ReplyCandidate | null {
+  if (
+    event.purpose !== "blocked" ||
+    event.effect.requiresUserAction !== true ||
+    event.workRef === null ||
+    event.origin.viewport === null
+  ) {
+    return null;
+  }
+  return {
+    eventId: event.eventId,
+    workRef: event.workRef,
+    viewport: structuredClone(event.origin.viewport),
+  };
+}
+
+/** Actual MessageTree dispatch adapter; the session head moves only after the pair lands. */
+export class MessageTreeWorkspaceReplyDelivery implements WorkspaceReplyDeliveryPort {
+  readonly #service: MessageTreeService;
+  readonly #sessions: SessionRegistry<unknown>;
+
+  constructor(service: MessageTreeService, sessions: SessionRegistry<unknown>) {
+    this.#service = service;
+    this.#sessions = sessions;
+  }
+
+  async deliver(request: WorkspaceReplyDeliveryRequest): Promise<WorkspaceReplyDeliveryReceipt> {
+    const live = this.#sessions.get(request.viewport.windowId);
+    if (
+      live === undefined ||
+      live.residentId !== request.residentId ||
+      live.generation !== request.viewport.generation
+    ) {
+      throw new ReplyRouteError("REPLY_TARGET_STALE", "workspace changed before dispatch");
+    }
+    const assistant = await this.#service.say(
+      request.residentId,
+      request.text,
+      request.viewport.windowId,
+    );
+    return Object.freeze({
+      phase: "workspace-committed",
+      residentId: request.residentId,
+      eventId: request.eventId,
+      workRef: request.workRef,
+      viewport: structuredClone(request.viewport),
+      assistantNodeId: assistant.id,
+    });
+  }
+}
+
+/**
+ * Routes only from unresolved canonical blocked events to the exact live workspace generation.
+ * Recency, focus, creation time, and model guesses are absent from both the constructor and input.
+ */
+export class BlockedReplyRouter {
+  readonly #stream: CanonicalStreamReadPort;
+  readonly #sessions: SessionRegistry<unknown>;
+  readonly #delivery: WorkspaceReplyDeliveryPort;
+  readonly #resolved = new Set<string>();
+
+  constructor(
+    stream: CanonicalStreamReadPort,
+    sessions: SessionRegistry<unknown>,
+    delivery: WorkspaceReplyDeliveryPort,
+  ) {
+    this.#stream = stream;
+    this.#sessions = sessions;
+    this.#delivery = delivery;
+  }
+
+  async route(value: unknown): Promise<ReplyRouteResult> {
+    const request = parseRequest(value);
+    const events = this.#stream.eventsAfter(request.residentId, 0);
+    const all = events.map(candidate).filter((item): item is ReplyCandidate => item !== null);
+    const unresolved = all.filter(
+      (item) => !this.#resolved.has(this.#resolutionKey(request.residentId, item.eventId)),
+    );
+    const live = unresolved.filter((item) => this.#isLive(request.residentId, item));
+    const selected = this.#select(request, all, unresolved, live);
+    if (selected.status !== "selected") return selected.result;
+
+    const receipt = await this.#delivery.deliver({
+      ...selected.candidate,
+      residentId: request.residentId,
+      text: request.text,
+    });
+    if (
+      receipt.phase !== "workspace-committed" ||
+      receipt.residentId !== request.residentId ||
+      receipt.eventId !== selected.candidate.eventId ||
+      receipt.workRef !== selected.candidate.workRef ||
+      receipt.viewport.windowId !== selected.candidate.viewport.windowId ||
+      receipt.viewport.generation !== selected.candidate.viewport.generation
+    ) {
+      throw new ReplyRouteError(
+        "REPLY_RECEIPT_MISMATCH",
+        "delivery receipt changed route identity",
+      );
+    }
+    this.#resolved.add(this.#resolutionKey(request.residentId, selected.candidate.eventId));
+    return { status: "routed", receipt };
+  }
+
+  #select(
+    request: ReplyRouteRequest,
+    all: readonly ReplyCandidate[],
+    unresolved: readonly ReplyCandidate[],
+    live: readonly ReplyCandidate[],
+  ):
+    | { readonly status: "selected"; readonly candidate: ReplyCandidate }
+    | {
+        readonly status: "result";
+        readonly result: Exclude<ReplyRouteResult, { status: "routed" }>;
+      } {
+    if (request.replyToEventId !== undefined) {
+      const any = all.find((item) => item.eventId === request.replyToEventId);
+      if (any === undefined) {
+        throw new ReplyRouteError("REPLY_TARGET_UNKNOWN", "replyToEventId does not name a blocker");
+      }
+      if (!unresolved.some((item) => item.eventId === any.eventId)) {
+        throw new ReplyRouteError(
+          "REPLY_TARGET_RESOLVED",
+          "blocked event already received a reply",
+        );
+      }
+      const active = live.find((item) => item.eventId === any.eventId);
+      if (active === undefined) {
+        throw new ReplyRouteError(
+          "REPLY_TARGET_STALE",
+          "blocked event no longer has its live workspace",
+        );
+      }
+      if (request.workRef !== undefined && request.workRef !== active.workRef) {
+        throw new ReplyRouteError(
+          "REPLY_TARGET_INCONSISTENT",
+          "replyToEventId and workRef name different targets",
+        );
+      }
+      return { status: "selected", candidate: active };
+    }
+
+    if (request.workRef !== undefined) {
+      const known = all.filter((item) => item.workRef === request.workRef);
+      if (known.length === 0) {
+        throw new ReplyRouteError("REPLY_TARGET_UNKNOWN", "workRef does not name a blocker");
+      }
+      const active = live.filter((item) => item.workRef === request.workRef);
+      if (active.length === 0) {
+        throw new ReplyRouteError("REPLY_TARGET_STALE", "workRef has no live unresolved blocker");
+      }
+      if (active.length > 1) {
+        throw new ReplyRouteError("REPLY_TARGET_AMBIGUOUS", "workRef names more than one blocker");
+      }
+      return { status: "selected", candidate: active[0] as ReplyCandidate };
+    }
+
+    if (live.length === 0) return { status: "result", result: { status: "no-target" } };
+    if (live.length > 1) {
+      return {
+        status: "result",
+        result: {
+          status: "disambiguation-required",
+          candidates: Object.freeze(live.map((item) => structuredClone(item))),
+        },
+      };
+    }
+    return { status: "selected", candidate: live[0] as ReplyCandidate };
+  }
+
+  #isLive(residentId: string, item: ReplyCandidate): boolean {
+    const window = this.#sessions.get(item.viewport.windowId);
+    return (
+      window !== undefined &&
+      window.residentId === residentId &&
+      window.generation === item.viewport.generation
+    );
+  }
+
+  #resolutionKey(residentId: string, eventId: string): string {
+    return `${residentId}\u0000${eventId}`;
+  }
+}

--- a/src/one-stream/reply-router.ts
+++ b/src/one-stream/reply-router.ts
@@ -267,6 +267,7 @@ export class MessageTreeWorkspaceReplyDelivery implements WorkspaceReplyDelivery
       request.text,
       request.viewport.windowId,
       {
+        idempotencyKey: `blocked-reply-delivery:${request.eventId}`,
         commitBoundary: {
           commit: (mutation) => {
             if (!this.#sessions.belongsToActiveWindow(dispatch)) {

--- a/src/one-stream/reply-router.ts
+++ b/src/one-stream/reply-router.ts
@@ -1,7 +1,8 @@
 import type { MessageTreeService } from "../message-tree/service.ts";
 import type { SessionRegistry } from "../session/session-registry.ts";
-import type { CanonicalEvent, EventViewport } from "./event-contract.ts";
+import type { CanonicalEvent, EventActor, EventViewport } from "./event-contract.ts";
 import type { CanonicalStreamReadPort } from "./store.ts";
+import type { CanonicalStreamWriter } from "./writer.ts";
 
 export interface ReplyRouteRequest {
   readonly residentId: string;
@@ -29,6 +30,20 @@ export interface WorkspaceReplyDeliveryReceipt extends ReplyCandidate {
 
 export interface WorkspaceReplyDeliveryPort {
   deliver(request: WorkspaceReplyDeliveryRequest): Promise<WorkspaceReplyDeliveryReceipt>;
+}
+
+export interface BlockedReplyResolutionPort {
+  resolvedEventIds(residentId: string): ReadonlySet<string>;
+  resolveAfterDelivery(
+    candidate: WorkspaceReplyDeliveryRequest,
+    deliver: () => Promise<WorkspaceReplyDeliveryReceipt>,
+  ): Promise<WorkspaceReplyDeliveryReceipt>;
+}
+
+export interface CanonicalBlockedReplyResolutionOptions {
+  /** Host-owned authority; callers replying to a blocker cannot self-appoint it. */
+  readonly authoritySource: EventActor;
+  readonly now?: () => string;
 }
 
 export type ReplyRouteResult =
@@ -59,6 +74,120 @@ export class ReplyRouteError extends Error {
     super(`${code}: ${message}`);
     this.name = "ReplyRouteError";
     this.code = code;
+  }
+}
+
+const resolutionQueues = new WeakMap<CanonicalStreamReadPort, Map<string, Promise<void>>>();
+
+function resolutionTarget(event: CanonicalEvent): string | null {
+  if (
+    event.purpose !== "result" ||
+    event.effect.state !== "committed-effective" ||
+    event.authoritySource.kind !== "host" ||
+    event.origin.reporter.kind !== "host" ||
+    event.payload.kind !== "blocked-reply-resolved" ||
+    typeof event.payload.replyToEventId !== "string" ||
+    event.payload.replyToEventId.length === 0
+  ) {
+    return null;
+  }
+  return event.payload.replyToEventId;
+}
+
+/**
+ * Writes the resolved receipt into the same canonical stream that supplied the blocker. The
+ * per-stream queue covers concurrent router instances in one host process; rebuilding a router or
+ * the port derives state from the durable event instead of process memory.
+ */
+export class CanonicalBlockedReplyResolutionPort implements BlockedReplyResolutionPort {
+  readonly #stream: CanonicalStreamReadPort;
+  readonly #writer: CanonicalStreamWriter;
+  readonly #authoritySource: EventActor;
+  readonly #now: () => string;
+
+  constructor(
+    stream: CanonicalStreamReadPort,
+    writer: CanonicalStreamWriter,
+    options: CanonicalBlockedReplyResolutionOptions,
+  ) {
+    this.#stream = stream;
+    this.#writer = writer;
+    this.#authoritySource = Object.freeze(structuredClone(options.authoritySource));
+    this.#now = options.now ?? (() => new Date().toISOString());
+  }
+
+  resolvedEventIds(residentId: string): ReadonlySet<string> {
+    return new Set(
+      this.#stream
+        .eventsAfter(residentId, 0)
+        .map(resolutionTarget)
+        .filter((eventId): eventId is string => eventId !== null),
+    );
+  }
+
+  resolveAfterDelivery(
+    candidate: WorkspaceReplyDeliveryRequest,
+    deliver: () => Promise<WorkspaceReplyDeliveryReceipt>,
+  ): Promise<WorkspaceReplyDeliveryReceipt> {
+    const key = `${candidate.residentId}\u0000${candidate.eventId}`;
+    return this.#enqueue(key, async () => {
+      if (this.resolvedEventIds(candidate.residentId).has(candidate.eventId)) {
+        throw new ReplyRouteError(
+          "REPLY_TARGET_RESOLVED",
+          "blocked event already received a reply",
+        );
+      }
+      const receipt = await deliver();
+      await this.#writer.submit({
+        residentId: candidate.residentId,
+        idempotencyKey: `blocked-reply-resolved:${candidate.eventId}`,
+        draft: {
+          purpose: "result",
+          occurredAt: this.#now(),
+          workRef: candidate.workRef,
+          authoritySource: this.#authoritySource,
+          origin: {
+            reporter: this.#authoritySource,
+            subject: { kind: "work", id: candidate.workRef },
+            viewport: structuredClone(candidate.viewport),
+          },
+          effect: {
+            state: "committed-effective",
+            requiresUserAction: false,
+            retry: "none",
+          },
+          artifactRef: `message-tree-node:${receipt.assistantNodeId}`,
+          payload: {
+            kind: "blocked-reply-resolved",
+            replyToEventId: candidate.eventId,
+            assistantNodeId: receipt.assistantNodeId,
+          },
+        },
+      });
+      return receipt;
+    });
+  }
+
+  #enqueue<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    let queues = resolutionQueues.get(this.#stream);
+    if (queues === undefined) {
+      queues = new Map();
+      resolutionQueues.set(this.#stream, queues);
+    }
+    const previous = queues.get(key) ?? Promise.resolve();
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const marker = previous.then(
+      () => gate,
+      () => gate,
+    );
+    queues.set(key, marker);
+    return previous.then(operation, operation).finally(() => {
+      release();
+      if (queues?.get(key) === marker) queues.delete(key);
+    });
   }
 }
 
@@ -121,11 +250,15 @@ export class MessageTreeWorkspaceReplyDelivery implements WorkspaceReplyDelivery
   }
 
   async deliver(request: WorkspaceReplyDeliveryRequest): Promise<WorkspaceReplyDeliveryReceipt> {
-    const live = this.#sessions.get(request.viewport.windowId);
+    let dispatch: ReturnType<SessionRegistry<unknown>["issueDispatch"]>;
+    try {
+      dispatch = this.#sessions.issueDispatch(request.viewport.windowId);
+    } catch {
+      throw new ReplyRouteError("REPLY_TARGET_STALE", "workspace changed before dispatch");
+    }
     if (
-      live === undefined ||
-      live.residentId !== request.residentId ||
-      live.generation !== request.viewport.generation
+      dispatch.residentId !== request.residentId ||
+      dispatch.generation !== request.viewport.generation
     ) {
       throw new ReplyRouteError("REPLY_TARGET_STALE", "workspace changed before dispatch");
     }
@@ -133,6 +266,20 @@ export class MessageTreeWorkspaceReplyDelivery implements WorkspaceReplyDelivery
       request.residentId,
       request.text,
       request.viewport.windowId,
+      {
+        commitBoundary: {
+          commit: (mutation) => {
+            if (!this.#sessions.belongsToActiveWindow(dispatch)) {
+              throw new ReplyRouteError(
+                "REPLY_TARGET_STALE",
+                "workspace changed while the reply was in flight",
+              );
+            }
+            // No await occurs between this generation check and the synchronous tree/head commit.
+            return mutation();
+          },
+        },
+      },
     );
     return Object.freeze({
       phase: "workspace-committed",
@@ -153,48 +300,52 @@ export class BlockedReplyRouter {
   readonly #stream: CanonicalStreamReadPort;
   readonly #sessions: SessionRegistry<unknown>;
   readonly #delivery: WorkspaceReplyDeliveryPort;
-  readonly #resolved = new Set<string>();
+  readonly #resolutions: BlockedReplyResolutionPort;
 
   constructor(
     stream: CanonicalStreamReadPort,
     sessions: SessionRegistry<unknown>,
     delivery: WorkspaceReplyDeliveryPort,
+    resolutions: BlockedReplyResolutionPort,
   ) {
     this.#stream = stream;
     this.#sessions = sessions;
     this.#delivery = delivery;
+    this.#resolutions = resolutions;
   }
 
   async route(value: unknown): Promise<ReplyRouteResult> {
     const request = parseRequest(value);
     const events = this.#stream.eventsAfter(request.residentId, 0);
     const all = events.map(candidate).filter((item): item is ReplyCandidate => item !== null);
-    const unresolved = all.filter(
-      (item) => !this.#resolved.has(this.#resolutionKey(request.residentId, item.eventId)),
-    );
+    const resolved = this.#resolutions.resolvedEventIds(request.residentId);
+    const unresolved = all.filter((item) => !resolved.has(item.eventId));
     const live = unresolved.filter((item) => this.#isLive(request.residentId, item));
     const selected = this.#select(request, all, unresolved, live);
     if (selected.status !== "selected") return selected.result;
 
-    const receipt = await this.#delivery.deliver({
+    const deliveryRequest = {
       ...selected.candidate,
       residentId: request.residentId,
       text: request.text,
+    } satisfies WorkspaceReplyDeliveryRequest;
+    const receipt = await this.#resolutions.resolveAfterDelivery(deliveryRequest, async () => {
+      const delivered = await this.#delivery.deliver(deliveryRequest);
+      if (
+        delivered.phase !== "workspace-committed" ||
+        delivered.residentId !== request.residentId ||
+        delivered.eventId !== selected.candidate.eventId ||
+        delivered.workRef !== selected.candidate.workRef ||
+        delivered.viewport.windowId !== selected.candidate.viewport.windowId ||
+        delivered.viewport.generation !== selected.candidate.viewport.generation
+      ) {
+        throw new ReplyRouteError(
+          "REPLY_RECEIPT_MISMATCH",
+          "delivery receipt changed route identity",
+        );
+      }
+      return delivered;
     });
-    if (
-      receipt.phase !== "workspace-committed" ||
-      receipt.residentId !== request.residentId ||
-      receipt.eventId !== selected.candidate.eventId ||
-      receipt.workRef !== selected.candidate.workRef ||
-      receipt.viewport.windowId !== selected.candidate.viewport.windowId ||
-      receipt.viewport.generation !== selected.candidate.viewport.generation
-    ) {
-      throw new ReplyRouteError(
-        "REPLY_RECEIPT_MISMATCH",
-        "delivery receipt changed route identity",
-      );
-    }
-    this.#resolved.add(this.#resolutionKey(request.residentId, selected.candidate.eventId));
     return { status: "routed", receipt };
   }
 
@@ -271,9 +422,5 @@ export class BlockedReplyRouter {
       window.residentId === residentId &&
       window.generation === item.viewport.generation
     );
-  }
-
-  #resolutionKey(residentId: string, eventId: string): string {
-    return `${residentId}\u0000${eventId}`;
   }
 }

--- a/tests/one-stream-reply-router.test.ts
+++ b/tests/one-stream-reply-router.test.ts
@@ -229,6 +229,85 @@ describe("OS-06 canonical blocked reply routing", () => {
     }
   });
 
+  it("recovers a committed tree delivery when the durable resolved receipt failed", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "mist-reply-crash-gap-"));
+    let closeWriter = async (): Promise<void> => undefined;
+    let responderCalls = 0;
+    try {
+      const built = await assembly({
+        dataDir,
+        assistantReply: async (_residentId, message) => {
+          responderCalls += 1;
+          await closeWriter();
+          return `reply:${message}`;
+        },
+      });
+      closeWriter = () => built.writer.close();
+
+      await expect(
+        built.router.route({
+          residentId: "resident-a",
+          text: "answer-survives-receipt-crash",
+          replyToEventId: built.blocked[0]?.eventId,
+        }),
+      ).rejects.toThrow("canonical stream writer is closed");
+      expect(built.tree.history("resident-a")).toHaveLength(2);
+      expect(responderCalls).toBe(1);
+
+      const restoredStream = new CanonicalStreamStore({ dataDir });
+      const restoredWriter = new CanonicalStreamWriter(restoredStream);
+      const restoredTree = new MessageTreeStore();
+      restoredTree.createRoom("resident-a");
+      restoredTree.importTree("resident-a", built.tree.exportTree("resident-a"));
+      const restoredService = new MessageTreeService(
+        restoredTree,
+        {
+          getHead: (windowId) => built.sessions.getHead(windowId),
+          setHead: (windowId, headId) => built.sessions.setHead(windowId, headId),
+        },
+        {
+          assistantReply: () => {
+            responderCalls += 1;
+            throw new Error("committed delivery must not invoke responder again");
+          },
+        },
+      );
+      const rebuilt = new BlockedReplyRouter(
+        restoredStream,
+        built.sessions,
+        new MessageTreeWorkspaceReplyDelivery(restoredService, built.sessions),
+        new CanonicalBlockedReplyResolutionPort(restoredStream, restoredWriter, {
+          authoritySource: { kind: "host", id: "mist-host" },
+        }),
+      );
+
+      await expect(
+        rebuilt.route({
+          residentId: "resident-a",
+          text: "answer-survives-receipt-crash",
+          replyToEventId: built.blocked[0]?.eventId,
+        }),
+      ).resolves.toMatchObject({ status: "routed" });
+      expect(responderCalls).toBe(1);
+      expect(restoredTree.history("resident-a")).toHaveLength(2);
+      expect(
+        restoredStream
+          .eventsAfter("resident-a", 0)
+          .filter((event) => event.payload.kind === "blocked-reply-resolved"),
+      ).toHaveLength(1);
+      await expect(
+        rebuilt.route({
+          residentId: "resident-a",
+          text: "answer-survives-receipt-crash",
+          replyToEventId: built.blocked[0]?.eventId,
+        }),
+      ).rejects.toMatchObject({ code: "REPLY_TARGET_RESOLVED" });
+      await restoredWriter.close();
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("serializes concurrent replies to one blocker before either can dispatch twice", async () => {
     let releaseReply = (): void => undefined;
     let markStarted = (): void => undefined;

--- a/tests/one-stream-reply-router.test.ts
+++ b/tests/one-stream-reply-router.test.ts
@@ -308,6 +308,86 @@ describe("OS-06 canonical blocked reply routing", () => {
     }
   });
 
+  it("recovers the resolved receipt after later turns advanced beyond the committed pair", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "mist-reply-crash-gap-later-turn-"));
+    let closeWriter = async (): Promise<void> => undefined;
+    let blockerResponderCalls = 0;
+    try {
+      const built = await assembly({
+        dataDir,
+        assistantReply: async (_residentId, message) => {
+          if (message === "answer-before-later-turn") {
+            blockerResponderCalls += 1;
+            await closeWriter();
+          }
+          return `reply:${message}`;
+        },
+      });
+      closeWriter = () => built.writer.close();
+
+      await expect(
+        built.router.route({
+          residentId: "resident-a",
+          text: "answer-before-later-turn",
+          replyToEventId: built.blocked[0]?.eventId,
+        }),
+      ).rejects.toThrow("canonical stream writer is closed");
+      expect(blockerResponderCalls).toBe(1);
+      expect(built.tree.history("resident-a")).toHaveLength(2);
+
+      closeWriter = async () => undefined;
+      const later = await built.service.say("resident-a", "later-turn", built.first.windowId);
+      expect(built.sessions.getHead(built.first.windowId)).toBe(later.id);
+      expect(built.tree.history("resident-a")).toHaveLength(4);
+
+      const restoredStream = new CanonicalStreamStore({ dataDir });
+      const restoredWriter = new CanonicalStreamWriter(restoredStream);
+      const restoredTree = new MessageTreeStore();
+      restoredTree.createRoom("resident-a");
+      restoredTree.importTree("resident-a", built.tree.exportTree("resident-a"));
+      const restoredService = new MessageTreeService(
+        restoredTree,
+        {
+          getHead: (windowId) => built.sessions.getHead(windowId),
+          setHead: (windowId, headId) => built.sessions.setHead(windowId, headId),
+        },
+        {
+          assistantReply: () => {
+            blockerResponderCalls += 1;
+            throw new Error("committed blocker delivery must not invoke responder again");
+          },
+        },
+      );
+      const rebuilt = new BlockedReplyRouter(
+        restoredStream,
+        built.sessions,
+        new MessageTreeWorkspaceReplyDelivery(restoredService, built.sessions),
+        new CanonicalBlockedReplyResolutionPort(restoredStream, restoredWriter, {
+          authoritySource: { kind: "host", id: "mist-host" },
+        }),
+      );
+
+      await expect(
+        rebuilt.route({
+          residentId: "resident-a",
+          text: "answer-before-later-turn",
+          replyToEventId: built.blocked[0]?.eventId,
+        }),
+      ).resolves.toMatchObject({ status: "routed" });
+      expect(blockerResponderCalls).toBe(1);
+      expect(restoredTree.history("resident-a")).toHaveLength(4);
+      expect(built.sessions.getHead(built.first.windowId)).toBe(later.id);
+      expect(
+        restoredStream
+          .eventsAfter("resident-a", 0)
+          .filter((event) => event.payload.kind === "blocked-reply-resolved"),
+      ).toHaveLength(1);
+      await restoredWriter.close();
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("serializes concurrent replies to one blocker before either can dispatch twice", async () => {
     let releaseReply = (): void => undefined;
     let markStarted = (): void => undefined;

--- a/tests/one-stream-reply-router.test.ts
+++ b/tests/one-stream-reply-router.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { MessageTreeService, MessageTreeStore } from "../src/message-tree/index.ts";
+import {
+  BlockedReplyRouter,
+  BoundedWorkEventPort,
+  CanonicalStreamStore,
+  CanonicalStreamWriter,
+  MessageTreeWorkspaceReplyDelivery,
+  ReplyRouteError,
+} from "../src/one-stream/index.ts";
+import { SessionRegistry } from "../src/session/session-registry.ts";
+
+async function assembly() {
+  const stream = new CanonicalStreamStore();
+  stream.createStream("resident-a");
+  const writer = new CanonicalStreamWriter(stream);
+  const sessions = new SessionRegistry<null>();
+  const first = sessions.open("resident-a", { context: null });
+  const second = sessions.open("resident-a", { context: null });
+  const tree = new MessageTreeStore();
+  tree.createRoom("resident-a");
+  const service = new MessageTreeService(
+    tree,
+    {
+      getHead: (windowId) => sessions.getHead(windowId),
+      setHead: (windowId, headId) => sessions.setHead(windowId, headId),
+    },
+    {
+      assistantReply: (_residentId, message) => {
+        if (message === "dispatch-fails") throw new Error("responder unavailable");
+        return `reply:${message}`;
+      },
+    },
+  );
+  const workEvents = new BoundedWorkEventPort(writer, {
+    authoritySource: { kind: "host", id: "mist-host" },
+  });
+  const blocked = [];
+  for (const [index, window] of [first, second].entries()) {
+    blocked.push(
+      await workEvents.submit({
+        residentId: "resident-a",
+        idempotencyKey: `blocked-${index + 1}`,
+        purpose: "blocked",
+        occurredAt: `2026-09-04T08:00:0${index}.000Z`,
+        workRef: `work-${index + 1}`,
+        artifactRef: `artifact:block-${index + 1}`,
+        source: { windowId: window.windowId, generation: window.generation },
+        effect: {
+          state: "failed-not-effective",
+          requiresUserAction: true,
+          retry: "awaiting-external",
+        },
+        summary: `blocked ${index + 1}`,
+      }),
+    );
+  }
+  const router = new BlockedReplyRouter(
+    stream,
+    sessions,
+    new MessageTreeWorkspaceReplyDelivery(service, sessions),
+  );
+  return { stream, writer, sessions, tree, first, second, blocked, router };
+}
+
+describe("OS-06 canonical blocked reply routing", () => {
+  it("routes explicit handles exactly, allows one naked target, and never guesses among two", async () => {
+    const { writer, sessions, tree, first, second, blocked, router } = await assembly();
+    const before = JSON.stringify(tree.history("resident-a"));
+    const ambiguous = await router.route({ residentId: "resident-a", text: "naked" });
+    expect(ambiguous).toMatchObject({ status: "disambiguation-required" });
+    expect(ambiguous.status === "disambiguation-required" && ambiguous.candidates).toHaveLength(2);
+    expect(JSON.stringify(tree.history("resident-a"))).toBe(before);
+    expect(sessions.getHead(first.windowId)).toBeNull();
+    expect(sessions.getHead(second.windowId)).toBeNull();
+
+    const firstRoute = await router.route({
+      residentId: "resident-a",
+      text: "answer-one",
+      replyToEventId: blocked[0]?.eventId,
+      workRef: "work-1",
+    });
+    expect(firstRoute).toMatchObject({
+      status: "routed",
+      receipt: { eventId: blocked[0]?.eventId, viewport: { windowId: first.windowId } },
+    });
+    expect(sessions.getHead(first.windowId)).not.toBeNull();
+    expect(sessions.getHead(second.windowId)).toBeNull();
+
+    const naked = await router.route({ residentId: "resident-a", text: "answer-two" });
+    expect(naked).toMatchObject({
+      status: "routed",
+      receipt: { eventId: blocked[1]?.eventId, viewport: { windowId: second.windowId } },
+    });
+    expect(sessions.getHead(second.windowId)).not.toBeNull();
+    expect(tree.history("resident-a").map((node) => node.content)).toEqual([
+      "answer-one",
+      "reply:answer-one",
+      "answer-two",
+      "reply:answer-two",
+    ]);
+    expect(await router.route({ residentId: "resident-a", text: "nothing-left" })).toEqual({
+      status: "no-target",
+    });
+    await writer.close();
+  });
+
+  it("rejects unknown, inconsistent, stale, and failed targets without resolving another workspace", async () => {
+    const { writer, sessions, tree, first, blocked, router } = await assembly();
+    const before = JSON.stringify(tree.history("resident-a"));
+    await expect(
+      router.route({
+        residentId: "resident-a",
+        text: "wrong",
+        replyToEventId: "unknown-event",
+      }),
+    ).rejects.toMatchObject({ code: "REPLY_TARGET_UNKNOWN" });
+    await expect(
+      router.route({
+        residentId: "resident-a",
+        text: "wrong",
+        replyToEventId: blocked[0]?.eventId,
+        workRef: "work-2",
+      }),
+    ).rejects.toMatchObject({ code: "REPLY_TARGET_INCONSISTENT" });
+    expect(JSON.stringify(tree.history("resident-a"))).toBe(before);
+
+    sessions.kill(first.windowId);
+    await expect(
+      router.route({
+        residentId: "resident-a",
+        text: "stale",
+        replyToEventId: blocked[0]?.eventId,
+      }),
+    ).rejects.toMatchObject({ code: "REPLY_TARGET_STALE" });
+    expect(JSON.stringify(tree.history("resident-a"))).toBe(before);
+
+    await expect(
+      router.route({
+        residentId: "resident-a",
+        text: "dispatch-fails",
+        replyToEventId: blocked[1]?.eventId,
+      }),
+    ).rejects.toThrow("responder unavailable");
+    expect(JSON.stringify(tree.history("resident-a"))).toBe(before);
+    expect(
+      await router.route({
+        residentId: "resident-a",
+        text: "retry-after-failure",
+        replyToEventId: blocked[1]?.eventId,
+      }),
+    ).toMatchObject({ status: "routed", receipt: { eventId: blocked[1]?.eventId } });
+
+    await expect(
+      router.route({
+        residentId: "resident-a",
+        text: "duplicate",
+        replyToEventId: blocked[1]?.eventId,
+      }),
+    ).rejects.toBeInstanceOf(ReplyRouteError);
+    await writer.close();
+  });
+});

--- a/tests/one-stream-reply-router.test.ts
+++ b/tests/one-stream-reply-router.test.ts
@@ -1,8 +1,12 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { MessageTreeService, MessageTreeStore } from "../src/message-tree/index.ts";
 import {
   BlockedReplyRouter,
   BoundedWorkEventPort,
+  CanonicalBlockedReplyResolutionPort,
   CanonicalStreamStore,
   CanonicalStreamWriter,
   MessageTreeWorkspaceReplyDelivery,
@@ -10,8 +14,15 @@ import {
 } from "../src/one-stream/index.ts";
 import { SessionRegistry } from "../src/session/session-registry.ts";
 
-async function assembly() {
-  const stream = new CanonicalStreamStore();
+async function assembly(
+  options: {
+    assistantReply?: (residentId: string, message: string) => string | Promise<string>;
+    dataDir?: string;
+  } = {},
+) {
+  const stream = new CanonicalStreamStore(
+    options.dataDir === undefined ? {} : { dataDir: options.dataDir },
+  );
   stream.createStream("resident-a");
   const writer = new CanonicalStreamWriter(stream);
   const sessions = new SessionRegistry<null>();
@@ -26,10 +37,12 @@ async function assembly() {
       setHead: (windowId, headId) => sessions.setHead(windowId, headId),
     },
     {
-      assistantReply: (_residentId, message) => {
-        if (message === "dispatch-fails") throw new Error("responder unavailable");
-        return `reply:${message}`;
-      },
+      assistantReply:
+        options.assistantReply ??
+        ((_residentId, message) => {
+          if (message === "dispatch-fails") throw new Error("responder unavailable");
+          return `reply:${message}`;
+        }),
     },
   );
   const workEvents = new BoundedWorkEventPort(writer, {
@@ -55,12 +68,25 @@ async function assembly() {
       }),
     );
   }
-  const router = new BlockedReplyRouter(
+  const delivery = new MessageTreeWorkspaceReplyDelivery(service, sessions);
+  const resolutions = new CanonicalBlockedReplyResolutionPort(stream, writer, {
+    authoritySource: { kind: "host", id: "mist-host" },
+    now: () => "2026-09-04T08:01:00.000Z",
+  });
+  const router = new BlockedReplyRouter(stream, sessions, delivery, resolutions);
+  return {
     stream,
+    writer,
     sessions,
-    new MessageTreeWorkspaceReplyDelivery(service, sessions),
-  );
-  return { stream, writer, sessions, tree, first, second, blocked, router };
+    tree,
+    service,
+    delivery,
+    resolutions,
+    first,
+    second,
+    blocked,
+    router,
+  };
 }
 
 describe("OS-06 canonical blocked reply routing", () => {
@@ -158,6 +184,126 @@ describe("OS-06 canonical blocked reply routing", () => {
         replyToEventId: blocked[1]?.eventId,
       }),
     ).rejects.toBeInstanceOf(ReplyRouteError);
+    await writer.close();
+  });
+
+  it("derives resolved blockers from the durable stream after router and port rebuild", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "mist-reply-resolution-"));
+    try {
+      const { writer, sessions, tree, delivery, blocked, router } = await assembly({ dataDir });
+      await router.route({
+        residentId: "resident-a",
+        text: "answer-once",
+        replyToEventId: blocked[0]?.eventId,
+      });
+      const afterFirst = JSON.stringify(tree.history("resident-a"));
+      await writer.close();
+
+      const restoredStream = new CanonicalStreamStore({ dataDir });
+      const restoredWriter = new CanonicalStreamWriter(restoredStream);
+      const rebuilt = new BlockedReplyRouter(
+        restoredStream,
+        sessions,
+        delivery,
+        new CanonicalBlockedReplyResolutionPort(restoredStream, restoredWriter, {
+          authoritySource: { kind: "host", id: "mist-host" },
+        }),
+      );
+
+      await expect(
+        rebuilt.route({
+          residentId: "resident-a",
+          text: "must-not-repeat",
+          replyToEventId: blocked[0]?.eventId,
+        }),
+      ).rejects.toMatchObject({ code: "REPLY_TARGET_RESOLVED" });
+      expect(JSON.stringify(tree.history("resident-a"))).toBe(afterFirst);
+      expect(
+        restoredStream
+          .eventsAfter("resident-a", 0)
+          .filter((event) => event.payload.kind === "blocked-reply-resolved"),
+      ).toHaveLength(1);
+      await restoredWriter.close();
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes concurrent replies to one blocker before either can dispatch twice", async () => {
+    let releaseReply = (): void => undefined;
+    let markStarted = (): void => undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const replyReleased = new Promise<void>((resolve) => {
+      releaseReply = resolve;
+    });
+    const { stream, writer, tree, blocked, router } = await assembly({
+      assistantReply: async (_residentId, message) => {
+        markStarted();
+        await replyReleased;
+        return `reply:${message}`;
+      },
+    });
+
+    const first = router.route({
+      residentId: "resident-a",
+      text: "first",
+      replyToEventId: blocked[0]?.eventId,
+    });
+    await started;
+    const second = router.route({
+      residentId: "resident-a",
+      text: "second",
+      replyToEventId: blocked[0]?.eventId,
+    });
+    releaseReply();
+
+    await expect(first).resolves.toMatchObject({ status: "routed" });
+    await expect(second).rejects.toMatchObject({ code: "REPLY_TARGET_RESOLVED" });
+    expect(tree.history("resident-a")).toHaveLength(2);
+    expect(
+      stream
+        .eventsAfter("resident-a", 0)
+        .filter((event) => event.payload.kind === "blocked-reply-resolved"),
+    ).toHaveLength(1);
+    await writer.close();
+  });
+
+  it("rechecks generation at the synchronous tree/head commit boundary", async () => {
+    let releaseReply = (): void => undefined;
+    let markStarted = (): void => undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const replyReleased = new Promise<void>((resolve) => {
+      releaseReply = resolve;
+    });
+    const { writer, sessions, tree, first, blocked, router } = await assembly({
+      assistantReply: async (_residentId, message) => {
+        markStarted();
+        await replyReleased;
+        return `reply:${message}`;
+      },
+    });
+
+    const inFlight = router.route({
+      residentId: "resident-a",
+      text: "old-generation",
+      replyToEventId: blocked[0]?.eventId,
+    });
+    await started;
+    sessions.kill(first.windowId);
+    const reopened = sessions.open("resident-a", {
+      windowId: first.windowId,
+      context: null,
+    });
+    expect(reopened.generation).toBe(first.generation + 1);
+    releaseReply();
+
+    await expect(inFlight).rejects.toMatchObject({ code: "REPLY_TARGET_STALE" });
+    expect(tree.history("resident-a")).toEqual([]);
+    expect(sessions.getHead(first.windowId)).toBeNull();
     await writer.close();
   });
 });


### PR DESCRIPTION
Implements OS-06 of #84.

This PR routes replies only from unresolved canonical blocked events to the exact live workspace generation:

- replyToEventId selects one canonical blocker exactly
- workRef selects only when it names one live blocker
- a naked reply routes only when exactly one candidate remains
- multiple candidates return structured disambiguation and perform zero dispatch
- unknown, resolved, stale, ambiguous, or inconsistent handles fail loudly
- recency, focus, active tab, creation time, and model guesses do not exist in the router input
- successful delivery writes a host-issued resolved receipt into the same durable canonical stream
- router, resolution port, and stream-store rebuilds derive resolved state from that receipt
- concurrent replies to one blocker are serialized before delivery, so only one can commit
- the original generation receipt is rechecked at a synchronous tree/head commit boundary after the responder returns
- an in-flight kill plus reopen of the same windowId rejects the old reply with zero tree/head writes
- blocker-derived deterministic MessageTree node identities make workspace delivery idempotent across tree/service/router rebuilds
- if the workspace pair commits but the canonical resolved receipt fails, retry reuses the same immutable pair and only closes the missing receipt
- if later turns have advanced the same window head beyond that pair, recovery recognizes the pair as an ancestor, preserves the newer head, and still closes the receipt
- a different branch or window does not satisfy that ancestry check and remains fail-closed

Fresh final-base evidence on head 89e93a4 over main 27d5f94 after #139 merged:

- the only rebase conflict was the one-stream barrel export; resolution preserves both #139 workspace exports and #140 reply-router exports
- focused router and MessageTree service/store: 3 files / 33 tests passed
- isolated rerun of the initially timed-out C4 test: 1/1 passed in 1.6s
- clean non-concurrent full rerun: 49 files passed, 3 skipped; 508 tests passed, 38 todo
- lint, typecheck, and acceptance 6/6 all green
- mutation probe: ignoring durable resolution receipts makes four focused cases red
- mutation probe: bypassing the final generation fence makes the in-flight kill/reopen case red
- mutation probe: removing the blocker-derived delivery key makes immediate receipt-crash recovery red
- mutation probe: removing descendant-head recognition makes the later-turn crash-gap recovery red at node unreachable

The previous independent review on f2c6655 remains valid by maintainer ruling; the reviewer has been asked to confirm the rebased head. OS-06 remains unchecked for the final acceptance seat.
