### PR TITLE
feat(fact-ledger): MV-C04 闸在非缺失方——账侧写闸 + 不可伪造 system 豁免（#80 泳道 2 最后一格）

### DIFF
--- a/src/store/fact-ledger.ts
+++ b/src/store/fact-ledger.ts
@@ -305,9 +305,7 @@ export class FactLedger {
     origin?: WriteOrigin,
   ): LedgerEntry {
     const ledger = this.#ledger(residentId);
-    // C04 红灯占位：origin 已收、闸未落（拦截随绿灯 commit 落地）。
-    // 红灯测试必须在这个头上失败——落后窗的写入此刻仍被放行。
-    void origin;
+    this.#assertOriginCurrent(residentId, origin);
     // 运行时校验给绕过类型系统的调用方：supersede 走 append 会造出没有
     // supersedesSeq 指针的解除条目，推导视图直接被毒化。
     if (!FACT_KINDS.includes(input.kind)) {
@@ -333,8 +331,9 @@ export class FactLedger {
     origin?: WriteOrigin,
   ): LedgerEntry {
     const ledger = this.#ledger(residentId);
-    // C04 红灯占位：同 append——origin 已收、闸未落。
-    void origin;
+    // C04 闸先于目标校验：未知悉最新裁定的窗连「目标存不存在」的答案
+    // 都不该拿到——先验资格，再验参数。
+    this.#assertOriginCurrent(residentId, origin);
     const target = ledger.entries[targetSeq - 1];
     if (target === undefined || target.seq !== targetSeq) {
       throw new LedgerEntryNotFoundError(residentId, targetSeq);
@@ -350,6 +349,23 @@ export class FactLedger {
     const entry = this.#appendEntry(ledger, input.author, "supersede", input.reason, targetSeq);
     ledger.supersededSeqs.add(targetSeq);
     return entry;
+  }
+
+  /**
+   * C04（闸在非缺失方）：窗署名的裁定级写入，写前必过账侧探针——
+   * unknown 即 fail-closed（查不到 ≠ 没缺口），落后即拒收。闸站在
+   * 账的必经写路径上，不依赖窗自查；经 probeGap 走，注入的通道故障
+   * （MV-C03 装置）在这里同样生效。非窗来源（origin 缺省）不受此闸。
+   */
+  #assertOriginCurrent(residentId: string, origin: WriteOrigin | undefined): void {
+    if (origin === undefined) return;
+    const probe = this.probeGap(residentId, origin.viewportId);
+    if (probe.status === "unknown") {
+      throw new WriteGateUnavailableError(residentId, origin.viewportId, probe.cause);
+    }
+    if (probe.ackedSeq < probe.latestSeq) {
+      throw new StaleViewportError(residentId, origin.viewportId, probe.ackedSeq, probe.latestSeq);
+    }
   }
 
   #appendEntry(

--- a/src/store/fact-ledger.ts
+++ b/src/store/fact-ledger.ts
@@ -21,6 +21,13 @@
  * 查账失败只有一种形状：unknown。它与「查到是零」在类型上就是两个值——
  * GapProbe 的 unknown 分支根本不携带数字，调用方想把它当 0 用，类型系统
  * 不答应（MV-C03）。fail-closed 的拦截动作本身在派发链上，不在账里。
+ *
+ * 「知悉」在本文件里的定义是「账已交付」（ackedSeq 判据），不是「窗已
+ * 读取」：刚开窗、尚未取走 pendingInitial 的窗 ackedSeq=baselineSeq，
+ * 写闸视之为已知悉 baseline——这与 C03 把 ackedSeq 当唯一权威的口径
+ * 一致，是设计而非缺口（上游阿问 review 点名留注，免得下一刀当漏洞堵）。
+ * 同一口径的另一面：窗署名写入成功即视为知悉自己那条（写者自 ack，
+ * 见 append() 头注）。
  */
 
 import {
@@ -128,7 +135,7 @@ export class WriteGateUnavailableError extends Error {
 }
 
 /**
- * C04 权威半格：写入三元组携带的 generation 与权威现查（generationOf）
+ * C04 权威半格：写入三元组携带的 generation 与权威现查（viewportAuthority）
  * 不符——旧代的窗无权署名当代写入。换代意味着窗对世界的知悉从头论起
  * （D8 猝死语义：新代靠交接信重新对齐，不续旧窗），旧代号写入与落后
  * 序号写入是同一种病的两个切面。
@@ -139,6 +146,21 @@ export class StaleGenerationError extends Error {
       `viewport ${viewportId} of ${residentId} writes as generation ${claimed} but authority says ${current} —— 旧代的窗无权写裁定级条目`,
     );
     this.name = "StaleGenerationError";
+  }
+}
+
+/**
+ * C04 归属半格（上游界 review 抓的洞）：权威说这扇窗属于别的住户——
+ * 别家的真窗即使被误挂进目标账的确认位，也不许给目标账署名写入。
+ * 三元组的 residentId 自比只是自证清白，两侧都来自调用参数；归属
+ * 必须由权威（SessionRegistry 侧）现查，不凭调用方一面之词。
+ */
+export class ForeignViewportError extends Error {
+  constructor(residentId: string, viewportId: string, ownerResidentId: string) {
+    super(
+      `viewport ${viewportId} belongs to ${ownerResidentId}, not ${residentId} —— 别家的窗无权给这本账署名写入`,
+    );
+    this.name = "ForeignViewportError";
   }
 }
 
@@ -238,14 +260,33 @@ function copyEntry(entry: LedgerEntry): LedgerEntry {
   return { ...entry, origin: { ...entry.origin } };
 }
 
+/** 权威口对一扇活窗的完整答复：归属 + 代际，一次给全，不许只给一半。 */
+export type ViewportLiveIdentity = { residentId: string; generation: number };
+
 export interface FactLedgerOptions {
   dataDir?: string;
   /**
-   * 窗代际的权威查询口（一般由宿主的 SessionRegistry 适配，同 TurnGate 的
-   * generationOf）。窗署名写入必过它验代际；未接线或查不到都 fail-closed——
-   * 验不了资格的写入不放行，这正是「闸在非缺失方」的账侧承诺。
+   * 窗身份的权威查询口（一般由宿主的 SessionRegistry 适配）。窗署名写入
+   * 必过它验归属与代际；未接线或查不到都 fail-closed——验不了资格的写入
+   * 不放行，这正是「闸在非缺失方」的账侧承诺。
+   *
+   * 接口刻意返回完整 live identity 而不是裸 generation（上游界 review 定的
+   * 落点）：只回代际的口会把 ownership 信息丢掉，别家的真窗被误挂进目标账
+   * 的 ack row 后就能署名写入——归属与代际必须同源同查。
    */
-  generationOf?: (viewportId: string) => number | null;
+  viewportAuthority?: (viewportId: string) => ViewportLiveIdentity | null;
+  /**
+   * 显式故障注入口（测试装置用）：返回 unknown 时内部探针以之作答，返回
+   * null 走真探针。类型上只能注入 unknown——注不出「假新鲜」，装置只可能
+   * 让闸更关，不可能把闸注开。生产装配不接此口。
+   * （上游界 review 定的落点：此前测试靠 monkey-patch 公开 probeGap 注入
+   * 故障，实例属性遮蔽原型方法会连内部判据一起换掉，先例即风险——安全
+   * 判据自此走内部探针，公开 probeGap 只是查询门面。）
+   */
+  gapProbeFault?: (
+    residentId: string,
+    viewportId: string,
+  ) => { status: "unknown"; cause: string } | null;
 }
 
 export class FactLedger {
@@ -262,12 +303,18 @@ export class FactLedger {
   /** ts 只用于展示与追溯，不参与任何判断（铁律 2），单调化只为同毫秒条目排序稳定。 */
   #lastStamp = 0;
 
-  /** 窗代际权威口；undefined = 未接线，窗署名写入一律 fail-closed。 */
-  readonly #generationOf: ((viewportId: string) => number | null) | undefined;
+  /** 窗身份权威口；undefined = 未接线，窗署名写入一律 fail-closed。 */
+  readonly #viewportAuthority: ((viewportId: string) => ViewportLiveIdentity | null) | undefined;
+
+  /** 显式故障注入口（只造 unknown）；undefined = 无注入，走真探针。 */
+  readonly #gapProbeFault:
+    | ((residentId: string, viewportId: string) => { status: "unknown"; cause: string } | null)
+    | undefined;
 
   constructor(options: FactLedgerOptions = {}) {
     this.#dataDir = options.dataDir ?? null;
-    this.#generationOf = options.generationOf;
+    this.#viewportAuthority = options.viewportAuthority;
+    this.#gapProbeFault = options.gapProbeFault;
     if (this.#dataDir !== null) {
       mkdirSync(this.#dataDir, { recursive: true });
       this.#restore(this.#dataDir);
@@ -396,6 +443,11 @@ export class FactLedger {
    * 落一条事实（窗署名写口）。seq 由账侧发号——调用方没有传 seq 的入口，
    * 外部想伪造序号得先改这个类，那是 review 看得见的越权。origin 只收
    * viewport 三元组：system 豁免不在这个门上（见 ViewportWriteOrigin 头注）。
+   *
+   * 写者天然知悉自己刚写下的条目：entry 落账与写者确认位推进在同一次
+   * 持久化里完成（上游界 review 定的语义）——否则成功写入方会被自己的
+   * 上一笔判 stale，一轮多个裁定级动作（B03 真实派发链的常态）就得靠
+   * 每写一笔手工 ack 一次续命。别家窗的确认位不动：他们的知悉仍走缺口通道。
    */
   append(
     residentId: string,
@@ -404,11 +456,16 @@ export class FactLedger {
   ): LedgerEntry {
     const ledger = this.#ledger(residentId);
     this.#assertViewportOriginCurrent(residentId, origin);
-    return this.#appendFact(ledger, input, {
-      kind: "viewport",
-      viewportId: origin.viewportId,
-      generation: origin.generation,
-    });
+    return this.#appendFact(
+      ledger,
+      input,
+      {
+        kind: "viewport",
+        viewportId: origin.viewportId,
+        generation: origin.generation,
+      },
+      origin.viewportId,
+    );
   }
 
   /** append 的共用内里（窗口与 system 写手共用）：kind 校验 + 原子追加。 */
@@ -416,6 +473,7 @@ export class FactLedger {
     ledger: ResidentLedger,
     input: { author: string; kind: FactKind; body: string },
     origin: EntryOrigin,
+    selfAckViewportId: string | null = null,
   ): LedgerEntry {
     // 运行时校验给绕过类型系统的调用方：supersede 走 append 会造出没有
     // supersedesSeq 指针的解除条目，推导视图直接被毒化。
@@ -424,7 +482,15 @@ export class FactLedger {
         `append only accepts ${FACT_KINDS.join("/")}, got ${String(input.kind)} —— 解除走 supersede()`,
       );
     }
-    return this.#appendEntry(ledger, input.author, input.kind, input.body, null, origin);
+    return this.#appendEntry(
+      ledger,
+      input.author,
+      input.kind,
+      input.body,
+      null,
+      origin,
+      selfAckViewportId,
+    );
   }
 
   /**
@@ -445,11 +511,17 @@ export class FactLedger {
     // C04 闸先于目标校验：未知悉最新裁定的窗连「目标存不存在」的答案
     // 都不该拿到——先验资格，再验参数。
     this.#assertViewportOriginCurrent(residentId, origin);
-    return this.#supersedeEntry(ledger, targetSeq, input, {
-      kind: "viewport",
-      viewportId: origin.viewportId,
-      generation: origin.generation,
-    });
+    return this.#supersedeEntry(
+      ledger,
+      targetSeq,
+      input,
+      {
+        kind: "viewport",
+        viewportId: origin.viewportId,
+        generation: origin.generation,
+      },
+      origin.viewportId,
+    );
   }
 
   /** supersede 的共用内里（窗口与 system 写手共用）：目标校验 + 原子追加。 */
@@ -458,6 +530,7 @@ export class FactLedger {
     targetSeq: number,
     input: { author: string; reason: string },
     origin: EntryOrigin,
+    selfAckViewportId: string | null = null,
   ): LedgerEntry {
     const target = ledger.entries[targetSeq - 1];
     if (target === undefined || target.seq !== targetSeq) {
@@ -478,18 +551,22 @@ export class FactLedger {
       input.reason,
       targetSeq,
       origin,
+      selfAckViewportId,
     );
     ledger.supersededSeqs.add(targetSeq);
     return entry;
   }
 
   /**
-   * C04（闸在非缺失方）：窗署名裁定级写入的必经账侧闸。四道检查按
+   * C04（闸在非缺失方）：窗署名裁定级写入的必经账侧闸。五道检查按
    * 资格从内到外排：形状（运行时半格——JS 调用方自报 {kind:"system"}
-   * 在这里响亮拒绝，类型面则根本没有那个分支）→ residentId 一致 →
-   * 代际权威现查（未接线/查不到 fail-closed，旧代号拒收）→ 缺口
-   * （unknown fail-closed，落后拒收）。经 probeGap 走使 MV-C03 装置的
-   * 通道故障对写路径同样生效。
+   * 在这里响亮拒绝，类型面则根本没有那个分支）→ residentId 自比一致 →
+   * 权威现查（未接线/查不到 fail-closed）→ 归属（别家的窗拒收）与
+   * 代际（旧代号拒收）→ 缺口（unknown fail-closed，落后拒收）。
+   *
+   * 缺口判据走内部探针 #probeGap，不经公开 probeGap：安全判据不许被
+   * 实例属性遮蔽（上游界 review 抓的可误用性）；MV-C03 装置的通道故障
+   * 经 gapProbeFault 显式注入口对写路径同样生效。
    */
   #assertViewportOriginCurrent(residentId: string, origin: ViewportWriteOrigin): void {
     if (
@@ -509,25 +586,34 @@ export class FactLedger {
         `origin.residentId (${origin.residentId}) 与写入目标账 (${residentId}) 不一致 —— 三元组不许张冠李戴`,
       );
     }
-    if (this.#generationOf === undefined) {
+    if (this.#viewportAuthority === undefined) {
       throw new WriteGateUnavailableError(
         residentId,
         origin.viewportId,
-        "generationOf 权威未接线——验不了代际的窗署名写入 fail-closed",
+        "viewportAuthority 权威未接线——验不了归属与代际的窗署名写入 fail-closed",
       );
     }
-    const current = this.#generationOf(origin.viewportId);
-    if (current === null) {
+    const live = this.#viewportAuthority(origin.viewportId);
+    if (live === null) {
       throw new WriteGateUnavailableError(
         residentId,
         origin.viewportId,
-        `generation 权威查不到窗 ${origin.viewportId}——验不了资格即 fail-closed`,
+        `身份权威查不到窗 ${origin.viewportId}——验不了资格即 fail-closed`,
       );
     }
-    if (current !== origin.generation) {
-      throw new StaleGenerationError(residentId, origin.viewportId, origin.generation, current);
+    // 归属先于代际：连「这扇窗是谁家的」都对不上时，代际对错已无意义。
+    if (live.residentId !== residentId) {
+      throw new ForeignViewportError(residentId, origin.viewportId, live.residentId);
     }
-    const probe = this.probeGap(residentId, origin.viewportId);
+    if (live.generation !== origin.generation) {
+      throw new StaleGenerationError(
+        residentId,
+        origin.viewportId,
+        origin.generation,
+        live.generation,
+      );
+    }
+    const probe = this.#probeGap(residentId, origin.viewportId);
     if (probe.status === "unknown") {
       throw new WriteGateUnavailableError(residentId, origin.viewportId, probe.cause);
     }
@@ -543,6 +629,7 @@ export class FactLedger {
     body: string,
     supersedesSeq: number | null,
     origin: EntryOrigin,
+    selfAckViewportId: string | null = null,
   ): LedgerEntry {
     const entry: LedgerEntry = Object.freeze({
       seq: ledger.entries.length + 1,
@@ -553,16 +640,28 @@ export class FactLedger {
       supersedesSeq,
       origin: Object.freeze({ ...origin }),
     });
+    // 写者自 ack（界 review 定的语义）：窗署名写入时，该窗的确认位随条目
+    // 在同一次持久化里推进到新 seq——写者对自己刚提交的条目天然知悉，
+    // 不靠事后补一笔 ack 续命。system 写手无窗，selfAckViewportId 为 null。
+    const selfRow =
+      selfAckViewportId === null ? undefined : ledger.viewports.get(selfAckViewportId);
+    let candidateViewports: ReadonlyMap<string, ViewportAckRow> = ledger.viewports;
+    if (selfRow !== undefined && selfAckViewportId !== null) {
+      const advanced = new Map(ledger.viewports);
+      advanced.set(selfAckViewportId, { ...selfRow, ackedSeq: entry.seq });
+      candidateViewports = advanced;
+    }
     // 候选快照先落盘，成功才发布进内存：落盘失败时调用方收到错误，
     // 而账一个字节没变——不存在「内存改了、盘上没改」的中间态。
     // （故障注入打过的洞：先 push 再落盘，supersede 失败会留下
     // 「条目进了全史、解除标记没进」的自相矛盾。）
     this.#persistSnapshot(
-      this.#snapshotOf(ledger.residentId, [...ledger.entries, entry], ledger.viewports),
+      this.#snapshotOf(ledger.residentId, [...ledger.entries, entry], candidateViewports),
     );
     // 冻结石彻 append-only 的最后一步：即使有人拿到账内引用（持久化恢复
     // 之外的路径都返回副本），运行时也拒绝任何涂改。
     ledger.entries.push(entry);
+    if (selfRow !== undefined) selfRow.ackedSeq = entry.seq;
     return copyEntry(entry);
   }
 
@@ -677,11 +776,22 @@ export class FactLedger {
   /**
    * 永不抛的缺口探针：任何查账失败都归一成 { status: "unknown" }。
    * unknown 分支不携带数字，与「查到是零」在类型上不可混（MV-C03）。
+   *
+   * 这是查询门面：账侧写闸不经它，走同源的内部探针 #probeGap——覆盖
+   * 这个公开方法改变不了写资格判断（上游界 review 定的边界）。
    */
   probeGap(residentId: string, viewportId: string): GapProbe {
+    return this.#probeGap(residentId, viewportId);
+  }
+
+  /** 内部探针：写闸的唯一缺口判据。显式故障注入口只能让它答 unknown。 */
+  #probeGap(residentId: string, viewportId: string): GapProbe {
+    const fault = this.#gapProbeFault?.(residentId, viewportId);
+    if (fault != null) return fault;
     try {
-      const { latestSeq, ackedSeq } = this.gap(residentId, viewportId);
-      return { status: "ok", latestSeq, ackedSeq };
+      const ledger = this.#ledger(residentId);
+      const row = this.#viewportRow(ledger, viewportId);
+      return { status: "ok", latestSeq: ledger.entries.length, ackedSeq: row.ackedSeq };
     } catch (error) {
       return { status: "unknown", cause: error instanceof Error ? error.message : String(error) };
     }

--- a/src/store/fact-ledger.ts
+++ b/src/store/fact-ledger.ts
@@ -98,6 +98,42 @@ export class AckError extends Error {
 }
 
 /**
+ * C04（闸在非缺失方）：窗署名的裁定级写入，发起窗落后于账
+ * （ackedSeq < latestSeq）时的拒收。拦截站在账侧写路径上——窗自查
+ * 不是闸，忘了自查的窗和故意不自查的窗在这里长一个样。
+ */
+export class StaleViewportError extends Error {
+  constructor(residentId: string, viewportId: string, ackedSeq: number, latestSeq: number) {
+    super(
+      `viewport ${viewportId} of ${residentId} is stale (acked ${ackedSeq} < latest ${latestSeq}) —— 未知悉最新裁定的窗无权写裁定级条目，先过开工闸拉平缺口`,
+    );
+    this.name = "StaleViewportError";
+  }
+}
+
+/**
+ * C04 的 unknown 半格：窗署名写入时查账失败（GapProbe unknown）即
+ * fail-closed——「查不到」不许被当成「没缺口」放行（与 MV-C03 同一条
+ * 纪律：unknown 和零是两个值）。
+ */
+export class WriteGateUnavailableError extends Error {
+  constructor(residentId: string, viewportId: string, cause: string) {
+    super(
+      `ledger probe unknown for viewport ${viewportId} of ${residentId}（${cause}）—— 裁定级写入 fail-closed`,
+    );
+    this.name = "WriteGateUnavailableError";
+  }
+}
+
+/**
+ * 窗署名写入的发起方。不传 = 非窗来源（主线程／管理员落账），不受 C04
+ * 闸——闸拦的是「落后的窗」，不是「不是窗的写方」。
+ */
+export interface WriteOrigin {
+  viewportId: string;
+}
+
+/**
  * 缺口探针的返回形状（MV-C03 的落点）。
  *
  * 「查不到」（unknown）与「查到是零」（ok 且 latestSeq=ackedSeq=0）是两个
@@ -263,8 +299,15 @@ export class FactLedger {
    * 落一条事实。seq 由账侧发号——调用方没有传 seq 的入口，外部想伪造
    * 序号得先改这个类，那是 review 看得见的越权。
    */
-  append(residentId: string, input: { author: string; kind: FactKind; body: string }): LedgerEntry {
+  append(
+    residentId: string,
+    input: { author: string; kind: FactKind; body: string },
+    origin?: WriteOrigin,
+  ): LedgerEntry {
     const ledger = this.#ledger(residentId);
+    // C04 红灯占位：origin 已收、闸未落（拦截随绿灯 commit 落地）。
+    // 红灯测试必须在这个头上失败——落后窗的写入此刻仍被放行。
+    void origin;
     // 运行时校验给绕过类型系统的调用方：supersede 走 append 会造出没有
     // supersedesSeq 指针的解除条目，推导视图直接被毒化。
     if (!FACT_KINDS.includes(input.kind)) {
@@ -287,8 +330,11 @@ export class FactLedger {
     residentId: string,
     targetSeq: number,
     input: { author: string; reason: string },
+    origin?: WriteOrigin,
   ): LedgerEntry {
     const ledger = this.#ledger(residentId);
+    // C04 红灯占位：同 append——origin 已收、闸未落。
+    void origin;
     const target = ledger.entries[targetSeq - 1];
     if (target === undefined || target.seq !== targetSeq) {
       throw new LedgerEntryNotFoundError(residentId, targetSeq);

--- a/src/store/fact-ledger.ts
+++ b/src/store/fact-ledger.ts
@@ -126,12 +126,20 @@ export class WriteGateUnavailableError extends Error {
 }
 
 /**
- * 窗署名写入的发起方。不传 = 非窗来源（主线程／管理员落账），不受 C04
- * 闸——闸拦的是「落后的窗」，不是「不是窗的写方」。
+ * 裁定级写入的发起方——必填判别联合，不许省略、不许 null。
+ *
+ * 渡渡家内审 P1 + 上游 Laurie/Elio 定案：origin 可省略就是洞——落后窗
+ * 只要少传一个字段就被当 system 放行。所以豁免必须是写方显式签名声明的，
+ * 不是「缺省得到的」；类型层必填，绕过就是 review 看得见的越权，跟账侧
+ * 「seq 只能账发号」是同一个设计语言。
+ *
+ * - viewport 分支：账侧写前验 probeGap（unknown fail-closed）+ 落后拒收；
+ * - system 分支：可信宿主能力，带 reason 落痕，不凭调用者自报 kind 就绕闸；
+ *   本层至少钉死「省略即类型错误、reason 必填非空」。
  */
-export interface WriteOrigin {
-  viewportId: string;
-}
+export type WriteOrigin =
+  | { kind: "viewport"; viewportId: string }
+  | { kind: "system"; reason: string };
 
 /**
  * 缺口探针的返回形状（MV-C03 的落点）。
@@ -302,7 +310,7 @@ export class FactLedger {
   append(
     residentId: string,
     input: { author: string; kind: FactKind; body: string },
-    origin?: WriteOrigin,
+    origin: WriteOrigin,
   ): LedgerEntry {
     const ledger = this.#ledger(residentId);
     this.#assertOriginCurrent(residentId, origin);
@@ -328,7 +336,7 @@ export class FactLedger {
     residentId: string,
     targetSeq: number,
     input: { author: string; reason: string },
-    origin?: WriteOrigin,
+    origin: WriteOrigin,
   ): LedgerEntry {
     const ledger = this.#ledger(residentId);
     // C04 闸先于目标校验：未知悉最新裁定的窗连「目标存不存在」的答案
@@ -352,13 +360,22 @@ export class FactLedger {
   }
 
   /**
-   * C04（闸在非缺失方）：窗署名的裁定级写入，写前必过账侧探针——
-   * unknown 即 fail-closed（查不到 ≠ 没缺口），落后即拒收。闸站在
-   * 账的必经写路径上，不依赖窗自查；经 probeGap 走，注入的通道故障
-   * （MV-C03 装置）在这里同样生效。非窗来源（origin 缺省）不受此闸。
+   * C04（闸在非缺失方）：裁定级写入的必经账侧闸。origin 必填判别联合，
+   * 省略在类型层就是编译错误（渡渡家内审 P1：可省略即洞）。
+   *
+   * - viewport 来源：写前过 probeGap，unknown fail-closed（查不到 ≠ 没缺口），
+   *   落后（ackedSeq < latestSeq）拒收。经 probeGap 走使 MV-C03 装置的
+   *   通道故障对写路径同样生效。
+   * - system 来源：可信宿主豁免，reason 非空才放行（豁免必须显式署名，
+   *   不是缺省得到；空署名等于没署名）。
    */
-  #assertOriginCurrent(residentId: string, origin: WriteOrigin | undefined): void {
-    if (origin === undefined) return;
+  #assertOriginCurrent(residentId: string, origin: WriteOrigin): void {
+    if (origin.kind === "system") {
+      if (origin.reason.trim() === "") {
+        throw new Error("system-origin write requires a non-empty reason —— 豁免必须显式署名");
+      }
+      return;
+    }
     const probe = this.probeGap(residentId, origin.viewportId);
     if (probe.status === "unknown") {
       throw new WriteGateUnavailableError(residentId, origin.viewportId, probe.cause);

--- a/src/store/fact-ledger.ts
+++ b/src/store/fact-ledger.ts
@@ -55,6 +55,8 @@ export interface LedgerEntry {
   readonly kind: LedgerEntryKind;
   readonly body: string;
   readonly supersedesSeq: number | null;
+  /** 发起方印痕（C04）：谁署名写下的这条——viewport 三元组或 system 豁免的 reason。追加时定死，同为不可变字段。 */
+  readonly origin: EntryOrigin;
 }
 
 /** 跨住户访问时抛这个，不返回空账——静默的空结果会把 bug 藏起来（同 ResidentStore 的房规）。 */
@@ -126,19 +128,49 @@ export class WriteGateUnavailableError extends Error {
 }
 
 /**
- * 裁定级写入的发起方——必填判别联合，不许省略、不许 null。
- *
- * 渡渡家内审 P1 + 上游 Laurie/Elio 定案：origin 可省略就是洞——落后窗
- * 只要少传一个字段就被当 system 放行。所以豁免必须是写方显式签名声明的，
- * 不是「缺省得到的」；类型层必填，绕过就是 review 看得见的越权，跟账侧
- * 「seq 只能账发号」是同一个设计语言。
- *
- * - viewport 分支：账侧写前验 probeGap（unknown fail-closed）+ 落后拒收；
- * - system 分支：可信宿主能力，带 reason 落痕，不凭调用者自报 kind 就绕闸；
- *   本层至少钉死「省略即类型错误、reason 必填非空」。
+ * C04 权威半格：写入三元组携带的 generation 与权威现查（generationOf）
+ * 不符——旧代的窗无权署名当代写入。换代意味着窗对世界的知悉从头论起
+ * （D8 猝死语义：新代靠交接信重新对齐，不续旧窗），旧代号写入与落后
+ * 序号写入是同一种病的两个切面。
  */
-export type WriteOrigin =
-  | { kind: "viewport"; viewportId: string }
+export class StaleGenerationError extends Error {
+  constructor(residentId: string, viewportId: string, claimed: number, current: number) {
+    super(
+      `viewport ${viewportId} of ${residentId} writes as generation ${claimed} but authority says ${current} —— 旧代的窗无权写裁定级条目`,
+    );
+    this.name = "StaleGenerationError";
+  }
+}
+
+/**
+ * 裁定级写入的发起方三元组——对外写口唯一的合法形状。
+ *
+ * 渡渡家内审两轮 + 上游 Laurie/Elio 定案的落点：豁免不能是「缺省得到的」
+ * （P1 前半：origin 可省略即洞），也不能是「自报得到的」（P1 后半：联合
+ * 字段人人可构造，落后窗自称 system 照样绕闸）。所以公开 append/supersede
+ * 的 origin 类型里根本没有 system 分支——system 豁免只经 FactLedger.create()
+ * 铸给组装层的 SystemLedgerWriter 能力对象，不持有能力的调用方在类型上
+ * 就没有豁免可谈，跟「seq 只能账发号」是同一个设计语言。
+ *
+ * 三元组 (residentId, viewportId, generation) 一个不许少（上游 Elio 口径；
+ * viewportId 即宿主发号的 windowId，w_ + ULID）：residentId 必须与写入
+ * 目标账一致（防张冠李戴），generation 由账侧向权威 generationOf 现查
+ * 比对——旧代号拒收，authority 未接线或查不到即 fail-closed。
+ */
+export type ViewportWriteOrigin = {
+  kind: "viewport";
+  residentId: string;
+  viewportId: string;
+  generation: number;
+};
+
+/**
+ * 落进账目的发起方印痕（LedgerEntry.origin）——与 author 并排永存
+ * （上游 Laurie 口径：system 豁免必须显式署名且归档可审计，reason 只做
+ * 写前校验不落痕等于没署名）。residentId 不重复落：条目本身就住在那本账里。
+ */
+export type EntryOrigin =
+  | { kind: "viewport"; viewportId: string; generation: number }
   | { kind: "system"; reason: string };
 
 /**
@@ -186,8 +218,35 @@ interface LedgerRecord {
   viewports: { viewportId: string; baselineSeq: number; ackedSeq: number }[];
 }
 
-const SCHEMA_VERSION = 1;
+/** v2：条目落痕 origin 字段（C04 权威半格）。v1 旧档显式失败等迁移，不猜。 */
+const SCHEMA_VERSION = 2;
 const FILE_SUFFIX = ".facts.json";
+
+/** SystemLedgerWriter 的铸造印——模块私有，外部拿不到，等于构造函数上了锁。 */
+const SYSTEM_WRITER_BRAND = Symbol("fact-ledger system writer");
+
+/** system 豁免每次写入的署名校验：空署名等于没署名。 */
+function assertSystemReason(reason: string): string {
+  if (typeof reason !== "string" || reason.trim() === "") {
+    throw new Error("system-origin write requires a non-empty reason —— 豁免必须显式署名");
+  }
+  return reason;
+}
+
+/** 条目副本（含 origin 深一层）：改返回值涂改不了账。 */
+function copyEntry(entry: LedgerEntry): LedgerEntry {
+  return { ...entry, origin: { ...entry.origin } };
+}
+
+export interface FactLedgerOptions {
+  dataDir?: string;
+  /**
+   * 窗代际的权威查询口（一般由宿主的 SessionRegistry 适配，同 TurnGate 的
+   * generationOf）。窗署名写入必过它验代际；未接线或查不到都 fail-closed——
+   * 验不了资格的写入不放行，这正是「闸在非缺失方」的账侧承诺。
+   */
+  generationOf?: (viewportId: string) => number | null;
+}
 
 export class FactLedger {
   readonly #ledgers = new Map<string, ResidentLedger>();
@@ -203,12 +262,42 @@ export class FactLedger {
   /** ts 只用于展示与追溯，不参与任何判断（铁律 2），单调化只为同毫秒条目排序稳定。 */
   #lastStamp = 0;
 
-  constructor(options: { dataDir?: string } = {}) {
+  /** 窗代际权威口；undefined = 未接线，窗署名写入一律 fail-closed。 */
+  readonly #generationOf: ((viewportId: string) => number | null) | undefined;
+
+  constructor(options: FactLedgerOptions = {}) {
     this.#dataDir = options.dataDir ?? null;
+    this.#generationOf = options.generationOf;
     if (this.#dataDir !== null) {
       mkdirSync(this.#dataDir, { recursive: true });
       this.#restore(this.#dataDir);
     }
+  }
+
+  /**
+   * 组装层入口：开一本账，同时铸出它的 system 写手。SystemLedgerWriter
+   * 只有这一个出生点（类不导出、构造带模块私有印），账实例上也没有任何
+   * 方法能再取到它——能力只在铸出那一刻交给调用方，由组装层决定给谁。
+   * 用普通 new 构造的账没有 system 写手，等于这本账上不存在豁免。
+   */
+  static create(options: FactLedgerOptions = {}): {
+    ledger: FactLedger;
+    systemWriter: SystemLedgerWriter;
+  } {
+    const ledger = new FactLedger(options);
+    const systemWriter = new SystemLedgerWriter(SYSTEM_WRITER_BRAND, {
+      append: (residentId, input, reason) =>
+        ledger.#appendFact(ledger.#ledger(residentId), input, {
+          kind: "system",
+          reason: assertSystemReason(reason),
+        }),
+      supersede: (residentId, targetSeq, input, reason) =>
+        ledger.#supersedeEntry(ledger.#ledger(residentId), targetSeq, input, {
+          kind: "system",
+          reason: assertSystemReason(reason),
+        }),
+    });
+    return { ledger, systemWriter };
   }
 
   /** 同一进程内单调递增的时间戳，避免同毫秒条目排序不稳定。 */
@@ -304,16 +393,30 @@ export class FactLedger {
   // --- 追加（账上唯一的写形状）---
 
   /**
-   * 落一条事实。seq 由账侧发号——调用方没有传 seq 的入口，外部想伪造
-   * 序号得先改这个类，那是 review 看得见的越权。
+   * 落一条事实（窗署名写口）。seq 由账侧发号——调用方没有传 seq 的入口，
+   * 外部想伪造序号得先改这个类，那是 review 看得见的越权。origin 只收
+   * viewport 三元组：system 豁免不在这个门上（见 ViewportWriteOrigin 头注）。
    */
   append(
     residentId: string,
     input: { author: string; kind: FactKind; body: string },
-    origin: WriteOrigin,
+    origin: ViewportWriteOrigin,
   ): LedgerEntry {
     const ledger = this.#ledger(residentId);
-    this.#assertOriginCurrent(residentId, origin);
+    this.#assertViewportOriginCurrent(residentId, origin);
+    return this.#appendFact(ledger, input, {
+      kind: "viewport",
+      viewportId: origin.viewportId,
+      generation: origin.generation,
+    });
+  }
+
+  /** append 的共用内里（窗口与 system 写手共用）：kind 校验 + 原子追加。 */
+  #appendFact(
+    ledger: ResidentLedger,
+    input: { author: string; kind: FactKind; body: string },
+    origin: EntryOrigin,
+  ): LedgerEntry {
     // 运行时校验给绕过类型系统的调用方：supersede 走 append 会造出没有
     // supersedesSeq 指针的解除条目，推导视图直接被毒化。
     if (!FACT_KINDS.includes(input.kind)) {
@@ -321,7 +424,7 @@ export class FactLedger {
         `append only accepts ${FACT_KINDS.join("/")}, got ${String(input.kind)} —— 解除走 supersede()`,
       );
     }
-    return this.#appendEntry(ledger, input.author, input.kind, input.body, null);
+    return this.#appendEntry(ledger, input.author, input.kind, input.body, null, origin);
   }
 
   /**
@@ -336,15 +439,29 @@ export class FactLedger {
     residentId: string,
     targetSeq: number,
     input: { author: string; reason: string },
-    origin: WriteOrigin,
+    origin: ViewportWriteOrigin,
   ): LedgerEntry {
     const ledger = this.#ledger(residentId);
     // C04 闸先于目标校验：未知悉最新裁定的窗连「目标存不存在」的答案
     // 都不该拿到——先验资格，再验参数。
-    this.#assertOriginCurrent(residentId, origin);
+    this.#assertViewportOriginCurrent(residentId, origin);
+    return this.#supersedeEntry(ledger, targetSeq, input, {
+      kind: "viewport",
+      viewportId: origin.viewportId,
+      generation: origin.generation,
+    });
+  }
+
+  /** supersede 的共用内里（窗口与 system 写手共用）：目标校验 + 原子追加。 */
+  #supersedeEntry(
+    ledger: ResidentLedger,
+    targetSeq: number,
+    input: { author: string; reason: string },
+    origin: EntryOrigin,
+  ): LedgerEntry {
     const target = ledger.entries[targetSeq - 1];
     if (target === undefined || target.seq !== targetSeq) {
-      throw new LedgerEntryNotFoundError(residentId, targetSeq);
+      throw new LedgerEntryNotFoundError(ledger.residentId, targetSeq);
     }
     if (target.kind === "supersede") {
       throw new InvalidSupersedeError(
@@ -354,27 +471,61 @@ export class FactLedger {
     if (ledger.supersededSeqs.has(targetSeq)) {
       throw new InvalidSupersedeError(`entry seq ${targetSeq} is already superseded`);
     }
-    const entry = this.#appendEntry(ledger, input.author, "supersede", input.reason, targetSeq);
+    const entry = this.#appendEntry(
+      ledger,
+      input.author,
+      "supersede",
+      input.reason,
+      targetSeq,
+      origin,
+    );
     ledger.supersededSeqs.add(targetSeq);
     return entry;
   }
 
   /**
-   * C04（闸在非缺失方）：裁定级写入的必经账侧闸。origin 必填判别联合，
-   * 省略在类型层就是编译错误（渡渡家内审 P1：可省略即洞）。
-   *
-   * - viewport 来源：写前过 probeGap，unknown fail-closed（查不到 ≠ 没缺口），
-   *   落后（ackedSeq < latestSeq）拒收。经 probeGap 走使 MV-C03 装置的
-   *   通道故障对写路径同样生效。
-   * - system 来源：可信宿主豁免，reason 非空才放行（豁免必须显式署名，
-   *   不是缺省得到；空署名等于没署名）。
+   * C04（闸在非缺失方）：窗署名裁定级写入的必经账侧闸。四道检查按
+   * 资格从内到外排：形状（运行时半格——JS 调用方自报 {kind:"system"}
+   * 在这里响亮拒绝，类型面则根本没有那个分支）→ residentId 一致 →
+   * 代际权威现查（未接线/查不到 fail-closed，旧代号拒收）→ 缺口
+   * （unknown fail-closed，落后拒收）。经 probeGap 走使 MV-C03 装置的
+   * 通道故障对写路径同样生效。
    */
-  #assertOriginCurrent(residentId: string, origin: WriteOrigin): void {
-    if (origin.kind === "system") {
-      if (origin.reason.trim() === "") {
-        throw new Error("system-origin write requires a non-empty reason —— 豁免必须显式署名");
-      }
-      return;
+  #assertViewportOriginCurrent(residentId: string, origin: ViewportWriteOrigin): void {
+    if (
+      typeof origin !== "object" ||
+      origin === null ||
+      origin.kind !== "viewport" ||
+      typeof origin.residentId !== "string" ||
+      typeof origin.viewportId !== "string" ||
+      !Number.isInteger(origin.generation)
+    ) {
+      throw new Error(
+        'write origin must be a viewport triplet {kind:"viewport", residentId, viewportId, generation} —— system 豁免只经 FactLedger.create() 铸出的 SystemLedgerWriter，不凭调用方自报',
+      );
+    }
+    if (origin.residentId !== residentId) {
+      throw new Error(
+        `origin.residentId (${origin.residentId}) 与写入目标账 (${residentId}) 不一致 —— 三元组不许张冠李戴`,
+      );
+    }
+    if (this.#generationOf === undefined) {
+      throw new WriteGateUnavailableError(
+        residentId,
+        origin.viewportId,
+        "generationOf 权威未接线——验不了代际的窗署名写入 fail-closed",
+      );
+    }
+    const current = this.#generationOf(origin.viewportId);
+    if (current === null) {
+      throw new WriteGateUnavailableError(
+        residentId,
+        origin.viewportId,
+        `generation 权威查不到窗 ${origin.viewportId}——验不了资格即 fail-closed`,
+      );
+    }
+    if (current !== origin.generation) {
+      throw new StaleGenerationError(residentId, origin.viewportId, origin.generation, current);
     }
     const probe = this.probeGap(residentId, origin.viewportId);
     if (probe.status === "unknown") {
@@ -391,6 +542,7 @@ export class FactLedger {
     kind: LedgerEntryKind,
     body: string,
     supersedesSeq: number | null,
+    origin: EntryOrigin,
   ): LedgerEntry {
     const entry: LedgerEntry = Object.freeze({
       seq: ledger.entries.length + 1,
@@ -399,6 +551,7 @@ export class FactLedger {
       kind,
       body,
       supersedesSeq,
+      origin: Object.freeze({ ...origin }),
     });
     // 候选快照先落盘，成功才发布进内存：落盘失败时调用方收到错误，
     // 而账一个字节没变——不存在「内存改了、盘上没改」的中间态。
@@ -410,7 +563,7 @@ export class FactLedger {
     // 冻结石彻 append-only 的最后一步：即使有人拿到账内引用（持久化恢复
     // 之外的路径都返回副本），运行时也拒绝任何涂改。
     ledger.entries.push(entry);
-    return { ...entry };
+    return copyEntry(entry);
   }
 
   // --- 推导视图与追溯 ---
@@ -425,7 +578,7 @@ export class FactLedger {
    * 返回副本——改返回值涂改不了账。
    */
   entries(residentId: string): LedgerEntry[] {
-    return this.#ledger(residentId).entries.map((entry) => ({ ...entry }));
+    return this.#ledger(residentId).entries.map(copyEntry);
   }
 
   /**
@@ -446,7 +599,7 @@ export class FactLedger {
     const ledger = this.#ledger(residentId);
     return ledger.entries
       .filter((entry) => entry.kind !== "supersede" && !ledger.supersededSeqs.has(entry.seq))
-      .map((entry) => ({ ...entry }));
+      .map(copyEntry);
   }
 
   // --- 窗级确认位（viewport 一词从 glossary，图纸上说的「窗」）---
@@ -496,7 +649,7 @@ export class FactLedger {
   pendingInitial(residentId: string, viewportId: string): LedgerEntry[] | null {
     const row = this.#viewportRow(this.#ledger(residentId), viewportId);
     const pending = row.pendingInitial;
-    return pending === null ? null : pending.map((entry) => ({ ...entry }));
+    return pending === null ? null : pending.map(copyEntry);
   }
 
   /**
@@ -538,9 +691,7 @@ export class FactLedger {
   gapEntries(residentId: string, viewportId: string): LedgerEntry[] {
     const ledger = this.#ledger(residentId);
     const row = this.#viewportRow(ledger, viewportId);
-    return ledger.entries
-      .filter((entry) => entry.seq > row.ackedSeq)
-      .map((entry) => ({ ...entry }));
+    return ledger.entries.filter((entry) => entry.seq > row.ackedSeq).map(copyEntry);
   }
 
   /**
@@ -589,7 +740,7 @@ export class FactLedger {
     return {
       schemaVersion: SCHEMA_VERSION,
       residentId,
-      entries: entries.map((entry) => ({ ...entry })),
+      entries: entries.map(copyEntry),
       viewports: [...viewports.entries()].map(([viewportId, row]) => ({
         viewportId,
         baselineSeq: row.baselineSeq,
@@ -660,7 +811,9 @@ export class FactLedger {
       this.#restoreViewports(record);
       this.#ledgers.set(record.residentId, {
         residentId: record.residentId,
-        entries: record.entries.map((entry) => Object.freeze({ ...entry })),
+        entries: record.entries.map((entry) =>
+          Object.freeze({ ...entry, origin: Object.freeze({ ...entry.origin }) }),
+        ),
         supersededSeqs: new Set(
           record.entries.flatMap((entry) =>
             entry.kind === "supersede" && entry.supersedesSeq !== null ? [entry.supersedesSeq] : [],
@@ -721,7 +874,11 @@ export class FactLedger {
         throw bad(`第 ${i + 1} 条不是对象`);
       }
       const e = entry as Record<string, unknown>;
-      exactKeys(e, ["seq", "ts", "author", "kind", "body", "supersedesSeq"], `第 ${i + 1} 条`);
+      exactKeys(
+        e,
+        ["seq", "ts", "author", "kind", "body", "supersedesSeq", "origin"],
+        `第 ${i + 1} 条`,
+      );
       if (!Number.isInteger(e.seq)) throw bad(`第 ${i + 1} 条的 seq 不是整数`);
       if (typeof e.ts !== "string") throw bad(`第 ${i + 1} 条的 ts 不是字符串`);
       if (typeof e.author !== "string") throw bad(`第 ${i + 1} 条的 author 不是字符串`);
@@ -729,6 +886,29 @@ export class FactLedger {
       if (typeof e.body !== "string") throw bad(`第 ${i + 1} 条的 body 不是字符串`);
       if (e.supersedesSeq !== null && !Number.isInteger(e.supersedesSeq)) {
         throw bad(`第 ${i + 1} 条的 supersedesSeq 既不是 null 也不是整数`);
+      }
+      // origin 印痕（C04）：审计字段坏了同样是坏档——落痕缺失或形状不对的
+      // 条目无法回答「谁署名写的」，不许静默凑合。
+      const origin = e.origin;
+      if (typeof origin !== "object" || origin === null || Array.isArray(origin)) {
+        throw bad(`第 ${i + 1} 条的 origin 不是对象`);
+      }
+      const o = origin as Record<string, unknown>;
+      if (o.kind === "viewport") {
+        exactKeys(o, ["kind", "viewportId", "generation"], `第 ${i + 1} 条的 origin`);
+        if (typeof o.viewportId !== "string") {
+          throw bad(`第 ${i + 1} 条 origin 的 viewportId 不是字符串`);
+        }
+        if (!Number.isInteger(o.generation)) {
+          throw bad(`第 ${i + 1} 条 origin 的 generation 不是整数`);
+        }
+      } else if (o.kind === "system") {
+        exactKeys(o, ["kind", "reason"], `第 ${i + 1} 条的 origin`);
+        if (typeof o.reason !== "string" || o.reason.trim() === "") {
+          throw bad(`第 ${i + 1} 条 origin 的 system reason 不是非空字符串——空署名等于没署名`);
+        }
+      } else {
+        throw bad(`第 ${i + 1} 条 origin 带着未知 kind=${String(o.kind)}`);
       }
     }
     if (!Array.isArray(record.viewports)) throw bad("viewports 不是数组");
@@ -821,3 +1001,59 @@ export class FactLedger {
     }
   }
 }
+
+/** SystemLedgerWriter 内里的特权写口——由 FactLedger.create() 在铸造时闭包交付。 */
+interface SystemRawWriter {
+  append(
+    residentId: string,
+    input: { author: string; kind: FactKind; body: string },
+    reason: string,
+  ): LedgerEntry;
+  supersede(
+    residentId: string,
+    targetSeq: number,
+    input: { author: string; reason: string },
+    reason: string,
+  ): LedgerEntry;
+}
+
+/**
+ * system 豁免的能力对象（上游 Elio 口径：豁免是可信宿主能力，不是任意
+ * 调用方自报的 kind=system）。类只导出类型不导出值，构造函数再验模块私有
+ * 铸造印——模块之外既 new 不出来也仿不出来；唯一出生点是 FactLedger.create()，
+ * 由组装层决定这份能力交到谁手里。
+ *
+ * 每次写入仍必须给出非空 reason（豁免必须显式署名），reason 与 author 并排
+ * 落进不可变账目（LedgerEntry.origin），归档查询可审计。
+ */
+class SystemLedgerWriter {
+  readonly #raw: SystemRawWriter;
+
+  constructor(brand: symbol, raw: SystemRawWriter) {
+    if (brand !== SYSTEM_WRITER_BRAND) {
+      throw new Error("SystemLedgerWriter 只能由 FactLedger.create() 铸出——能力不可伪造");
+    }
+    this.#raw = raw;
+  }
+
+  /** 以 system 身份落一条事实；reason = 这次豁免的署名，落痕进条目。 */
+  append(
+    residentId: string,
+    input: { author: string; kind: FactKind; body: string },
+    reason: string,
+  ): LedgerEntry {
+    return this.#raw.append(residentId, input, reason);
+  }
+
+  /** 以 system 身份解除一条事实；originReason 与条目 body 里的解除理由是两回事——前者答「凭什么豁免」，后者答「为什么解除」。 */
+  supersede(
+    residentId: string,
+    targetSeq: number,
+    input: { author: string; reason: string },
+    originReason: string,
+  ): LedgerEntry {
+    return this.#raw.supersede(residentId, targetSeq, input, originReason);
+  }
+}
+
+export type { SystemLedgerWriter };

--- a/tests/driver-ledger-wiring.test.ts
+++ b/tests/driver-ledger-wiring.test.ts
@@ -50,7 +50,11 @@ describe("F1 启动包与首窗 baseline 时序", () => {
     const pack = await driver.buildBootPack(residentId);
     expect(pack.currentFacts).toEqual([]);
 
-    ledger.append(residentId, { author: "main-thread", kind: "ruling", body: "占位裁定-包后" });
+    ledger.append(
+      residentId,
+      { author: "main-thread", kind: "ruling", body: "占位裁定-包后" },
+      { kind: "system", reason: "test" },
+    );
     await driver.say(residentId, "占位首句");
 
     expect(prompts[0]).toContain(
@@ -81,7 +85,11 @@ describe("F1 启动包与首窗 baseline 时序", () => {
     expect(ledger.has(residentId)).toBe(true);
     expect(ledger.latestSeq(residentId)).toBe(0);
 
-    ledger.append(residentId, { author: "main-thread", kind: "ruling", body: "占位裁定-包前" });
+    ledger.append(
+      residentId,
+      { author: "main-thread", kind: "ruling", body: "占位裁定-包前" },
+      { kind: "system", reason: "test" },
+    );
     const pack = await revived.buildBootPack(residentId);
     expect(pack.currentFacts?.map((entry) => entry.body)).toEqual(["占位裁定-包前"]);
 
@@ -101,11 +109,15 @@ describe("F1 启动包与首窗 baseline 时序", () => {
       },
     });
     const residentId = await driver.createResident("placeholder-f1c");
-    ledger.append(residentId, {
-      author: "main-thread",
-      kind: "ruling",
-      body: "占位裁定-say-first",
-    });
+    ledger.append(
+      residentId,
+      {
+        author: "main-thread",
+        kind: "ruling",
+        body: "占位裁定-say-first",
+      },
+      { kind: "system", reason: "test" },
+    );
 
     // 没开过包、没开过窗：say 懒开窗记 baseline=1 把缺口清零，但开窗不算
     // 交付——首轮开工注入必须把现行有效集交给模型，否则这条裁定永久失踪。
@@ -145,11 +157,15 @@ describe("F1 启动包与首窗 baseline 时序", () => {
     ledger.probeGap = realProbe;
     expect(events).toEqual([]);
 
-    ledger.append(residentId, {
-      author: "main-thread",
-      kind: "ruling",
-      body: "占位裁定-history-first",
-    });
+    ledger.append(
+      residentId,
+      {
+        author: "main-thread",
+        kind: "ruling",
+        body: "占位裁定-history-first",
+      },
+      { kind: "system", reason: "test" },
+    );
     const pack = await driver.buildBootPack(residentId);
     expect(pack.currentFacts?.map((entry) => entry.body)).toEqual(["占位裁定-history-first"]);
 
@@ -222,7 +238,11 @@ describe("F4 住户与账本生命周期原子性", () => {
     createDriver({ dataDir: residentsDir, factLedger: ledger1 });
     expect(ledger1.has(oldId)).toBe(true);
     expect(ledger1.latestSeq(oldId)).toBe(0);
-    ledger1.append(oldId, { author: "main-thread", kind: "ruling", body: "占位真账" });
+    ledger1.append(
+      oldId,
+      { author: "main-thread", kind: "ruling", body: "占位真账" },
+      { kind: "system", reason: "test" },
+    );
     ledger1.openViewport(oldId, "w_probe");
     ledger1.ack(oldId, "w_probe", 1);
 
@@ -293,7 +313,11 @@ describe("F4 住户与账本生命周期原子性", () => {
     const ledger = new FactLedger({ dataDir: factsDir });
     const driver = createDriver({ dataDir: residentsDir, factLedger: ledger });
     const residentId = await driver.createResident("placeholder-destroy-abort");
-    ledger.append(residentId, { author: "main-thread", kind: "ruling", body: "占位真账" });
+    ledger.append(
+      residentId,
+      { author: "main-thread", kind: "ruling", body: "占位真账" },
+      { kind: "system", reason: "test" },
+    );
 
     // facts.json 已删（prepare 成功）、住户快照删不动（第二步抛）→
     // abort 必须把账的文件写回去，两边都不许半删。
@@ -368,7 +392,11 @@ describe("F5 两个真实 MistDriver 共用 dataDir 与 FactLedger", () => {
     }
 
     // ack 各归各：A 窗 ack 一条 ruling，B 窗的确认位不动；反之亦然。
-    ledger.append(residentId, { author: "main-thread", kind: "ruling", body: "占位共享裁定" });
+    ledger.append(
+      residentId,
+      { author: "main-thread", kind: "ruling", body: "占位共享裁定" },
+      { kind: "system", reason: "test" },
+    );
     await driverA.say(residentId, "占位 A 窗第二句");
     expect(ledger.ackedSeq(residentId, windowA)).toBe(1);
     expect(ledger.ackedSeq(residentId, windowB)).toBe(0);
@@ -397,11 +425,15 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
 
     // reviseNode 懒开新窗：baseline 记在此刻，初始快照也冻结在此刻（空）。
     await driver.reviseNode(residentId, assistant.id, "占位改口");
-    ledger.append(residentId, {
-      author: "main-thread",
-      kind: "ruling",
-      body: "占位裁定-revise-first",
-    });
+    ledger.append(
+      residentId,
+      {
+        author: "main-thread",
+        kind: "ruling",
+        body: "占位裁定-revise-first",
+      },
+      { kind: "system", reason: "test" },
+    );
     await driver.say(residentId, "占位新窗首句");
 
     const prompt = prompts[prompts.length - 1];
@@ -425,11 +457,15 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
       },
     });
     const residentId = await driver.createResident("placeholder-supersede-timing");
-    ledger.append(residentId, {
-      author: "main-thread",
-      kind: "ruling",
-      body: "占位裁定-将被解除",
-    });
+    ledger.append(
+      residentId,
+      {
+        author: "main-thread",
+        kind: "ruling",
+        body: "占位裁定-将被解除",
+      },
+      { kind: "system", reason: "test" },
+    );
     // 第一扇窗先把 ruling 交付掉（初始对齐注入），拿到一个旧节点。
     await driver.say(residentId, "占位旧节点");
     const assistant = (await driver.history(residentId)).find((node) => node.role === "assistant");
@@ -439,7 +475,12 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
     // 新窗在 ruling 还活着时冻结快照；随后 ruling 被解除——现取 currentSet
     // 已经空了，但冻结快照里它还是原来的样子。
     await driver.reviseNode(residentId, assistant.id, "占位改口");
-    ledger.supersede(residentId, 1, { author: "main-thread", reason: "占位解除理由" });
+    ledger.supersede(
+      residentId,
+      1,
+      { author: "main-thread", reason: "占位解除理由" },
+      { kind: "system", reason: "test" },
+    );
     expect(ledger.currentSet(residentId)).toEqual([]);
     await driver.say(residentId, "占位新窗首句");
 
@@ -459,7 +500,11 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
     const ledger = new FactLedger();
     const driver = createDriver({ factLedger: ledger });
     const residentId = await driver.createResident("placeholder-bootpack-after-say");
-    ledger.append(residentId, { author: "main-thread", kind: "ruling", body: "占位裁定" });
+    ledger.append(
+      residentId,
+      { author: "main-thread", kind: "ruling", body: "占位裁定" },
+      { kind: "system", reason: "test" },
+    );
     await driver.say(residentId, "占位首句"); // 首轮注入即交付
 
     await expect(driver.buildBootPack(residentId)).rejects.toThrow(BootPackAlignmentError);
@@ -474,7 +519,11 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
     const ledger = new FactLedger();
     const driver = createDriver({ factLedger: ledger });
     const residentId = await driver.createResident("placeholder-bootpack-twice");
-    ledger.append(residentId, { author: "main-thread", kind: "ruling", body: "占位裁定" });
+    ledger.append(
+      residentId,
+      { author: "main-thread", kind: "ruling", body: "占位裁定" },
+      { kind: "system", reason: "test" },
+    );
 
     const pack = await driver.buildBootPack(residentId);
     expect(pack.currentFacts).toHaveLength(1);
@@ -493,7 +542,11 @@ describe("ResidentStore 与 FactLedger 同目录共存（阻塞二）", () => {
     store1.commit(residentId, "占位承诺");
     ledger1.createLedger(residentId);
     ledger1.openViewport(residentId, "w_probe");
-    ledger1.append(residentId, { author: "main-thread", kind: "ruling", body: "占位裁定" });
+    ledger1.append(
+      residentId,
+      { author: "main-thread", kind: "ruling", body: "占位裁定" },
+      { kind: "system", reason: "test" },
+    );
     ledger1.ack(residentId, "w_probe", 1);
 
     // 重启形态：两个存储从同一目录各自恢复——修复前 ResidentStore 会把

--- a/tests/driver-ledger-wiring.test.ts
+++ b/tests/driver-ledger-wiring.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 
 describe("F1 启动包与首窗 baseline 时序", () => {
   it("(a) bootpack 之后落的裁定走缺口通道：首轮 say 必须拉到，不永久漏", async () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     const events: TurnGateEvent[] = [];
     const prompts: string[] = [];
     const driver = createDriver({
@@ -50,10 +50,10 @@ describe("F1 启动包与首窗 baseline 时序", () => {
     const pack = await driver.buildBootPack(residentId);
     expect(pack.currentFacts).toEqual([]);
 
-    ledger.append(
+    system.append(
       residentId,
       { author: "main-thread", kind: "ruling", body: "占位裁定-包后" },
-      { kind: "system", reason: "test" },
+      "test",
     );
     await driver.say(residentId, "占位首句");
 
@@ -71,7 +71,7 @@ describe("F1 启动包与首窗 baseline 时序", () => {
     const legacy = createDriver({ dataDir: residentsDir });
     const residentId = await legacy.createResident("placeholder-f1b");
 
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     const prompts: string[] = [];
     const revived = createDriver({
       dataDir: residentsDir,
@@ -85,10 +85,10 @@ describe("F1 启动包与首窗 baseline 时序", () => {
     expect(ledger.has(residentId)).toBe(true);
     expect(ledger.latestSeq(residentId)).toBe(0);
 
-    ledger.append(
+    system.append(
       residentId,
       { author: "main-thread", kind: "ruling", body: "占位裁定-包前" },
-      { kind: "system", reason: "test" },
+      "test",
     );
     const pack = await revived.buildBootPack(residentId);
     expect(pack.currentFacts?.map((entry) => entry.body)).toEqual(["占位裁定-包前"]);
@@ -99,7 +99,7 @@ describe("F1 启动包与首窗 baseline 时序", () => {
   });
 
   it("(3) 账上有 ruling 时直接 say-first：首轮注入初始对齐的现行集，第二轮不重复", async () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     const prompts: string[] = [];
     const driver = createDriver({
       factLedger: ledger,
@@ -109,14 +109,14 @@ describe("F1 启动包与首窗 baseline 时序", () => {
       },
     });
     const residentId = await driver.createResident("placeholder-f1c");
-    ledger.append(
+    system.append(
       residentId,
       {
         author: "main-thread",
         kind: "ruling",
         body: "占位裁定-say-first",
       },
-      { kind: "system", reason: "test" },
+      "test",
     );
 
     // 没开过包、没开过窗：say 懒开窗记 baseline=1 把缺口清零，但开窗不算
@@ -132,7 +132,7 @@ describe("F1 启动包与首窗 baseline 时序", () => {
   });
 
   it("(4) history 不开窗：ruling 进包不进缺口，只出现一次", async () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     const events: TurnGateEvent[] = [];
     const prompts: string[] = [];
     const driver = createDriver({
@@ -157,14 +157,14 @@ describe("F1 启动包与首窗 baseline 时序", () => {
     ledger.probeGap = realProbe;
     expect(events).toEqual([]);
 
-    ledger.append(
+    system.append(
       residentId,
       {
         author: "main-thread",
         kind: "ruling",
         body: "占位裁定-history-first",
       },
-      { kind: "system", reason: "test" },
+      "test",
     );
     const pack = await driver.buildBootPack(residentId);
     expect(pack.currentFacts?.map((entry) => entry.body)).toEqual(["占位裁定-history-first"]);
@@ -179,7 +179,7 @@ describe("F1 启动包与首窗 baseline 时序", () => {
 describe("F4 住户与账本生命周期原子性", () => {
   it("createResident 开户失败回滚：住户、消息房、账都不留", async () => {
     const factsDir = freshDir();
-    const ledger = new FactLedger({ dataDir: factsDir });
+    const { ledger } = FactLedger.create({ dataDir: factsDir });
     const driver = createDriver({ factLedger: ledger });
 
     chmodSync(factsDir, 0o555);
@@ -200,7 +200,7 @@ describe("F4 住户与账本生命周期原子性", () => {
   });
 
   it("importResident 补账失败回滚导入件：住户、消息房都不留，同包可再导入", async () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     const driver = createDriver({ factLedger: ledger });
     const sourceId = await driver.createResident("placeholder-import-source");
     await driver.remember(sourceId, "占位记忆");
@@ -234,15 +234,11 @@ describe("F4 住户与账本生命周期原子性", () => {
     const oldId = await legacy.createResident("placeholder-old");
 
     // 第一次带账启动：老住户没有 facts.json，补一本空账。
-    const ledger1 = new FactLedger({ dataDir: factsDir });
+    const { ledger: ledger1, systemWriter: system1 } = FactLedger.create({ dataDir: factsDir });
     createDriver({ dataDir: residentsDir, factLedger: ledger1 });
     expect(ledger1.has(oldId)).toBe(true);
     expect(ledger1.latestSeq(oldId)).toBe(0);
-    ledger1.append(
-      oldId,
-      { author: "main-thread", kind: "ruling", body: "占位真账" },
-      { kind: "system", reason: "test" },
-    );
+    system1.append(oldId, { author: "main-thread", kind: "ruling", body: "占位真账" }, "test");
     ledger1.openViewport(oldId, "w_probe");
     ledger1.ack(oldId, "w_probe", 1);
 
@@ -257,7 +253,7 @@ describe("F4 住户与账本生命周期原子性", () => {
   it("destroyResident 同步销账：facts.json 不留、重启不诈尸、destroyLedger 幂等", async () => {
     const residentsDir = freshDir();
     const factsDir = freshDir();
-    const ledger = new FactLedger({ dataDir: factsDir });
+    const { ledger } = FactLedger.create({ dataDir: factsDir });
     const driver = createDriver({ dataDir: residentsDir, factLedger: ledger });
     const residentId = await driver.createResident("placeholder-destroy");
     expect(readdirSync(factsDir)).toEqual([`${residentId}.facts.json`]);
@@ -276,7 +272,7 @@ describe("F4 住户与账本生命周期原子性", () => {
   it("destroy 第一步失败（facts 目录不可写）：全在且可用，恢复后销得干净", async () => {
     const residentsDir = freshDir();
     const factsDir = freshDir();
-    const ledger = new FactLedger({ dataDir: factsDir });
+    const { ledger } = FactLedger.create({ dataDir: factsDir });
     const driver = createDriver({ dataDir: residentsDir, factLedger: ledger });
     const residentId = await driver.createResident("placeholder-destroy-fail");
     await driver.remember(residentId, "占位记忆");
@@ -310,14 +306,10 @@ describe("F4 住户与账本生命周期原子性", () => {
   it("destroy 第二步失败（住户档案删不掉）：账本文件被恢复，全在", async () => {
     const residentsDir = freshDir();
     const factsDir = freshDir();
-    const ledger = new FactLedger({ dataDir: factsDir });
+    const { ledger, systemWriter: system } = FactLedger.create({ dataDir: factsDir });
     const driver = createDriver({ dataDir: residentsDir, factLedger: ledger });
     const residentId = await driver.createResident("placeholder-destroy-abort");
-    ledger.append(
-      residentId,
-      { author: "main-thread", kind: "ruling", body: "占位真账" },
-      { kind: "system", reason: "test" },
-    );
+    system.append(residentId, { author: "main-thread", kind: "ruling", body: "占位真账" }, "test");
 
     // facts.json 已删（prepare 成功）、住户快照删不动（第二步抛）→
     // abort 必须把账的文件写回去，两边都不许半删。
@@ -337,7 +329,7 @@ describe("F4 住户与账本生命周期原子性", () => {
   });
 
   it("缺账住户的 destroy 不回归：prepare/finalize 都是 no-op，住户照销", async () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     const driver = createDriver({ factLedger: ledger });
     const residentId = await driver.createResident("placeholder-no-ledger");
     // 手工把账拆掉，造出「有住户没账」的缺账住户。
@@ -359,7 +351,7 @@ describe("F5 两个真实 MistDriver 共用 dataDir 与 FactLedger", () => {
         events.push(event);
       },
     };
-    const ledger = new FactLedger({ dataDir: factsDir });
+    const { ledger, systemWriter: system } = FactLedger.create({ dataDir: factsDir });
     const driverA = createDriver({
       dataDir: residentsDir,
       factLedger: ledger,
@@ -392,10 +384,10 @@ describe("F5 两个真实 MistDriver 共用 dataDir 与 FactLedger", () => {
     }
 
     // ack 各归各：A 窗 ack 一条 ruling，B 窗的确认位不动；反之亦然。
-    ledger.append(
+    system.append(
       residentId,
       { author: "main-thread", kind: "ruling", body: "占位共享裁定" },
-      { kind: "system", reason: "test" },
+      "test",
     );
     await driverA.say(residentId, "占位 A 窗第二句");
     expect(ledger.ackedSeq(residentId, windowA)).toBe(1);
@@ -408,7 +400,7 @@ describe("F5 两个真实 MistDriver 共用 dataDir 与 FactLedger", () => {
 
 describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）", () => {
   it("revise-first：开窗后落的 ruling 只经缺口出现一次，不标初始对齐", async () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     const prompts: string[] = [];
     const driver = createDriver({
       factLedger: ledger,
@@ -425,14 +417,14 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
 
     // reviseNode 懒开新窗：baseline 记在此刻，初始快照也冻结在此刻（空）。
     await driver.reviseNode(residentId, assistant.id, "占位改口");
-    ledger.append(
+    system.append(
       residentId,
       {
         author: "main-thread",
         kind: "ruling",
         body: "占位裁定-revise-first",
       },
-      { kind: "system", reason: "test" },
+      "test",
     );
     await driver.say(residentId, "占位新窗首句");
 
@@ -447,7 +439,7 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
   });
 
   it("开窗已有 ruling、首轮交付前被 supersede：快照保住原 ruling，按序看到事实→解除", async () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     const prompts: string[] = [];
     const driver = createDriver({
       factLedger: ledger,
@@ -457,14 +449,14 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
       },
     });
     const residentId = await driver.createResident("placeholder-supersede-timing");
-    ledger.append(
+    system.append(
       residentId,
       {
         author: "main-thread",
         kind: "ruling",
         body: "占位裁定-将被解除",
       },
-      { kind: "system", reason: "test" },
+      "test",
     );
     // 第一扇窗先把 ruling 交付掉（初始对齐注入），拿到一个旧节点。
     await driver.say(residentId, "占位旧节点");
@@ -475,12 +467,7 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
     // 新窗在 ruling 还活着时冻结快照；随后 ruling 被解除——现取 currentSet
     // 已经空了，但冻结快照里它还是原来的样子。
     await driver.reviseNode(residentId, assistant.id, "占位改口");
-    ledger.supersede(
-      residentId,
-      1,
-      { author: "main-thread", reason: "占位解除理由" },
-      { kind: "system", reason: "test" },
-    );
+    system.supersede(residentId, 1, { author: "main-thread", reason: "占位解除理由" }, "test");
     expect(ledger.currentSet(residentId)).toEqual([]);
     await driver.say(residentId, "占位新窗首句");
 
@@ -497,14 +484,10 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
   });
 
   it("say-first 交付后再 buildBootPack：显式抛 BootPackAlignmentError", async () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     const driver = createDriver({ factLedger: ledger });
     const residentId = await driver.createResident("placeholder-bootpack-after-say");
-    ledger.append(
-      residentId,
-      { author: "main-thread", kind: "ruling", body: "占位裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append(residentId, { author: "main-thread", kind: "ruling", body: "占位裁定" }, "test");
     await driver.say(residentId, "占位首句"); // 首轮注入即交付
 
     await expect(driver.buildBootPack(residentId)).rejects.toThrow(BootPackAlignmentError);
@@ -516,14 +499,10 @@ describe("初始对齐 exactly-once（冻结快照语义，四轮复核反例）
   });
 
   it("bootpack-first（正常交付）后再 buildBootPack：同样显式抛", async () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     const driver = createDriver({ factLedger: ledger });
     const residentId = await driver.createResident("placeholder-bootpack-twice");
-    ledger.append(
-      residentId,
-      { author: "main-thread", kind: "ruling", body: "占位裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append(residentId, { author: "main-thread", kind: "ruling", body: "占位裁定" }, "test");
 
     const pack = await driver.buildBootPack(residentId);
     expect(pack.currentFacts).toHaveLength(1);
@@ -536,17 +515,13 @@ describe("ResidentStore 与 FactLedger 同目录共存（阻塞二）", () => {
   it("联合往返：两边各自认领各自的后缀，互不吞档", () => {
     const dir = freshDir();
     const store1 = new ResidentStore({ dataDir: dir });
-    const ledger1 = new FactLedger({ dataDir: dir });
+    const { ledger: ledger1, systemWriter: system1 } = FactLedger.create({ dataDir: dir });
     const residentId = store1.createResident("placeholder-shared-dir");
     store1.remember(residentId, "占位记忆");
     store1.commit(residentId, "占位承诺");
     ledger1.createLedger(residentId);
     ledger1.openViewport(residentId, "w_probe");
-    ledger1.append(
-      residentId,
-      { author: "main-thread", kind: "ruling", body: "占位裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system1.append(residentId, { author: "main-thread", kind: "ruling", body: "占位裁定" }, "test");
     ledger1.ack(residentId, "w_probe", 1);
 
     // 重启形态：两个存储从同一目录各自恢复——修复前 ResidentStore 会把

--- a/tests/fact-ledger.test.ts
+++ b/tests/fact-ledger.test.ts
@@ -45,9 +45,21 @@ describe("发号与 append-only", () => {
   it("seq 由账侧发号，从 1 起单调递增", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    const a = ledger.append("r", { author: "main", kind: "ruling", body: "第一条" });
-    const b = ledger.append("r", { author: "main", kind: "active_rule", body: "第二条" });
-    const c = ledger.append("r", { author: "main", kind: "confirmed_preference", body: "第三条" });
+    const a = ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "第一条" },
+      { kind: "system", reason: "test" },
+    );
+    const b = ledger.append(
+      "r",
+      { author: "main", kind: "active_rule", body: "第二条" },
+      { kind: "system", reason: "test" },
+    );
+    const c = ledger.append(
+      "r",
+      { author: "main", kind: "confirmed_preference", body: "第三条" },
+      { kind: "system", reason: "test" },
+    );
     expect([a.seq, b.seq, c.seq]).toEqual([1, 2, 3]);
     expect(ledger.latestSeq("r")).toBe(3);
   });
@@ -65,18 +77,26 @@ describe("发号与 append-only", () => {
     // 运行时校验给绕过类型系统的调用方：没有 supersedesSeq 指针的「解除」
     // 会毒化推导视图，必须当场炸。
     expect(() =>
-      ledger.append("r", {
-        author: "main",
-        kind: "supersede" as never,
-        body: "伪装成事实的解除",
-      }),
+      ledger.append(
+        "r",
+        {
+          author: "main",
+          kind: "supersede" as never,
+          body: "伪装成事实的解除",
+        },
+        { kind: "system", reason: "test" },
+      ),
     ).toThrow(/supersede\(\)/);
   });
 
   it("拿到的是副本，改返回值涂改不了账", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    const appended = ledger.append("r", { author: "main", kind: "ruling", body: "原话" });
+    const appended = ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "原话" },
+      { kind: "system", reason: "test" },
+    );
     (appended as { body: string }).body = "涂改后的假话";
     const listed = ledger.entries("r");
     (listed[0] as { body: string }).body = "又一次涂改";
@@ -86,7 +106,11 @@ describe("发号与 append-only", () => {
   it("账面条目在运行时是冻结的", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "正文" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "正文" },
+      { kind: "system", reason: "test" },
+    );
     // entries() 返回副本，这里直接探账内引用做不到——但 append 的返回
     // 与账内条目同形，冻结行为用恢复路径间接验（持久化一节）。
     // 这里至少保证：账侧给出的任何条目形状都带齐六字段。
@@ -103,9 +127,29 @@ describe("发号与 append-only", () => {
   it("重复开户显式报错，不静默重置", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "不能丢" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "不能丢" },
+      { kind: "system", reason: "test" },
+    );
     expect(() => ledger.createLedger("r")).toThrow(/already exists/);
     expect(ledger.latestSeq("r")).toBe(1);
+  });
+
+  // C04（渡渡家内审 P1）：豁免必须显式署名，不是缺省得到。system 来源
+  // 空 reason 不算署名——拒收，且账上零多写。origin 省略在类型层已是编译
+  // 错误，这里钉的是运行期「空署名等于没署名」这一半。
+  it("system 来源空 reason 被拒，账上不多写", () => {
+    const ledger = new FactLedger();
+    ledger.createLedger("r");
+    expect(() =>
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "无名豁免" },
+        { kind: "system", reason: "  " },
+      ),
+    ).toThrow(/non-empty reason/);
+    expect(ledger.latestSeq("r")).toBe(0);
   });
 });
 
@@ -113,9 +157,18 @@ describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
   it("解除后旧条目字节不变", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "周六一起去图书馆" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "周六一起去图书馆" },
+      { kind: "system", reason: "test" },
+    );
     const before = JSON.stringify(ledger.entries("r")[0]);
-    ledger.supersede("r", 1, { author: "main", reason: "她改成周日了" });
+    ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "她改成周日了" },
+      { kind: "system", reason: "test" },
+    );
     const after = JSON.stringify(ledger.entries("r")[0]);
     expect(after).toBe(before);
   });
@@ -123,9 +176,22 @@ describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
   it("解除是一条自带序号的新账目，supersedesSeq 指旧 seq", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "旧裁定" });
-    ledger.append("r", { author: "main", kind: "active_rule", body: "夹在中间的规矩" });
-    const s = ledger.supersede("r", 1, { author: "main", reason: "解除旧裁定" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "旧裁定" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.append(
+      "r",
+      { author: "main", kind: "active_rule", body: "夹在中间的规矩" },
+      { kind: "system", reason: "test" },
+    );
+    const s = ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "解除旧裁定" },
+      { kind: "system", reason: "test" },
+    );
     expect(s.seq).toBe(3);
     expect(s.kind).toBe("supersede");
     expect(s.supersedesSeq).toBe(1);
@@ -138,8 +204,17 @@ describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
   it("现行有效集不再含被解除的条目", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "旧裁定" });
-    ledger.supersede("r", 1, { author: "main", reason: "解除" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "旧裁定" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "解除" },
+      { kind: "system", reason: "test" },
+    );
     expect(ledger.currentSet("r")).toEqual([]);
     // 但归档查询仍能追到它——「曾被解除的条目」本身是可查事实。
     expect(ledger.entries("r")).toHaveLength(2);
@@ -148,10 +223,19 @@ describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
   it("已 ack 旧条目的窗，下一轮经缺口通道可见该解除", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "旧裁定" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "旧裁定" },
+      { kind: "system", reason: "test" },
+    );
     ledger.openViewport("r", "w-a");
     ledger.ack("r", "w-a", 1); // 窗已确认旧裁定
-    const s = ledger.supersede("r", 1, { author: "main", reason: "解除" });
+    const s = ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "解除" },
+      { kind: "system", reason: "test" },
+    );
     // 已 ack ≠ 仍然有效：解除经同一条缺口通道送达。
     const missing = ledger.gapEntries("r", "w-a");
     expect(missing).toHaveLength(1);
@@ -162,44 +246,85 @@ describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
   it("解除不存在的 seq 报错", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "只有一条" });
-    expect(() => ledger.supersede("r", 2, { author: "main", reason: "x" })).toThrow(
-      LedgerEntryNotFoundError,
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "只有一条" },
+      { kind: "system", reason: "test" },
     );
-    expect(() => ledger.supersede("r", 0, { author: "main", reason: "x" })).toThrow(
-      LedgerEntryNotFoundError,
-    );
+    expect(() =>
+      ledger.supersede("r", 2, { author: "main", reason: "x" }, { kind: "system", reason: "test" }),
+    ).toThrow(LedgerEntryNotFoundError);
+    expect(() =>
+      ledger.supersede("r", 0, { author: "main", reason: "x" }, { kind: "system", reason: "test" }),
+    ).toThrow(LedgerEntryNotFoundError);
   });
 
   it("不能解除一条 supersede", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
-    ledger.supersede("r", 1, { author: "main", reason: "解除" });
-    expect(() => ledger.supersede("r", 2, { author: "main", reason: "解除那条解除" })).toThrow(
-      InvalidSupersedeError,
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定" },
+      { kind: "system", reason: "test" },
     );
+    ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "解除" },
+      { kind: "system", reason: "test" },
+    );
+    expect(() =>
+      ledger.supersede(
+        "r",
+        2,
+        { author: "main", reason: "解除那条解除" },
+        { kind: "system", reason: "test" },
+      ),
+    ).toThrow(InvalidSupersedeError);
   });
 
   it("重复解除同一条显式报错", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
-    ledger.supersede("r", 1, { author: "main", reason: "第一次解除" });
-    // 静默放行会把「操作方以为还没解除过」藏起来。
-    expect(() => ledger.supersede("r", 1, { author: "main", reason: "第二次解除" })).toThrow(
-      /already superseded/,
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定" },
+      { kind: "system", reason: "test" },
     );
+    ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "第一次解除" },
+      { kind: "system", reason: "test" },
+    );
+    // 静默放行会把「操作方以为还没解除过」藏起来。
+    expect(() =>
+      ledger.supersede(
+        "r",
+        1,
+        { author: "main", reason: "第二次解除" },
+        { kind: "system", reason: "test" },
+      ),
+    ).toThrow(/already superseded/);
   });
 
   it("跨住户解除报错，且那本账毫发无损", () => {
     const ledger = new FactLedger();
     ledger.createLedger("a");
     ledger.createLedger("b");
-    ledger.append("a", { author: "main", kind: "ruling", body: "A 的裁定" });
-    expect(() => ledger.supersede("b", 1, { author: "main", reason: "B 想解除 A 的" })).toThrow(
-      LedgerEntryNotFoundError,
+    ledger.append(
+      "a",
+      { author: "main", kind: "ruling", body: "A 的裁定" },
+      { kind: "system", reason: "test" },
     );
+    expect(() =>
+      ledger.supersede(
+        "b",
+        1,
+        { author: "main", reason: "B 想解除 A 的" },
+        { kind: "system", reason: "test" },
+      ),
+    ).toThrow(LedgerEntryNotFoundError);
     expect(ledger.entries("a")).toHaveLength(1);
     expect(ledger.currentSet("a")).toHaveLength(1);
   });
@@ -209,9 +334,21 @@ describe("现行有效集是推导视图", () => {
   it("同一种 kind 多条并行生效是常态（2026-08-20 主笔拍板的新语义）", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定一" });
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定二" });
-    ledger.append("r", { author: "main", kind: "active_rule", body: "规矩一" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定一" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定二" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.append(
+      "r",
+      { author: "main", kind: "active_rule", body: "规矩一" },
+      { kind: "system", reason: "test" },
+    );
     // 不是「每条 kind 的最新一条」——未被指名的全部现行，按 seq 升序。
     const current = ledger.currentSet("r");
     expect(current.map((e) => e.body)).toEqual(["裁定一", "裁定二", "规矩一"]);
@@ -220,30 +357,74 @@ describe("现行有效集是推导视图", () => {
   it("supersede 精确指向单条：解除两条并行 ruling 中的一条，另一条仍在", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定一" });
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定二" });
-    ledger.supersede("r", 2, { author: "main", reason: "只解除裁定二" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定一" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定二" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.supersede(
+      "r",
+      2,
+      { author: "main", reason: "只解除裁定二" },
+      { kind: "system", reason: "test" },
+    );
     expect(ledger.currentSet("r").map((e) => e.body)).toEqual(["裁定一"]);
     // 不存在「回退」——裁定一自始至终都在集里，不是被解除后重新浮上来的。
-    ledger.supersede("r", 1, { author: "main", reason: "解除裁定一" });
+    ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "解除裁定一" },
+      { kind: "system", reason: "test" },
+    );
     expect(ledger.currentSet("r")).toEqual([]);
   });
 
   it("解除一条不影响其他 kind 的并行条目", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定一" });
-    ledger.append("r", { author: "main", kind: "active_rule", body: "规矩一" });
-    ledger.append("r", { author: "main", kind: "confirmed_preference", body: "偏好一" });
-    ledger.supersede("r", 1, { author: "main", reason: "只解除裁定一" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定一" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.append(
+      "r",
+      { author: "main", kind: "active_rule", body: "规矩一" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.append(
+      "r",
+      { author: "main", kind: "confirmed_preference", body: "偏好一" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "只解除裁定一" },
+      { kind: "system", reason: "test" },
+    );
     expect(ledger.currentSet("r").map((e) => e.body)).toEqual(["规矩一", "偏好一"]);
   });
 
   it("supersede 条目自身不是事实，不进现行有效集", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定一" });
-    ledger.supersede("r", 1, { author: "main", reason: "解除" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定一" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.supersede(
+      "r",
+      1,
+      { author: "main", reason: "解除" },
+      { kind: "system", reason: "test" },
+    );
     // 集是空的——解除记录留在全史里查（entries），不冒充一条现行事实。
     expect(ledger.currentSet("r")).toEqual([]);
     expect(ledger.entries("r")).toHaveLength(2);
@@ -252,7 +433,11 @@ describe("现行有效集是推导视图", () => {
   it("视图拿到的是副本，改它毒化不了账", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
-    ledger.append("r", { author: "main", kind: "ruling", body: "现行裁定" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "现行裁定" },
+      { kind: "system", reason: "test" },
+    );
     const view = ledger.currentSet("r");
     (view[0] as { body: string }).body = "毒化";
     expect(ledger.currentSet("r")[0]?.body).toBe("现行裁定");
@@ -264,7 +449,11 @@ describe("新窗 baseline（MV-A05 账侧）", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
     for (let i = 0; i < 50; i += 1) {
-      ledger.append("r", { author: "main", kind: "ruling", body: `历史裁定 ${i + 1}` });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: `历史裁定 ${i + 1}` },
+        { kind: "system", reason: "test" },
+      );
     }
     const baseline = ledger.openViewport("r", "w-new");
     expect(baseline).toBe(50);
@@ -291,7 +480,11 @@ describe("新窗 baseline（MV-A05 账侧）", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
     for (let i = 0; i < 50; i += 1) {
-      ledger.append("r", { author: "main", kind: "ruling", body: `历史裁定 ${i + 1}` });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: `历史裁定 ${i + 1}` },
+        { kind: "system", reason: "test" },
+      );
     }
     ledger.openViewport("r", "w-new");
     // 新窗不背全史 ≠ 历史不可达：归档查询是另一条路。
@@ -305,7 +498,11 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
     ledger.openViewport("r", "w-b");
-    const ruling = ledger.append("r", { author: "main", kind: "ruling", body: "新裁定" });
+    const ruling = ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "新裁定" },
+      { kind: "system", reason: "test" },
+    );
     // 无推送通道，拉是唯一正确性来源——账侧只有拉与回执两个动作（C02 的落点）。
     expect(ledger.gap("r", "w-b")).toEqual({ latestSeq: 1, ackedSeq: 0 });
     const missing = ledger.gapEntries("r", "w-b");
@@ -320,7 +517,11 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
     ledger.openViewport("r", "w-b");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定" },
+      { kind: "system", reason: "test" },
+    );
     ledger.ack("r", "w-a", 1);
     expect(ledger.gap("r", "w-a").ackedSeq).toBe(1);
     expect(ledger.gap("r", "w-b").ackedSeq).toBe(0);
@@ -331,7 +532,11 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定" },
+      { kind: "system", reason: "test" },
+    );
     // 回执丢失 = ack 从未到账：账上不存在「已知悉」的痕迹，也没有「违约」标记——
     // 传播机制的账不算窗的（C05）。窗重拉，缺口条目还在，补 ack 即闭合。
     expect(ledger.gapEntries("r", "w-a")).toHaveLength(1);
@@ -343,7 +548,11 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定" },
+      { kind: "system", reason: "test" },
+    );
     ledger.ack("r", "w-a", 1);
     expect(() => ledger.ack("r", "w-a", 1)).not.toThrow();
     expect(ledger.ackedSeq("r", "w-a")).toBe(1);
@@ -353,8 +562,16 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
-    ledger.append("r", { author: "main", kind: "ruling", body: "一" });
-    ledger.append("r", { author: "main", kind: "ruling", body: "二" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "一" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "二" },
+      { kind: "system", reason: "test" },
+    );
     ledger.ack("r", "w-a", 2);
     expect(() => ledger.ack("r", "w-a", 1)).toThrow(AckError);
     expect(ledger.ackedSeq("r", "w-a")).toBe(2);
@@ -364,7 +581,11 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
     const ledger = new FactLedger();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
-    ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
+    ledger.append(
+      "r",
+      { author: "main", kind: "ruling", body: "裁定" },
+      { kind: "system", reason: "test" },
+    );
     expect(() => ledger.ack("r", "w-a", 2)).toThrow(AckError);
     expect(() => ledger.ack("r", "w-a", -1)).toThrow(AckError);
   });
@@ -480,9 +701,13 @@ describe("住户隔离", () => {
   it("跨住户读写一律抛 LedgerNotFoundError", () => {
     const ledger = new FactLedger();
     ledger.createLedger("a");
-    expect(() => ledger.append("b", { author: "main", kind: "ruling", body: "x" })).toThrow(
-      LedgerNotFoundError,
-    );
+    expect(() =>
+      ledger.append(
+        "b",
+        { author: "main", kind: "ruling", body: "x" },
+        { kind: "system", reason: "test" },
+      ),
+    ).toThrow(LedgerNotFoundError);
     expect(() => ledger.entries("b")).toThrow(LedgerNotFoundError);
     expect(() => ledger.currentSet("b")).toThrow(LedgerNotFoundError);
     expect(() => ledger.openViewport("b", "w-x")).toThrow(LedgerNotFoundError);
@@ -493,11 +718,19 @@ describe("住户隔离", () => {
     const ledger = new FactLedger();
     ledger.createLedger("a");
     ledger.createLedger("b");
-    ledger.append("a", { author: "main", kind: "ruling", body: "A 的秘密裁定" });
+    ledger.append(
+      "a",
+      { author: "main", kind: "ruling", body: "A 的秘密裁定" },
+      { kind: "system", reason: "test" },
+    );
     expect(ledger.latestSeq("a")).toBe(1);
     expect(ledger.latestSeq("b")).toBe(0);
     expect(ledger.entries("b")).toEqual([]);
-    const bFirst = ledger.append("b", { author: "main", kind: "ruling", body: "B 的第一条" });
+    const bFirst = ledger.append(
+      "b",
+      { author: "main", kind: "ruling", body: "B 的第一条" },
+      { kind: "system", reason: "test" },
+    );
     expect(bFirst.seq).toBe(1);
   });
 });
@@ -507,17 +740,34 @@ describe("持久化", () => {
     withTempDir((dataDir) => {
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("r");
-      ledger.append("r", { author: "main", kind: "ruling", body: "裁定一" });
-      ledger.append("r", { author: "main", kind: "active_rule", body: "规矩一" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "裁定一" },
+        { kind: "system", reason: "test" },
+      );
+      ledger.append(
+        "r",
+        { author: "main", kind: "active_rule", body: "规矩一" },
+        { kind: "system", reason: "test" },
+      );
       ledger.openViewport("r", "w-a"); // baseline=2，窗已对齐到规矩一
-      ledger.supersede("r", 1, { author: "main", reason: "解除裁定一" });
+      ledger.supersede(
+        "r",
+        1,
+        { author: "main", reason: "解除裁定一" },
+        { kind: "system", reason: "test" },
+      );
 
       const restored = new FactLedger({ dataDir });
       expect(restored.entries("r")).toEqual(ledger.entries("r"));
       expect(restored.gap("r", "w-a")).toEqual({ latestSeq: 3, ackedSeq: 2 });
       expect(restored.gapEntries("r", "w-a").map((e) => e.kind)).toEqual(["supersede"]);
       expect(restored.currentSet("r").map((e) => e.body)).toEqual(["规矩一"]);
-      const next = restored.append("r", { author: "main", kind: "ruling", body: "裁定二" });
+      const next = restored.append(
+        "r",
+        { author: "main", kind: "ruling", body: "裁定二" },
+        { kind: "system", reason: "test" },
+      );
       expect(next.seq).toBe(4);
     });
   });
@@ -528,16 +778,46 @@ describe("持久化", () => {
       // 在线 append 松（同型事故），视图推导也可能在两条路径上悄悄分叉。
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("r");
-      ledger.append("r", { author: "main", kind: "ruling", body: "裁定一" });
-      ledger.append("r", { author: "main", kind: "ruling", body: "裁定二" });
-      ledger.append("r", { author: "main", kind: "active_rule", body: "规矩一" });
-      ledger.append("r", { author: "main", kind: "confirmed_preference", body: "偏好一" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "裁定一" },
+        { kind: "system", reason: "test" },
+      );
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "裁定二" },
+        { kind: "system", reason: "test" },
+      );
+      ledger.append(
+        "r",
+        { author: "main", kind: "active_rule", body: "规矩一" },
+        { kind: "system", reason: "test" },
+      );
+      ledger.append(
+        "r",
+        { author: "main", kind: "confirmed_preference", body: "偏好一" },
+        { kind: "system", reason: "test" },
+      );
       ledger.openViewport("r", "w-1"); // baseline=4
       ledger.ack("r", "w-1", 4);
-      ledger.supersede("r", 2, { author: "main", reason: "只解除裁定二" });
-      ledger.supersede("r", 4, { author: "main", reason: "偏好一作废——这个 kind 全解除" });
+      ledger.supersede(
+        "r",
+        2,
+        { author: "main", reason: "只解除裁定二" },
+        { kind: "system", reason: "test" },
+      );
+      ledger.supersede(
+        "r",
+        4,
+        { author: "main", reason: "偏好一作废——这个 kind 全解除" },
+        { kind: "system", reason: "test" },
+      );
       ledger.openViewport("r", "w-2"); // baseline=6
-      ledger.append("r", { author: "main", kind: "active_rule", body: "规矩二" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "active_rule", body: "规矩二" },
+        { kind: "system", reason: "test" },
+      );
 
       // 在线取一次，落盘后新实例再取一次，深比较相等。
       const restored = new FactLedger({ dataDir });
@@ -558,7 +838,11 @@ describe("持久化", () => {
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("a");
       ledger.createLedger("b");
-      ledger.append("a", { author: "main", kind: "ruling", body: "A 的" });
+      ledger.append(
+        "a",
+        { author: "main", kind: "ruling", body: "A 的" },
+        { kind: "system", reason: "test" },
+      );
       const restored = new FactLedger({ dataDir });
       expect(restored.latestSeq("a")).toBe(1);
       expect(restored.latestSeq("b")).toBe(0);
@@ -798,12 +1082,20 @@ describe("持久化", () => {
     withTempDir((dataDir) => {
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("r");
-      ledger.append("r", { author: "main", kind: "ruling", body: "已落盘" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "已落盘" },
+        { kind: "system", reason: "test" },
+      );
       writeFileSync(join(dataDir, "r.facts.json.tmp"), "没写完的一次写入");
       const restored = new FactLedger({ dataDir });
       expect(restored.latestSeq("r")).toBe(1);
       // 下一次写入覆盖残留。
-      restored.append("r", { author: "main", kind: "ruling", body: "二" });
+      restored.append(
+        "r",
+        { author: "main", kind: "ruling", body: "二" },
+        { kind: "system", reason: "test" },
+      );
       expect(readFileSync(join(dataDir, "r.facts.json"), "utf8")).toContain("二");
     });
   });
@@ -812,7 +1104,11 @@ describe("持久化", () => {
     withTempDir((dataDir) => {
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("r");
-      ledger.append("r", { author: "main", kind: "ruling", body: "正文" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "正文" },
+        { kind: "system", reason: "test" },
+      );
       const restored = new FactLedger({ dataDir });
       const copy = restored.entries("r");
       (copy[0] as { body: string }).body = "涂改";
@@ -839,16 +1135,30 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
     withTempDir((dataDir) => {
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("r");
-      ledger.append("r", { author: "main", kind: "ruling", body: "一" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "一" },
+        { kind: "system", reason: "test" },
+      );
       whileReadonly(dataDir, () => {
-        expect(() => ledger.append("r", { author: "main", kind: "ruling", body: "二" })).toThrow();
+        expect(() =>
+          ledger.append(
+            "r",
+            { author: "main", kind: "ruling", body: "二" },
+            { kind: "system", reason: "test" },
+          ),
+        ).toThrow();
         expect(ledger.latestSeq("r")).toBe(1);
         expect(ledger.entries("r").map((e) => e.body)).toEqual(["一"]);
       });
       // 盘上也没多：新实例读到的和内存一致。
       expect(new FactLedger({ dataDir }).entries("r")).toHaveLength(1);
       // 恢复可写后追加成功，seq 连续——失败没有吃掉序号。
-      const entry = ledger.append("r", { author: "main", kind: "ruling", body: "二" });
+      const entry = ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "二" },
+        { kind: "system", reason: "test" },
+      );
       expect(entry.seq).toBe(2);
     });
   });
@@ -857,9 +1167,20 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
     withTempDir((dataDir) => {
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("r");
-      ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "裁定" },
+        { kind: "system", reason: "test" },
+      );
       whileReadonly(dataDir, () => {
-        expect(() => ledger.supersede("r", 1, { author: "main", reason: "解除" })).toThrow();
+        expect(() =>
+          ledger.supersede(
+            "r",
+            1,
+            { author: "main", reason: "解除" },
+            { kind: "system", reason: "test" },
+          ),
+        ).toThrow();
         // 这是故障注入打过的洞：旧实现先 push 再落盘，失败后全史多一条
         // supersede 而 supersededSeqs 没更新，currentSet 与全史自相矛盾。
         // 现在必须是干净的「什么都没发生」。
@@ -867,7 +1188,12 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
         expect(ledger.currentSet("r").map((e) => e.body)).toEqual(["裁定"]);
       });
       // 恢复可写后同一次解除能正常完成。
-      ledger.supersede("r", 1, { author: "main", reason: "解除" });
+      ledger.supersede(
+        "r",
+        1,
+        { author: "main", reason: "解除" },
+        { kind: "system", reason: "test" },
+      );
       expect(ledger.currentSet("r")).toEqual([]);
     });
   });
@@ -876,7 +1202,11 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
     withTempDir((dataDir) => {
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("r");
-      ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "裁定" },
+        { kind: "system", reason: "test" },
+      );
       whileReadonly(dataDir, () => {
         expect(() => ledger.openViewport("r", "w-a")).toThrow();
         expect(() => ledger.gap("r", "w-a")).toThrow(ViewportNotFoundError);
@@ -890,7 +1220,11 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
       const ledger = new FactLedger({ dataDir });
       ledger.createLedger("r");
       ledger.openViewport("r", "w-a");
-      ledger.append("r", { author: "main", kind: "ruling", body: "裁定" });
+      ledger.append(
+        "r",
+        { author: "main", kind: "ruling", body: "裁定" },
+        { kind: "system", reason: "test" },
+      );
       whileReadonly(dataDir, () => {
         expect(() => ledger.ack("r", "w-a", 1)).toThrow();
         expect(ledger.ackedSeq("r", "w-a")).toBe(0);

--- a/tests/fact-ledger.test.ts
+++ b/tests/fact-ledger.test.ts
@@ -20,6 +20,7 @@ import {
   LedgerEntryNotFoundError,
   LedgerNotFoundError,
   ViewportNotFoundError,
+  WriteGateUnavailableError,
 } from "../src/store/fact-ledger.ts";
 
 function withTempDir(run: (dataDir: string) => void): void {
@@ -43,60 +44,48 @@ function whileReadonly(dataDir: string, run: () => void): void {
 
 describe("发号与 append-only", () => {
   it("seq 由账侧发号，从 1 起单调递增", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    const a = ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "第一条" },
-      { kind: "system", reason: "test" },
-    );
-    const b = ledger.append(
-      "r",
-      { author: "main", kind: "active_rule", body: "第二条" },
-      { kind: "system", reason: "test" },
-    );
-    const c = ledger.append(
+    const a = system.append("r", { author: "main", kind: "ruling", body: "第一条" }, "test");
+    const b = system.append("r", { author: "main", kind: "active_rule", body: "第二条" }, "test");
+    const c = system.append(
       "r",
       { author: "main", kind: "confirmed_preference", body: "第三条" },
-      { kind: "system", reason: "test" },
+      "test",
     );
     expect([a.seq, b.seq, c.seq]).toEqual([1, 2, 3]);
     expect(ledger.latestSeq("r")).toBe(3);
   });
 
   it("空账 latestSeq 为 0", () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     ledger.createLedger("r");
     expect(ledger.latestSeq("r")).toBe(0);
     expect(ledger.entries("r")).toEqual([]);
   });
 
   it("append 不收 supersede——解除只能走 supersede()", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     // 运行时校验给绕过类型系统的调用方：没有 supersedesSeq 指针的「解除」
     // 会毒化推导视图，必须当场炸。
     expect(() =>
-      ledger.append(
+      system.append(
         "r",
         {
           author: "main",
           kind: "supersede" as never,
           body: "伪装成事实的解除",
         },
-        { kind: "system", reason: "test" },
+        "test",
       ),
     ).toThrow(/supersede\(\)/);
   });
 
   it("拿到的是副本，改返回值涂改不了账", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    const appended = ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "原话" },
-      { kind: "system", reason: "test" },
-    );
+    const appended = system.append("r", { author: "main", kind: "ruling", body: "原话" }, "test");
     (appended as { body: string }).body = "涂改后的假话";
     const listed = ledger.entries("r");
     (listed[0] as { body: string }).body = "又一次涂改";
@@ -104,16 +93,12 @@ describe("发号与 append-only", () => {
   });
 
   it("账面条目在运行时是冻结的", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "正文" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "正文" }, "test");
     // entries() 返回副本，这里直接探账内引用做不到——但 append 的返回
     // 与账内条目同形，冻结行为用恢复路径间接验（持久化一节）。
-    // 这里至少保证：账侧给出的任何条目形状都带齐六字段。
+    // 这里至少保证：账侧给出的任何条目形状都带齐七字段（含 origin 印痕）。
     expect(ledger.entries("r")[0]).toEqual({
       seq: 1,
       ts: expect.any(String),
@@ -121,17 +106,14 @@ describe("发号与 append-only", () => {
       kind: "ruling",
       body: "正文",
       supersedesSeq: null,
+      origin: { kind: "system", reason: "test" },
     });
   });
 
   it("重复开户显式报错，不静默重置", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "不能丢" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "不能丢" }, "test");
     expect(() => ledger.createLedger("r")).toThrow(/already exists/);
     expect(ledger.latestSeq("r")).toBe(1);
   });
@@ -140,14 +122,10 @@ describe("发号与 append-only", () => {
   // 空 reason 不算署名——拒收，且账上零多写。origin 省略在类型层已是编译
   // 错误，这里钉的是运行期「空署名等于没署名」这一半。
   it("system 来源空 reason 被拒，账上不多写", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     expect(() =>
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "无名豁免" },
-        { kind: "system", reason: "  " },
-      ),
+      system.append("r", { author: "main", kind: "ruling", body: "无名豁免" }, "  "),
     ).toThrow(/non-empty reason/);
     expect(ledger.latestSeq("r")).toBe(0);
   });
@@ -155,43 +133,21 @@ describe("发号与 append-only", () => {
 
 describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
   it("解除后旧条目字节不变", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "周六一起去图书馆" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "周六一起去图书馆" }, "test");
     const before = JSON.stringify(ledger.entries("r")[0]);
-    ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "她改成周日了" },
-      { kind: "system", reason: "test" },
-    );
+    system.supersede("r", 1, { author: "main", reason: "她改成周日了" }, "test");
     const after = JSON.stringify(ledger.entries("r")[0]);
     expect(after).toBe(before);
   });
 
   it("解除是一条自带序号的新账目，supersedesSeq 指旧 seq", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "旧裁定" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.append(
-      "r",
-      { author: "main", kind: "active_rule", body: "夹在中间的规矩" },
-      { kind: "system", reason: "test" },
-    );
-    const s = ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "解除旧裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "旧裁定" }, "test");
+    system.append("r", { author: "main", kind: "active_rule", body: "夹在中间的规矩" }, "test");
+    const s = system.supersede("r", 1, { author: "main", reason: "解除旧裁定" }, "test");
     expect(s.seq).toBe(3);
     expect(s.kind).toBe("supersede");
     expect(s.supersedesSeq).toBe(1);
@@ -202,40 +158,22 @@ describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
   });
 
   it("现行有效集不再含被解除的条目", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "旧裁定" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "解除" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "旧裁定" }, "test");
+    system.supersede("r", 1, { author: "main", reason: "解除" }, "test");
     expect(ledger.currentSet("r")).toEqual([]);
     // 但归档查询仍能追到它——「曾被解除的条目」本身是可查事实。
     expect(ledger.entries("r")).toHaveLength(2);
   });
 
   it("已 ack 旧条目的窗，下一轮经缺口通道可见该解除", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "旧裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "旧裁定" }, "test");
     ledger.openViewport("r", "w-a");
     ledger.ack("r", "w-a", 1); // 窗已确认旧裁定
-    const s = ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "解除" },
-      { kind: "system", reason: "test" },
-    );
+    const s = system.supersede("r", 1, { author: "main", reason: "解除" }, "test");
     // 已 ack ≠ 仍然有效：解除经同一条缺口通道送达。
     const missing = ledger.gapEntries("r", "w-a");
     expect(missing).toHaveLength(1);
@@ -244,86 +182,45 @@ describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
   });
 
   it("解除不存在的 seq 报错", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "只有一条" },
-      { kind: "system", reason: "test" },
+    system.append("r", { author: "main", kind: "ruling", body: "只有一条" }, "test");
+    expect(() => system.supersede("r", 2, { author: "main", reason: "x" }, "test")).toThrow(
+      LedgerEntryNotFoundError,
     );
-    expect(() =>
-      ledger.supersede("r", 2, { author: "main", reason: "x" }, { kind: "system", reason: "test" }),
-    ).toThrow(LedgerEntryNotFoundError);
-    expect(() =>
-      ledger.supersede("r", 0, { author: "main", reason: "x" }, { kind: "system", reason: "test" }),
-    ).toThrow(LedgerEntryNotFoundError);
+    expect(() => system.supersede("r", 0, { author: "main", reason: "x" }, "test")).toThrow(
+      LedgerEntryNotFoundError,
+    );
   });
 
   it("不能解除一条 supersede", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "解除" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
+    system.supersede("r", 1, { author: "main", reason: "解除" }, "test");
     expect(() =>
-      ledger.supersede(
-        "r",
-        2,
-        { author: "main", reason: "解除那条解除" },
-        { kind: "system", reason: "test" },
-      ),
+      system.supersede("r", 2, { author: "main", reason: "解除那条解除" }, "test"),
     ).toThrow(InvalidSupersedeError);
   });
 
   it("重复解除同一条显式报错", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "第一次解除" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
+    system.supersede("r", 1, { author: "main", reason: "第一次解除" }, "test");
     // 静默放行会把「操作方以为还没解除过」藏起来。
     expect(() =>
-      ledger.supersede(
-        "r",
-        1,
-        { author: "main", reason: "第二次解除" },
-        { kind: "system", reason: "test" },
-      ),
+      system.supersede("r", 1, { author: "main", reason: "第二次解除" }, "test"),
     ).toThrow(/already superseded/);
   });
 
   it("跨住户解除报错，且那本账毫发无损", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("a");
     ledger.createLedger("b");
-    ledger.append(
-      "a",
-      { author: "main", kind: "ruling", body: "A 的裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("a", { author: "main", kind: "ruling", body: "A 的裁定" }, "test");
     expect(() =>
-      ledger.supersede(
-        "b",
-        1,
-        { author: "main", reason: "B 想解除 A 的" },
-        { kind: "system", reason: "test" },
-      ),
+      system.supersede("b", 1, { author: "main", reason: "B 想解除 A 的" }, "test"),
     ).toThrow(LedgerEntryNotFoundError);
     expect(ledger.entries("a")).toHaveLength(1);
     expect(ledger.currentSet("a")).toHaveLength(1);
@@ -332,112 +229,52 @@ describe("supersede 是追加不是涂改（MV-C07 账侧）", () => {
 
 describe("现行有效集是推导视图", () => {
   it("同一种 kind 多条并行生效是常态（2026-08-20 主笔拍板的新语义）", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定一" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定二" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.append(
-      "r",
-      { author: "main", kind: "active_rule", body: "规矩一" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定一" }, "test");
+    system.append("r", { author: "main", kind: "ruling", body: "裁定二" }, "test");
+    system.append("r", { author: "main", kind: "active_rule", body: "规矩一" }, "test");
     // 不是「每条 kind 的最新一条」——未被指名的全部现行，按 seq 升序。
     const current = ledger.currentSet("r");
     expect(current.map((e) => e.body)).toEqual(["裁定一", "裁定二", "规矩一"]);
   });
 
   it("supersede 精确指向单条：解除两条并行 ruling 中的一条，另一条仍在", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定一" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定二" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.supersede(
-      "r",
-      2,
-      { author: "main", reason: "只解除裁定二" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定一" }, "test");
+    system.append("r", { author: "main", kind: "ruling", body: "裁定二" }, "test");
+    system.supersede("r", 2, { author: "main", reason: "只解除裁定二" }, "test");
     expect(ledger.currentSet("r").map((e) => e.body)).toEqual(["裁定一"]);
     // 不存在「回退」——裁定一自始至终都在集里，不是被解除后重新浮上来的。
-    ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "解除裁定一" },
-      { kind: "system", reason: "test" },
-    );
+    system.supersede("r", 1, { author: "main", reason: "解除裁定一" }, "test");
     expect(ledger.currentSet("r")).toEqual([]);
   });
 
   it("解除一条不影响其他 kind 的并行条目", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定一" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.append(
-      "r",
-      { author: "main", kind: "active_rule", body: "规矩一" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.append(
-      "r",
-      { author: "main", kind: "confirmed_preference", body: "偏好一" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "只解除裁定一" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定一" }, "test");
+    system.append("r", { author: "main", kind: "active_rule", body: "规矩一" }, "test");
+    system.append("r", { author: "main", kind: "confirmed_preference", body: "偏好一" }, "test");
+    system.supersede("r", 1, { author: "main", reason: "只解除裁定一" }, "test");
     expect(ledger.currentSet("r").map((e) => e.body)).toEqual(["规矩一", "偏好一"]);
   });
 
   it("supersede 条目自身不是事实，不进现行有效集", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定一" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.supersede(
-      "r",
-      1,
-      { author: "main", reason: "解除" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定一" }, "test");
+    system.supersede("r", 1, { author: "main", reason: "解除" }, "test");
     // 集是空的——解除记录留在全史里查（entries），不冒充一条现行事实。
     expect(ledger.currentSet("r")).toEqual([]);
     expect(ledger.entries("r")).toHaveLength(2);
   });
 
   it("视图拿到的是副本，改它毒化不了账", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "现行裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "现行裁定" }, "test");
     const view = ledger.currentSet("r");
     (view[0] as { body: string }).body = "毒化";
     expect(ledger.currentSet("r")[0]?.body).toBe("现行裁定");
@@ -446,14 +283,10 @@ describe("现行有效集是推导视图", () => {
 
 describe("新窗 baseline（MV-A05 账侧）", () => {
   it("账内预置 50 条后新窗 ackedSeq = 开窗时 latestSeq，不背全史", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     for (let i = 0; i < 50; i += 1) {
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: `历史裁定 ${i + 1}` },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: `历史裁定 ${i + 1}` }, "test");
     }
     const baseline = ledger.openViewport("r", "w-new");
     expect(baseline).toBe(50);
@@ -463,28 +296,24 @@ describe("新窗 baseline（MV-A05 账侧）", () => {
   });
 
   it("空账上开的新窗 baseline 为 0", () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     ledger.createLedger("r");
     expect(ledger.openViewport("r", "w-new")).toBe(0);
     expect(ledger.gap("r", "w-new")).toEqual({ latestSeq: 0, ackedSeq: 0 });
   });
 
   it("同一窗重复开户显式报错", () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
     expect(() => ledger.openViewport("r", "w-a")).toThrow(/already exists/);
   });
 
   it("历史裁定仍走归档查询可达", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     for (let i = 0; i < 50; i += 1) {
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: `历史裁定 ${i + 1}` },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: `历史裁定 ${i + 1}` }, "test");
     }
     ledger.openViewport("r", "w-new");
     // 新窗不背全史 ≠ 历史不可达：归档查询是另一条路。
@@ -494,15 +323,11 @@ describe("新窗 baseline（MV-A05 账侧）", () => {
 
 describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
   it("裁定落账后另一窗缺口打开，拉取+回执后关闭", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
     ledger.openViewport("r", "w-b");
-    const ruling = ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "新裁定" },
-      { kind: "system", reason: "test" },
-    );
+    const ruling = system.append("r", { author: "main", kind: "ruling", body: "新裁定" }, "test");
     // 无推送通道，拉是唯一正确性来源——账侧只有拉与回执两个动作（C02 的落点）。
     expect(ledger.gap("r", "w-b")).toEqual({ latestSeq: 1, ackedSeq: 0 });
     const missing = ledger.gapEntries("r", "w-b");
@@ -513,15 +338,11 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
   });
 
   it("缺口是逐窗独立的：一窗确认不替另一窗确认", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
     ledger.openViewport("r", "w-b");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
     ledger.ack("r", "w-a", 1);
     expect(ledger.gap("r", "w-a").ackedSeq).toBe(1);
     expect(ledger.gap("r", "w-b").ackedSeq).toBe(0);
@@ -529,14 +350,10 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
   });
 
   it("回执丢失场景：窗不被记为已知悉，重拉后正常 ack", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
     // 回执丢失 = ack 从未到账：账上不存在「已知悉」的痕迹，也没有「违约」标记——
     // 传播机制的账不算窗的（C05）。窗重拉，缺口条目还在，补 ack 即闭合。
     expect(ledger.gapEntries("r", "w-a")).toHaveLength(1);
@@ -545,53 +362,37 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
   });
 
   it("重复 ack 同一个 seq 幂等放行（回执重发是常态）", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
     ledger.ack("r", "w-a", 1);
     expect(() => ledger.ack("r", "w-a", 1)).not.toThrow();
     expect(ledger.ackedSeq("r", "w-a")).toBe(1);
   });
 
   it("ack 回归显式报错：确认位只前进不后退", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "一" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "二" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "一" }, "test");
+    system.append("r", { author: "main", kind: "ruling", body: "二" }, "test");
     ledger.ack("r", "w-a", 2);
     expect(() => ledger.ack("r", "w-a", 1)).toThrow(AckError);
     expect(ledger.ackedSeq("r", "w-a")).toBe(2);
   });
 
   it("不能 ack 账上还不存在的 seq", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
-    ledger.append(
-      "r",
-      { author: "main", kind: "ruling", body: "裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
     expect(() => ledger.ack("r", "w-a", 2)).toThrow(AckError);
     expect(() => ledger.ack("r", "w-a", -1)).toThrow(AckError);
   });
 
   it("查没开过户的窗抛 ViewportNotFoundError", () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     ledger.createLedger("r");
     expect(() => ledger.gap("r", "w-ghost")).toThrow(ViewportNotFoundError);
     expect(() => ledger.ack("r", "w-ghost", 0)).toThrow(ViewportNotFoundError);
@@ -600,7 +401,7 @@ describe("拉式缺口与回执（MV-C01/C02/C05 账侧）", () => {
 
 describe("查账失败按缺处理（MV-C03 账侧）", () => {
   it("「查不到」与「查到是零」是两个值，不编码成同一个", () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-a");
     // 查到是零：ok 分支，数字俱在，latestSeq = ackedSeq = 0。
@@ -617,7 +418,7 @@ describe("查账失败按缺处理（MV-C03 账侧）", () => {
   });
 
   it("类型层看门狗：unknown 分支取 latestSeq 必须编译不过", () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     const probe = ledger.probeGap("nobody", "w-x");
     if (probe.status === "unknown") {
       // 类型级的承诺用编译器来验：哪天 GapProbe 被改成 unknown 也带数字
@@ -635,7 +436,7 @@ describe("查账失败按缺处理（MV-C03 账侧）", () => {
   });
 
   it("probeGap 永不抛：任何失败都归一成 unknown", () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     // 连账都没开的住户。
     expect(() => ledger.probeGap("nobody", "w-x")).not.toThrow();
     const probe = ledger.probeGap("nobody", "w-x");
@@ -647,9 +448,147 @@ describe("查账失败按缺处理（MV-C03 账侧）", () => {
   });
 
   it("gap() 与 probeGap() 分工：要炸的炸，要探的探", () => {
-    const ledger = new FactLedger();
+    const { ledger } = FactLedger.create();
     expect(() => ledger.gap("nobody", "w-x")).toThrow(LedgerNotFoundError);
     expect(ledger.probeGap("nobody", "w-x").status).toBe("unknown");
+  });
+});
+
+describe("C04 权威半格：豁免是能力不是自报（渡渡家内审二轮 + 上游 Laurie/Elio）", () => {
+  /** 带代际权威的账：gens 就是这些测试里的 SessionRegistry 替身。 */
+  function gatedLedger() {
+    const gens = new Map<string, number>();
+    const created = FactLedger.create({
+      generationOf: (viewportId) => gens.get(viewportId) ?? null,
+    });
+    return { ...created, gens };
+  }
+
+  it('落后窗伪报 system 必红：强喂 {kind:"system"} 进公开写口被拒，账上零多写', () => {
+    // 复刻二轮复审的绕闸路径：B 窗 ackedSeq=0 落后于 latestSeq=1，
+    // 换掉省略 origin 的招数，改自报 system——类型层本已没有这个分支，
+    // 这里模拟 JS 调用方硬塞，必须在运行时半格响亮拒绝。
+    const { ledger, systemWriter: system, gens } = gatedLedger();
+    ledger.createLedger("r");
+    ledger.openViewport("r", "w-b");
+    gens.set("w-b", 1);
+    system.append("r", { author: "main", kind: "ruling", body: "既有裁定" }, "seed");
+    expect(ledger.probeGap("r", "w-b")).toEqual({ status: "ok", latestSeq: 1, ackedSeq: 0 });
+    expect(() =>
+      ledger.append("r", { author: "b-window", kind: "ruling", body: "应被拦的裁定" }, {
+        kind: "system",
+        reason: "I claim system",
+      } as never),
+    ).toThrow(/SystemLedgerWriter/);
+    expect(() =>
+      ledger.supersede("r", 1, { author: "b-window", reason: "应被拦的解除" }, {
+        kind: "system",
+        reason: "I claim system",
+      } as never),
+    ).toThrow(/SystemLedgerWriter/);
+    expect(ledger.latestSeq("r")).toBe(1);
+  });
+
+  it("system 能力对象不可从模块伪造：类只导出类型，值域里没有构造函数", async () => {
+    const mod = (await import("../src/store/fact-ledger.ts")) as Record<string, unknown>;
+    expect(mod.SystemLedgerWriter).toBeUndefined();
+  });
+
+  it("旧 generation 必红：权威说当代是 2，拿 1 来写被拒，账上零多写", () => {
+    const { ledger, gens } = gatedLedger();
+    ledger.createLedger("r");
+    ledger.openViewport("r", "w-b");
+    gens.set("w-b", 2);
+    expect(() =>
+      ledger.append(
+        "r",
+        { author: "b-window", kind: "ruling", body: "旧代的裁定" },
+        { kind: "viewport", residentId: "r", viewportId: "w-b", generation: 1 },
+      ),
+    ).toThrow(/旧代的窗无权/);
+    expect(ledger.latestSeq("r")).toBe(0);
+  });
+
+  it("generation 权威未接线或查不到：fail-closed，不放行", () => {
+    // 未接线：普通 new 出来的账没有 generationOf——验不了资格就不放行。
+    const { ledger: bare } = FactLedger.create();
+    bare.createLedger("r");
+    bare.openViewport("r", "w-b");
+    expect(() =>
+      bare.append(
+        "r",
+        { author: "b-window", kind: "ruling", body: "没人验代际" },
+        { kind: "viewport", residentId: "r", viewportId: "w-b", generation: 1 },
+      ),
+    ).toThrow(WriteGateUnavailableError);
+    expect(bare.latestSeq("r")).toBe(0);
+    // 接了线但权威查不到这扇窗：同样 fail-closed。
+    const { ledger, gens } = gatedLedger();
+    ledger.createLedger("r");
+    ledger.openViewport("r", "w-b");
+    expect(gens.has("w-b")).toBe(false);
+    expect(() =>
+      ledger.append(
+        "r",
+        { author: "b-window", kind: "ruling", body: "权威不认识我" },
+        { kind: "viewport", residentId: "r", viewportId: "w-b", generation: 1 },
+      ),
+    ).toThrow(WriteGateUnavailableError);
+    expect(ledger.latestSeq("r")).toBe(0);
+  });
+
+  it("三元组 residentId 与目标账不一致：拒收（不许张冠李戴）", () => {
+    const { ledger, gens } = gatedLedger();
+    ledger.createLedger("r");
+    ledger.createLedger("other");
+    ledger.openViewport("r", "w-b");
+    gens.set("w-b", 1);
+    expect(() =>
+      ledger.append(
+        "r",
+        { author: "b-window", kind: "ruling", body: "拿别家身份写这家账" },
+        { kind: "viewport", residentId: "other", viewportId: "w-b", generation: 1 },
+      ),
+    ).toThrow(/不一致/);
+    expect(ledger.latestSeq("r")).toBe(0);
+  });
+
+  it("可信 host 写入成功，reason 与 author 并排落痕、归档可读、重启后仍在", () => {
+    withTempDir((dataDir) => {
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
+      ledger.createLedger("r");
+      system.append(
+        "r",
+        { author: "admin", kind: "ruling", body: "宿主落的裁定" },
+        "acceptance: seed ruling",
+      );
+      const archived = ledger.entries("r")[0];
+      expect(archived?.origin).toEqual({ kind: "system", reason: "acceptance: seed ruling" });
+      // 归档审计要经得住进程重启：印痕在账目里，不在内存里。
+      const { ledger: restored } = FactLedger.create({ dataDir });
+      expect(restored.entries("r")[0]?.origin).toEqual({
+        kind: "system",
+        reason: "acceptance: seed ruling",
+      });
+    });
+  });
+
+  it("守规窗写入成功，三元组印痕落进条目", () => {
+    const { ledger, gens } = gatedLedger();
+    ledger.createLedger("r");
+    ledger.openViewport("r", "w-b");
+    gens.set("w-b", 3);
+    const entry = ledger.append(
+      "r",
+      { author: "b-window", kind: "ruling", body: "守规矩的裁定" },
+      { kind: "viewport", residentId: "r", viewportId: "w-b", generation: 3 },
+    );
+    expect(entry.origin).toEqual({ kind: "viewport", viewportId: "w-b", generation: 3 });
+    expect(ledger.entries("r")[0]?.origin).toEqual({
+      kind: "viewport",
+      viewportId: "w-b",
+      generation: 3,
+    });
   });
 });
 
@@ -661,7 +600,7 @@ describe("序号而非时间戳（MV-C06）", () => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [
             {
@@ -671,6 +610,7 @@ describe("序号而非时间戳（MV-C06）", () => {
               kind: "ruling",
               body: "一",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
             {
               seq: 2,
@@ -679,12 +619,13 @@ describe("序号而非时间戳（MV-C06）", () => {
               kind: "ruling",
               body: "二",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
           ],
           viewports: [{ viewportId: "w-a", baselineSeq: 0, ackedSeq: 0 }],
         }),
       );
-      const ledger = new FactLedger({ dataDir });
+      const { ledger } = FactLedger.create({ dataDir });
       const entries = ledger.entries("r");
       // ts 确实是倒的——前提成立，这个测试不是空转。
       expect(Date.parse(entries[1]?.ts ?? "")).toBeLessThan(Date.parse(entries[0]?.ts ?? ""));
@@ -699,15 +640,11 @@ describe("序号而非时间戳（MV-C06）", () => {
 
 describe("住户隔离", () => {
   it("跨住户读写一律抛 LedgerNotFoundError", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("a");
-    expect(() =>
-      ledger.append(
-        "b",
-        { author: "main", kind: "ruling", body: "x" },
-        { kind: "system", reason: "test" },
-      ),
-    ).toThrow(LedgerNotFoundError);
+    expect(() => system.append("b", { author: "main", kind: "ruling", body: "x" }, "test")).toThrow(
+      LedgerNotFoundError,
+    );
     expect(() => ledger.entries("b")).toThrow(LedgerNotFoundError);
     expect(() => ledger.currentSet("b")).toThrow(LedgerNotFoundError);
     expect(() => ledger.openViewport("b", "w-x")).toThrow(LedgerNotFoundError);
@@ -715,21 +652,17 @@ describe("住户隔离", () => {
   });
 
   it("两本账互不可见：seq 各自发号，条目各归各", () => {
-    const ledger = new FactLedger();
+    const { ledger, systemWriter: system } = FactLedger.create();
     ledger.createLedger("a");
     ledger.createLedger("b");
-    ledger.append(
-      "a",
-      { author: "main", kind: "ruling", body: "A 的秘密裁定" },
-      { kind: "system", reason: "test" },
-    );
+    system.append("a", { author: "main", kind: "ruling", body: "A 的秘密裁定" }, "test");
     expect(ledger.latestSeq("a")).toBe(1);
     expect(ledger.latestSeq("b")).toBe(0);
     expect(ledger.entries("b")).toEqual([]);
-    const bFirst = ledger.append(
+    const bFirst = system.append(
       "b",
       { author: "main", kind: "ruling", body: "B 的第一条" },
-      { kind: "system", reason: "test" },
+      "test",
     );
     expect(bFirst.seq).toBe(1);
   });
@@ -738,35 +671,22 @@ describe("住户隔离", () => {
 describe("持久化", () => {
   it("条目、seq 水位、确认位原样恢复，恢复后继续发号不撞", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "裁定一" },
-        { kind: "system", reason: "test" },
-      );
-      ledger.append(
-        "r",
-        { author: "main", kind: "active_rule", body: "规矩一" },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: "裁定一" }, "test");
+      system.append("r", { author: "main", kind: "active_rule", body: "规矩一" }, "test");
       ledger.openViewport("r", "w-a"); // baseline=2，窗已对齐到规矩一
-      ledger.supersede(
-        "r",
-        1,
-        { author: "main", reason: "解除裁定一" },
-        { kind: "system", reason: "test" },
-      );
+      system.supersede("r", 1, { author: "main", reason: "解除裁定一" }, "test");
 
-      const restored = new FactLedger({ dataDir });
+      const { ledger: restored, systemWriter: restoredSystem } = FactLedger.create({ dataDir });
       expect(restored.entries("r")).toEqual(ledger.entries("r"));
       expect(restored.gap("r", "w-a")).toEqual({ latestSeq: 3, ackedSeq: 2 });
       expect(restored.gapEntries("r", "w-a").map((e) => e.kind)).toEqual(["supersede"]);
       expect(restored.currentSet("r").map((e) => e.body)).toEqual(["规矩一"]);
-      const next = restored.append(
+      const next = restoredSystem.append(
         "r",
         { author: "main", kind: "ruling", body: "裁定二" },
-        { kind: "system", reason: "test" },
+        "test",
       );
       expect(next.seq).toBe(4);
     });
@@ -776,51 +696,21 @@ describe("持久化", () => {
     withTempDir((dataDir) => {
       // 这颗钉子钉的是一类洞，不是一个洞：restore 的 supersede 校验曾比
       // 在线 append 松（同型事故），视图推导也可能在两条路径上悄悄分叉。
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "裁定一" },
-        { kind: "system", reason: "test" },
-      );
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "裁定二" },
-        { kind: "system", reason: "test" },
-      );
-      ledger.append(
-        "r",
-        { author: "main", kind: "active_rule", body: "规矩一" },
-        { kind: "system", reason: "test" },
-      );
-      ledger.append(
-        "r",
-        { author: "main", kind: "confirmed_preference", body: "偏好一" },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: "裁定一" }, "test");
+      system.append("r", { author: "main", kind: "ruling", body: "裁定二" }, "test");
+      system.append("r", { author: "main", kind: "active_rule", body: "规矩一" }, "test");
+      system.append("r", { author: "main", kind: "confirmed_preference", body: "偏好一" }, "test");
       ledger.openViewport("r", "w-1"); // baseline=4
       ledger.ack("r", "w-1", 4);
-      ledger.supersede(
-        "r",
-        2,
-        { author: "main", reason: "只解除裁定二" },
-        { kind: "system", reason: "test" },
-      );
-      ledger.supersede(
-        "r",
-        4,
-        { author: "main", reason: "偏好一作废——这个 kind 全解除" },
-        { kind: "system", reason: "test" },
-      );
+      system.supersede("r", 2, { author: "main", reason: "只解除裁定二" }, "test");
+      system.supersede("r", 4, { author: "main", reason: "偏好一作废——这个 kind 全解除" }, "test");
       ledger.openViewport("r", "w-2"); // baseline=6
-      ledger.append(
-        "r",
-        { author: "main", kind: "active_rule", body: "规矩二" },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "active_rule", body: "规矩二" }, "test");
 
       // 在线取一次，落盘后新实例再取一次，深比较相等。
-      const restored = new FactLedger({ dataDir });
+      const { ledger: restored, systemWriter: restoredSystem } = FactLedger.create({ dataDir });
       expect(restored.currentSet("r")).toEqual(ledger.currentSet("r"));
       // 前提不是空转：集里确实有内容，且有 kind 被全解除。
       expect(ledger.currentSet("r").map((e) => e.body)).toEqual(["裁定一", "规矩一", "规矩二"]);
@@ -835,15 +725,11 @@ describe("持久化", () => {
 
   it("多住户共用一个目录，文件名与 ResidentStore 不撞", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("a");
       ledger.createLedger("b");
-      ledger.append(
-        "a",
-        { author: "main", kind: "ruling", body: "A 的" },
-        { kind: "system", reason: "test" },
-      );
-      const restored = new FactLedger({ dataDir });
+      system.append("a", { author: "main", kind: "ruling", body: "A 的" }, "test");
+      const { ledger: restored, systemWriter: restoredSystem } = FactLedger.create({ dataDir });
       expect(restored.latestSeq("a")).toBe(1);
       expect(restored.latestSeq("b")).toBe(0);
       // .facts.json 后缀刻意与 ResidentStore 的 .json 区分，两个存储可共用目录。
@@ -853,7 +739,7 @@ describe("持久化", () => {
 
   it("快照权限 0600", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
       const mode = statSync(join(dataDir, "r.facts.json")).mode & 0o777;
       expect(mode).toBe(0o600);
@@ -874,7 +760,7 @@ describe("持久化", () => {
     withTempDir((dataDir) => {
       writeFileSync(
         join(dataDir, "a.facts.json"),
-        JSON.stringify({ schemaVersion: 1, residentId: "b", entries: [], viewports: [] }),
+        JSON.stringify({ schemaVersion: 2, residentId: "b", entries: [], viewports: [] }),
       );
       expect(() => new FactLedger({ dataDir })).toThrow(/文件名与身份对不上/);
     });
@@ -885,7 +771,7 @@ describe("持久化", () => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [
             {
@@ -895,6 +781,7 @@ describe("持久化", () => {
               kind: "ruling",
               body: "一",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
             {
               seq: 3,
@@ -903,6 +790,7 @@ describe("持久化", () => {
               kind: "ruling",
               body: "三",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
           ],
           viewports: [],
@@ -917,7 +805,7 @@ describe("持久化", () => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [
             {
@@ -927,6 +815,7 @@ describe("持久化", () => {
               kind: "bogus",
               body: "x",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
           ],
           viewports: [],
@@ -941,7 +830,7 @@ describe("持久化", () => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [
             {
@@ -951,6 +840,7 @@ describe("持久化", () => {
               kind: "ruling",
               body: "一",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
             {
               seq: 2,
@@ -959,6 +849,7 @@ describe("持久化", () => {
               kind: "supersede",
               body: "解除一",
               supersedesSeq: 1,
+              origin: { kind: "system", reason: "test" },
             },
             {
               seq: 3,
@@ -967,6 +858,7 @@ describe("持久化", () => {
               kind: "supersede",
               body: "解除解除",
               supersedesSeq: 2,
+              origin: { kind: "system", reason: "test" },
             },
           ],
           viewports: [],
@@ -981,7 +873,7 @@ describe("持久化", () => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [
             {
@@ -991,6 +883,7 @@ describe("持久化", () => {
               kind: "ruling",
               body: "一",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
             {
               seq: 2,
@@ -999,6 +892,7 @@ describe("持久化", () => {
               kind: "supersede",
               body: "第一次解除",
               supersedesSeq: 1,
+              origin: { kind: "system", reason: "test" },
             },
             {
               seq: 3,
@@ -1007,6 +901,7 @@ describe("持久化", () => {
               kind: "supersede",
               body: "第二次解除",
               supersedesSeq: 1,
+              origin: { kind: "system", reason: "test" },
             },
           ],
           viewports: [],
@@ -1021,7 +916,7 @@ describe("持久化", () => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [
             {
@@ -1031,6 +926,7 @@ describe("持久化", () => {
               kind: "ruling",
               body: "一",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
             {
               seq: 2,
@@ -1039,6 +935,7 @@ describe("持久化", () => {
               kind: "supersede",
               body: "解除一",
               supersedesSeq: "1",
+              origin: { kind: "system", reason: "test" },
             },
           ],
           viewports: [],
@@ -1053,7 +950,7 @@ describe("持久化", () => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [],
           viewports: [{ viewportId: "w-a", baselineSeq: 0, ackedSeq: 5 }],
@@ -1068,7 +965,7 @@ describe("持久化", () => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [],
           viewports: [{ viewportId: "w-a", baselineSeq: "0", ackedSeq: "0" }],
@@ -1080,36 +977,24 @@ describe("持久化", () => {
 
   it("残留 .tmp 被跳过，旧 .json 仍是权威", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "已落盘" },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: "已落盘" }, "test");
       writeFileSync(join(dataDir, "r.facts.json.tmp"), "没写完的一次写入");
-      const restored = new FactLedger({ dataDir });
+      const { ledger: restored, systemWriter: restoredSystem } = FactLedger.create({ dataDir });
       expect(restored.latestSeq("r")).toBe(1);
       // 下一次写入覆盖残留。
-      restored.append(
-        "r",
-        { author: "main", kind: "ruling", body: "二" },
-        { kind: "system", reason: "test" },
-      );
+      restoredSystem.append("r", { author: "main", kind: "ruling", body: "二" }, "test");
       expect(readFileSync(join(dataDir, "r.facts.json"), "utf8")).toContain("二");
     });
   });
 
   it("恢复的条目仍是冻结的，账外副本涂改无效", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "正文" },
-        { kind: "system", reason: "test" },
-      );
-      const restored = new FactLedger({ dataDir });
+      system.append("r", { author: "main", kind: "ruling", body: "正文" }, "test");
+      const { ledger: restored, systemWriter: restoredSystem } = FactLedger.create({ dataDir });
       const copy = restored.entries("r");
       (copy[0] as { body: string }).body = "涂改";
       expect(restored.entries("r")[0]?.body).toBe("正文");
@@ -1120,7 +1005,7 @@ describe("持久化", () => {
 describe("落盘失败不改内存（写路径先落盘后发布）", () => {
   it("createLedger 落盘失败：内存里不留半本账", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger } = FactLedger.create({ dataDir });
       whileReadonly(dataDir, () => {
         expect(() => ledger.createLedger("r")).toThrow();
         expect(ledger.has("r")).toBe(false);
@@ -1133,20 +1018,12 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
 
   it("append 落盘失败：条目不多、seq 不动、盘与内存一致", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "一" },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: "一" }, "test");
       whileReadonly(dataDir, () => {
         expect(() =>
-          ledger.append(
-            "r",
-            { author: "main", kind: "ruling", body: "二" },
-            { kind: "system", reason: "test" },
-          ),
+          system.append("r", { author: "main", kind: "ruling", body: "二" }, "test"),
         ).toThrow();
         expect(ledger.latestSeq("r")).toBe(1);
         expect(ledger.entries("r").map((e) => e.body)).toEqual(["一"]);
@@ -1154,32 +1031,19 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
       // 盘上也没多：新实例读到的和内存一致。
       expect(new FactLedger({ dataDir }).entries("r")).toHaveLength(1);
       // 恢复可写后追加成功，seq 连续——失败没有吃掉序号。
-      const entry = ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "二" },
-        { kind: "system", reason: "test" },
-      );
+      const entry = system.append("r", { author: "main", kind: "ruling", body: "二" }, "test");
       expect(entry.seq).toBe(2);
     });
   });
 
   it("supersede 落盘失败：不留「条目进了全史、解除标记没进」的半改", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "裁定" },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
       whileReadonly(dataDir, () => {
         expect(() =>
-          ledger.supersede(
-            "r",
-            1,
-            { author: "main", reason: "解除" },
-            { kind: "system", reason: "test" },
-          ),
+          system.supersede("r", 1, { author: "main", reason: "解除" }, "test"),
         ).toThrow();
         // 这是故障注入打过的洞：旧实现先 push 再落盘，失败后全史多一条
         // supersede 而 supersededSeqs 没更新，currentSet 与全史自相矛盾。
@@ -1188,25 +1052,16 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
         expect(ledger.currentSet("r").map((e) => e.body)).toEqual(["裁定"]);
       });
       // 恢复可写后同一次解除能正常完成。
-      ledger.supersede(
-        "r",
-        1,
-        { author: "main", reason: "解除" },
-        { kind: "system", reason: "test" },
-      );
+      system.supersede("r", 1, { author: "main", reason: "解除" }, "test");
       expect(ledger.currentSet("r")).toEqual([]);
     });
   });
 
   it("openViewport 落盘失败：不留确认位", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "裁定" },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
       whileReadonly(dataDir, () => {
         expect(() => ledger.openViewport("r", "w-a")).toThrow();
         expect(() => ledger.gap("r", "w-a")).toThrow(ViewportNotFoundError);
@@ -1217,14 +1072,10 @@ describe("落盘失败不改内存（写路径先落盘后发布）", () => {
 
   it("ack 落盘失败：确认位不动", () => {
     withTempDir((dataDir) => {
-      const ledger = new FactLedger({ dataDir });
+      const { ledger, systemWriter: system } = FactLedger.create({ dataDir });
       ledger.createLedger("r");
       ledger.openViewport("r", "w-a");
-      ledger.append(
-        "r",
-        { author: "main", kind: "ruling", body: "裁定" },
-        { kind: "system", reason: "test" },
-      );
+      system.append("r", { author: "main", kind: "ruling", body: "裁定" }, "test");
       whileReadonly(dataDir, () => {
         expect(() => ledger.ack("r", "w-a", 1)).toThrow();
         expect(ledger.ackedSeq("r", "w-a")).toBe(0);
@@ -1247,7 +1098,7 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
       // Map 以数字为键、字符串查不到，一本账无声消失。
       writeFileSync(
         join(dataDir, "123.facts.json"),
-        JSON.stringify({ schemaVersion: 1, residentId: 123, entries: [], viewports: [] }),
+        JSON.stringify({ schemaVersion: 2, residentId: 123, entries: [], viewports: [] }),
       );
       expect(() => new FactLedger({ dataDir })).toThrow(/residentId 不是字符串/);
     });
@@ -1257,14 +1108,14 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
     withTempDir((dataDir) => {
       writeFileSync(
         join(dataDir, "r.facts.json"),
-        JSON.stringify({ schemaVersion: 1, residentId: "r", entries: {}, viewports: [] }),
+        JSON.stringify({ schemaVersion: 2, residentId: "r", entries: {}, viewports: [] }),
       );
       expect(() => new FactLedger({ dataDir })).toThrow(/entries 不是数组/);
 
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [
             {
@@ -1274,6 +1125,7 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
               kind: "ruling",
               body: 42,
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
           ],
           viewports: [],
@@ -1284,7 +1136,7 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [
             {
@@ -1294,6 +1146,7 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
               kind: "ruling",
               body: "x",
               supersedesSeq: null,
+              origin: { kind: "system", reason: "test" },
             },
           ],
           viewports: [],
@@ -1308,7 +1161,7 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [],
           viewports: [{ viewportId: 123, baselineSeq: 0, ackedSeq: 0 }],
@@ -1319,7 +1172,7 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
       writeFileSync(
         join(dataDir, "r.facts.json"),
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           residentId: "r",
           entries: [],
           viewports: [{ viewportId: "w-a", baselineSeq: "0", ackedSeq: 0 }],
@@ -1334,7 +1187,7 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
       // 带 extra 的条目若恢复成功，会经 entries() 外泄、后续落盘继续保留——
       // 所以字段集合必须恰好，多一个都当场拒（同 migration assertExactKeys 口径）。
       const valid = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         residentId: "r",
         entries: [
           {
@@ -1344,6 +1197,7 @@ describe("恢复的运行时校验（不可信 JSON 不许直接断言成 Ledger
             kind: "ruling",
             body: "一",
             supersedesSeq: null,
+            origin: { kind: "system", reason: "test" },
           },
         ],
         viewports: [{ viewportId: "w-a", baselineSeq: 0, ackedSeq: 0 }],

--- a/tests/fact-ledger.test.ts
+++ b/tests/fact-ledger.test.ts
@@ -16,9 +16,11 @@ import { describe, expect, it } from "vitest";
 import {
   AckError,
   FactLedger,
+  ForeignViewportError,
   InvalidSupersedeError,
   LedgerEntryNotFoundError,
   LedgerNotFoundError,
+  StaleViewportError,
   ViewportNotFoundError,
   WriteGateUnavailableError,
 } from "../src/store/fact-ledger.ts";
@@ -455,23 +457,23 @@ describe("查账失败按缺处理（MV-C03 账侧）", () => {
 });
 
 describe("C04 权威半格：豁免是能力不是自报（渡渡家内审二轮 + 上游 Laurie/Elio）", () => {
-  /** 带代际权威的账：gens 就是这些测试里的 SessionRegistry 替身。 */
+  /** 带身份权威的账：owners 就是这些测试里的 SessionRegistry 替身（归属与代际同源同查）。 */
   function gatedLedger() {
-    const gens = new Map<string, number>();
+    const owners = new Map<string, { residentId: string; generation: number }>();
     const created = FactLedger.create({
-      generationOf: (viewportId) => gens.get(viewportId) ?? null,
+      viewportAuthority: (viewportId) => owners.get(viewportId) ?? null,
     });
-    return { ...created, gens };
+    return { ...created, owners };
   }
 
   it('落后窗伪报 system 必红：强喂 {kind:"system"} 进公开写口被拒，账上零多写', () => {
     // 复刻二轮复审的绕闸路径：B 窗 ackedSeq=0 落后于 latestSeq=1，
     // 换掉省略 origin 的招数，改自报 system——类型层本已没有这个分支，
     // 这里模拟 JS 调用方硬塞，必须在运行时半格响亮拒绝。
-    const { ledger, systemWriter: system, gens } = gatedLedger();
+    const { ledger, systemWriter: system, owners } = gatedLedger();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-b");
-    gens.set("w-b", 1);
+    owners.set("w-b", { residentId: "r", generation: 1 });
     system.append("r", { author: "main", kind: "ruling", body: "既有裁定" }, "seed");
     expect(ledger.probeGap("r", "w-b")).toEqual({ status: "ok", latestSeq: 1, ackedSeq: 0 });
     expect(() =>
@@ -495,10 +497,10 @@ describe("C04 权威半格：豁免是能力不是自报（渡渡家内审二轮
   });
 
   it("旧 generation 必红：权威说当代是 2，拿 1 来写被拒，账上零多写", () => {
-    const { ledger, gens } = gatedLedger();
+    const { ledger, owners } = gatedLedger();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-b");
-    gens.set("w-b", 2);
+    owners.set("w-b", { residentId: "r", generation: 2 });
     expect(() =>
       ledger.append(
         "r",
@@ -510,7 +512,7 @@ describe("C04 权威半格：豁免是能力不是自报（渡渡家内审二轮
   });
 
   it("generation 权威未接线或查不到：fail-closed，不放行", () => {
-    // 未接线：普通 new 出来的账没有 generationOf——验不了资格就不放行。
+    // 未接线：普通 new 出来的账没有 viewportAuthority——验不了资格就不放行。
     const { ledger: bare } = FactLedger.create();
     bare.createLedger("r");
     bare.openViewport("r", "w-b");
@@ -523,10 +525,10 @@ describe("C04 权威半格：豁免是能力不是自报（渡渡家内审二轮
     ).toThrow(WriteGateUnavailableError);
     expect(bare.latestSeq("r")).toBe(0);
     // 接了线但权威查不到这扇窗：同样 fail-closed。
-    const { ledger, gens } = gatedLedger();
+    const { ledger, owners } = gatedLedger();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-b");
-    expect(gens.has("w-b")).toBe(false);
+    expect(owners.has("w-b")).toBe(false);
     expect(() =>
       ledger.append(
         "r",
@@ -538,11 +540,11 @@ describe("C04 权威半格：豁免是能力不是自报（渡渡家内审二轮
   });
 
   it("三元组 residentId 与目标账不一致：拒收（不许张冠李戴）", () => {
-    const { ledger, gens } = gatedLedger();
+    const { ledger, owners } = gatedLedger();
     ledger.createLedger("r");
     ledger.createLedger("other");
     ledger.openViewport("r", "w-b");
-    gens.set("w-b", 1);
+    owners.set("w-b", { residentId: "r", generation: 1 });
     expect(() =>
       ledger.append(
         "r",
@@ -574,10 +576,10 @@ describe("C04 权威半格：豁免是能力不是自报（渡渡家内审二轮
   });
 
   it("守规窗写入成功，三元组印痕落进条目", () => {
-    const { ledger, gens } = gatedLedger();
+    const { ledger, owners } = gatedLedger();
     ledger.createLedger("r");
     ledger.openViewport("r", "w-b");
-    gens.set("w-b", 3);
+    owners.set("w-b", { residentId: "r", generation: 3 });
     const entry = ledger.append(
       "r",
       { author: "b-window", kind: "ruling", body: "守规矩的裁定" },
@@ -589,6 +591,165 @@ describe("C04 权威半格：豁免是能力不是自报（渡渡家内审二轮
       viewportId: "w-b",
       generation: 3,
     });
+  });
+
+  it("闸先于目标校验：落后窗 supersede 不存在的 seq，答案是 Stale 不是 NotFound（阿问 review 钉的性质）", () => {
+    // 未知悉最新裁定的窗连「目标存不存在」的答案都不该拿到——把闸挪到
+    // 目标校验之后，这条测试会精准转红（LedgerEntryNotFoundError 抛出）。
+    const { ledger, systemWriter: system, owners } = gatedLedger();
+    ledger.createLedger("r");
+    ledger.openViewport("r", "w-b");
+    owners.set("w-b", { residentId: "r", generation: 1 });
+    system.append("r", { author: "main", kind: "ruling", body: "让 w-b 落后的裁定" }, "seed");
+    expect(() =>
+      ledger.supersede(
+        "r",
+        999,
+        { author: "b-window", reason: "落后窗探路" },
+        {
+          kind: "viewport",
+          residentId: "r",
+          viewportId: "w-b",
+          generation: 1,
+        },
+      ),
+    ).toThrow(StaleViewportError);
+    expect(ledger.latestSeq("r")).toBe(1);
+  });
+
+  it("归属半格：别家的真活窗被误挂进目标账 ack row，也不得署名写入（界 review 的复现反例）", () => {
+    // 复刻界的复现链：w-bee 是住户 bee 的真窗（权威在案、代际现值），
+    // 误接线把它 openViewport 进了 a 的账——resident 自比与代际全过，
+    // 只有权威归属能拦住这笔写入。
+    const { ledger, owners } = gatedLedger();
+    ledger.createLedger("a");
+    ledger.createLedger("bee");
+    owners.set("w-bee", { residentId: "bee", generation: 1 });
+    ledger.openViewport("a", "w-bee"); // 误接线：别家的窗挂进了 a 的确认位
+    expect(() =>
+      ledger.append(
+        "a",
+        { author: "bee-window", kind: "ruling", body: "跨户写入" },
+        {
+          kind: "viewport",
+          residentId: "a",
+          viewportId: "w-bee",
+          generation: 1,
+        },
+      ),
+    ).toThrow(ForeignViewportError);
+    expect(ledger.latestSeq("a")).toBe(0);
+    // 回自己家写照常放行：权威归属对上即走。
+    ledger.openViewport("bee", "w-bee");
+    const entry = ledger.append(
+      "bee",
+      { author: "bee-window", kind: "ruling", body: "在自家写" },
+      {
+        kind: "viewport",
+        residentId: "bee",
+        viewportId: "w-bee",
+        generation: 1,
+      },
+    );
+    expect(entry.seq).toBe(1);
+  });
+
+  it("写者自 ack：同一扇窗连续两笔合法裁定级写入都放行，确认位随写推进（界 review 定的语义）", () => {
+    const { ledger, owners } = gatedLedger();
+    ledger.createLedger("r");
+    ledger.openViewport("r", "w-b");
+    owners.set("w-b", { residentId: "r", generation: 1 });
+    const origin = { kind: "viewport", residentId: "r", viewportId: "w-b", generation: 1 } as const;
+    const first = ledger.append("r", { author: "b", kind: "ruling", body: "第一笔" }, origin);
+    expect(ledger.ackedSeq("r", "w-b")).toBe(first.seq); // 写者天然知悉自己的条目
+    // 不补任何手工 ack，第二笔照常放行——写入与确认位推进同一次持久化完成。
+    const second = ledger.supersede("r", first.seq, { author: "b", reason: "改主意" }, origin);
+    expect(second.seq).toBe(2);
+    expect(ledger.ackedSeq("r", "w-b")).toBe(2);
+    // 别家窗的确认位不动：他们的知悉仍走缺口通道。
+    ledger.openViewport("r", "w-c");
+    owners.set("w-c", { residentId: "r", generation: 1 });
+    const third = ledger.append("r", { author: "b", kind: "ruling", body: "第三笔" }, origin);
+    expect(ledger.ackedSeq("r", "w-b")).toBe(third.seq);
+    expect(ledger.ackedSeq("r", "w-c")).toBe(2); // w-c 开窗 baseline=2，之后没动
+  });
+
+  it("写者自 ack 落盘同笔：重启恢复后确认位就是写后的值", () => {
+    withTempDir((dataDir) => {
+      const owners = new Map([["w-b", { residentId: "r", generation: 1 }]]);
+      const authority = (viewportId: string) => owners.get(viewportId) ?? null;
+      const { ledger } = FactLedger.create({ dataDir, viewportAuthority: authority });
+      ledger.createLedger("r");
+      ledger.openViewport("r", "w-b");
+      ledger.append(
+        "r",
+        { author: "b", kind: "ruling", body: "落盘的一笔" },
+        {
+          kind: "viewport",
+          residentId: "r",
+          viewportId: "w-b",
+          generation: 1,
+        },
+      );
+      const restored = new FactLedger({ dataDir, viewportAuthority: authority });
+      expect(restored.ackedSeq("r", "w-b")).toBe(1);
+    });
+  });
+
+  it("覆盖公开 probeGap 改变不了写资格：安全判据走内部探针（界 review 定的边界）", () => {
+    const { ledger, systemWriter: system, owners } = gatedLedger();
+    ledger.createLedger("r");
+    ledger.openViewport("r", "w-b");
+    owners.set("w-b", { residentId: "r", generation: 1 });
+    system.append("r", { author: "main", kind: "ruling", body: "让 w-b 落后" }, "seed");
+    // monkey-patch 公开探针谎报新鲜——查询门面被换，闸不为所动。
+    (ledger as { probeGap: unknown }).probeGap = () => ({
+      status: "ok",
+      latestSeq: 0,
+      ackedSeq: 0,
+    });
+    expect(() =>
+      ledger.append(
+        "r",
+        { author: "b-window", kind: "ruling", body: "想借假探针绕闸" },
+        {
+          kind: "viewport",
+          residentId: "r",
+          viewportId: "w-b",
+          generation: 1,
+        },
+      ),
+    ).toThrow(StaleViewportError);
+    expect(ledger.latestSeq("r")).toBe(1);
+  });
+
+  it("gapProbeFault 显式注入口：只造 unknown、写路径 fail-closed；类型上注不出假新鲜", () => {
+    let inject = false;
+    const owners = new Map([["w-b", { residentId: "r", generation: 1 }]]);
+    const { ledger } = FactLedger.create({
+      viewportAuthority: (viewportId) => owners.get(viewportId) ?? null,
+      gapProbeFault: () => (inject ? { status: "unknown", cause: "注入的查账失败" } : null),
+    });
+    ledger.createLedger("r");
+    ledger.openViewport("r", "w-b");
+    const origin = { kind: "viewport", residentId: "r", viewportId: "w-b", generation: 1 } as const;
+    ledger.append("r", { author: "b", kind: "ruling", body: "注入前照常" }, origin);
+    inject = true;
+    expect(() =>
+      ledger.append("r", { author: "b", kind: "ruling", body: "注入中必拒" }, origin),
+    ).toThrow(WriteGateUnavailableError);
+    expect(ledger.probeGap("r", "w-b").status).toBe("unknown"); // 查询门面同源可见
+    inject = false;
+    ledger.append("r", { author: "b", kind: "ruling", body: "注入撤销后恢复" }, origin);
+    expect(ledger.latestSeq("r")).toBe(2); // 注入中那笔被拒，账上只有前后两笔
+  });
+
+  it("SystemLedgerWriter 铸造印：拿原型构造函数配假印也铸不出写手（阿问 review 的纵深防御探针）", () => {
+    const { systemWriter } = FactLedger.create();
+    const proto = Object.getPrototypeOf(systemWriter) as {
+      constructor: new (...args: unknown[]) => unknown;
+    };
+    expect(() => new proto.constructor(Symbol("fake"), {})).toThrow(/铸出/);
   });
 });
 
@@ -823,6 +984,44 @@ describe("持久化", () => {
       );
       expect(() => new FactLedger({ dataDir })).toThrow(/未知 kind/);
     });
+  });
+
+  it("origin 印痕坏档显式失败：未知 kind / 空 system reason / generation 非整数（界 review 的 P3 回归）", () => {
+    // 把 #validateSnapshot 的 origin 深层校验拆掉后，这三份坏档会被静默
+    // 恢复进内存、经 entries() 外泄、再次落盘——此前无测试钉住（变异实证）。
+    const badOrigins: { name: string; origin: unknown; message: RegExp }[] = [
+      { name: "martian", origin: { kind: "martian" }, message: /未知 kind/ },
+      { name: "empty-reason", origin: { kind: "system", reason: "  " }, message: /空署名/ },
+      {
+        name: "bad-generation",
+        origin: { kind: "viewport", viewportId: "w-b", generation: "one" },
+        message: /generation 不是整数/,
+      },
+    ];
+    for (const bad of badOrigins) {
+      withTempDir((dataDir) => {
+        writeFileSync(
+          join(dataDir, "r.facts.json"),
+          JSON.stringify({
+            schemaVersion: 2,
+            residentId: "r",
+            entries: [
+              {
+                seq: 1,
+                ts: "2026-08-20T00:00:00.000Z",
+                author: "m",
+                kind: "ruling",
+                body: bad.name,
+                supersedesSeq: null,
+                origin: bad.origin,
+              },
+            ],
+            viewports: [],
+          }),
+        );
+        expect(() => new FactLedger({ dataDir }), bad.name).toThrow(bad.message);
+      });
+    }
   });
 
   it("supersede 指向另一条 supersede 的坏档显式失败", () => {

--- a/tests/fixtures/turn-gate-host.ts
+++ b/tests/fixtures/turn-gate-host.ts
@@ -99,7 +99,9 @@ type HostCommand = {
     | "recall"
     | "killSession"
     | "appendRuling"
+    | "appendRulingFromB"
     | "supersede"
+    | "supersedeFromB"
     | "entries"
     | "currentSet"
     | "openWindowB"
@@ -172,6 +174,21 @@ async function execute(command: HostCommand): Promise<unknown> {
         kind: command.kind ?? "ruling",
         body: requireString(command.body, "body"),
       });
+    // C04：B 窗署名的裁定级写入——同一个 append 入口，只多一个发起方。
+    // 窗「自查与否」在这条路径上不存在：装置故意不做任何前置检查，
+    // 拦不拦全看账侧。
+    case "appendRulingFromB": {
+      const residentId = requireString(command.residentId, "residentId");
+      return ledger.append(
+        residentId,
+        {
+          author: requireString(command.author, "author"),
+          kind: command.kind ?? "ruling",
+          body: requireString(command.body, "body"),
+        },
+        { viewportId: windowBOf(residentId) },
+      );
+    }
     case "supersede":
       return ledger.supersede(
         requireString(command.residentId, "residentId"),
@@ -181,6 +198,18 @@ async function execute(command: HostCommand): Promise<unknown> {
           reason: requireString(command.reason, "reason"),
         },
       );
+    case "supersedeFromB": {
+      const residentId = requireString(command.residentId, "residentId");
+      return ledger.supersede(
+        residentId,
+        command.targetSeq ?? -1,
+        {
+          author: requireString(command.author, "author"),
+          reason: requireString(command.reason, "reason"),
+        },
+        { viewportId: windowBOf(residentId) },
+      );
+    }
     case "entries":
       return ledger.entries(requireString(command.residentId, "residentId"));
     case "currentSet":

--- a/tests/fixtures/turn-gate-host.ts
+++ b/tests/fixtures/turn-gate-host.ts
@@ -169,11 +169,16 @@ async function execute(command: HostCommand): Promise<unknown> {
       await driver.killSession(requireString(command.residentId, "residentId"));
       return null;
     case "appendRuling":
-      return ledger.append(requireString(command.residentId, "residentId"), {
-        author: requireString(command.author, "author"),
-        kind: command.kind ?? "ruling",
-        body: requireString(command.body, "body"),
-      });
+      // 主线程/管理员落账：显式 system 来源，不受 C04 落后窗闸（豁免必须自报）。
+      return ledger.append(
+        requireString(command.residentId, "residentId"),
+        {
+          author: requireString(command.author, "author"),
+          kind: command.kind ?? "ruling",
+          body: requireString(command.body, "body"),
+        },
+        { kind: "system", reason: "main-thread ledger write" },
+      );
     // C04：B 窗署名的裁定级写入——同一个 append 入口，只多一个发起方。
     // 窗「自查与否」在这条路径上不存在：装置故意不做任何前置检查，
     // 拦不拦全看账侧。
@@ -186,10 +191,11 @@ async function execute(command: HostCommand): Promise<unknown> {
           kind: command.kind ?? "ruling",
           body: requireString(command.body, "body"),
         },
-        { viewportId: windowBOf(residentId) },
+        { kind: "viewport", viewportId: windowBOf(residentId) },
       );
     }
     case "supersede":
+      // 主线程解除：显式 system 来源。
       return ledger.supersede(
         requireString(command.residentId, "residentId"),
         command.targetSeq ?? -1,
@@ -197,6 +203,7 @@ async function execute(command: HostCommand): Promise<unknown> {
           author: requireString(command.author, "author"),
           reason: requireString(command.reason, "reason"),
         },
+        { kind: "system", reason: "main-thread supersede" },
       );
     case "supersedeFromB": {
       const residentId = requireString(command.residentId, "residentId");
@@ -207,7 +214,7 @@ async function execute(command: HostCommand): Promise<unknown> {
           author: requireString(command.author, "author"),
           reason: requireString(command.reason, "reason"),
         },
-        { viewportId: windowBOf(residentId) },
+        { kind: "viewport", viewportId: windowBOf(residentId) },
       );
     }
     case "entries":

--- a/tests/fixtures/turn-gate-host.ts
+++ b/tests/fixtures/turn-gate-host.ts
@@ -22,21 +22,24 @@ import {
   type TurnGateEvent,
   ViewportTurnGate,
 } from "../../src/session/turn-gate.ts";
-import {
-  type FactKind,
-  FactLedger,
-  type FactLedgerOptions,
-  type GapProbe,
-} from "../../src/store/fact-ledger.ts";
+import { type FactKind, FactLedger, type FactLedgerOptions } from "../../src/store/fact-ledger.ts";
 
 const dataDir = process.env.MIST_TURN_GATE_DATADIR;
 // 给了 dataDir 就是「落盘宿主」形态：ResidentStore 与 FactLedger 同目录共存
 // （各自认领各自的后缀），供父进程 SIGKILL 后原目录拉起，验猝死不续接。
 // 账的代际权威接 B 窗注册表（A 窗走 driver 不直写账）；systemWriter 是
 // 组装层（本 fixture 的主线程）持有的能力——只在这里铸出，B 窗命令拿不到。
+// MV-C03 故障注入走显式 gapProbeFault 口：只造 unknown、造不出假零也造不出
+// 假新鲜；此前 monkey-patch 公开 probeGap 的写法已被上游 review 定为可误用
+// 先例（实例属性遮蔽会连安全判据一起换），不再使用。
+let probeFails = false;
 const ledgerOptions: FactLedgerOptions = {
   ...(dataDir === undefined ? {} : { dataDir }),
-  generationOf: (viewportId) => sessionsB.get(viewportId)?.generation ?? null,
+  viewportAuthority: (viewportId) => {
+    const live = sessionsB.get(viewportId);
+    return live === undefined ? null : { residentId: live.residentId, generation: live.generation };
+  },
+  gapProbeFault: () => (probeFails ? { status: "unknown", cause: "注入的查账失败" } : null),
 };
 const { ledger, systemWriter } = FactLedger.create(ledgerOptions);
 const events: TurnGateEvent[] = [];
@@ -94,12 +97,7 @@ const serviceB = new MessageTreeService(
   },
 );
 
-// MV-C03 故障注入：查账必返 unknown。「查不到」与「查到是零」在 GapProbe
-// 类型上是两个值，注入只造 unknown，造不出假零。
-let probeFails = false;
-const realProbeGap = ledger.probeGap.bind(ledger);
-ledger.probeGap = (residentId, windowId): GapProbe =>
-  probeFails ? { status: "unknown", cause: "注入的查账失败" } : realProbeGap(residentId, windowId);
+// （MV-C03 故障注入已上移进 ledgerOptions.gapProbeFault——见构造处注释。）
 
 type HostCommand = {
   requestId: string;

--- a/tests/fixtures/turn-gate-host.ts
+++ b/tests/fixtures/turn-gate-host.ts
@@ -22,12 +22,23 @@ import {
   type TurnGateEvent,
   ViewportTurnGate,
 } from "../../src/session/turn-gate.ts";
-import { type FactKind, FactLedger, type GapProbe } from "../../src/store/fact-ledger.ts";
+import {
+  type FactKind,
+  FactLedger,
+  type FactLedgerOptions,
+  type GapProbe,
+} from "../../src/store/fact-ledger.ts";
 
 const dataDir = process.env.MIST_TURN_GATE_DATADIR;
 // 给了 dataDir 就是「落盘宿主」形态：ResidentStore 与 FactLedger 同目录共存
 // （各自认领各自的后缀），供父进程 SIGKILL 后原目录拉起，验猝死不续接。
-const ledger = dataDir === undefined ? new FactLedger() : new FactLedger({ dataDir });
+// 账的代际权威接 B 窗注册表（A 窗走 driver 不直写账）；systemWriter 是
+// 组装层（本 fixture 的主线程）持有的能力——只在这里铸出，B 窗命令拿不到。
+const ledgerOptions: FactLedgerOptions = {
+  ...(dataDir === undefined ? {} : { dataDir }),
+  generationOf: (viewportId) => sessionsB.get(viewportId)?.generation ?? null,
+};
+const { ledger, systemWriter } = FactLedger.create(ledgerOptions);
 const events: TurnGateEvent[] = [];
 const logger: TurnEventLogger = {
   log: (event) => {
@@ -141,6 +152,13 @@ function windowBOf(residentId: string): string {
   return windowId;
 }
 
+/** B 窗署名三元组用的代际——从注册表现取（装置模拟的是「守规矩地报出自己的真实代际」的窗）。 */
+function generationBOf(viewportId: string): number {
+  const generation = sessionsB.get(viewportId)?.generation;
+  if (generation === undefined) throw new Error(`no B session for ${viewportId}`);
+  return generation;
+}
+
 async function execute(command: HostCommand): Promise<unknown> {
   switch (command.op) {
     case "createResident": {
@@ -169,21 +187,23 @@ async function execute(command: HostCommand): Promise<unknown> {
       await driver.killSession(requireString(command.residentId, "residentId"));
       return null;
     case "appendRuling":
-      // 主线程/管理员落账：显式 system 来源，不受 C04 落后窗闸（豁免必须自报）。
-      return ledger.append(
+      // 主线程/管理员落账：走组装层持有的 system 能力写手——豁免凭能力
+      // 不凭自报，reason 落痕进条目（C04 权威半格）。
+      return systemWriter.append(
         requireString(command.residentId, "residentId"),
         {
           author: requireString(command.author, "author"),
           kind: command.kind ?? "ruling",
           body: requireString(command.body, "body"),
         },
-        { kind: "system", reason: "main-thread ledger write" },
+        "main-thread ledger write",
       );
     // C04：B 窗署名的裁定级写入——同一个 append 入口，只多一个发起方。
     // 窗「自查与否」在这条路径上不存在：装置故意不做任何前置检查，
     // 拦不拦全看账侧。
     case "appendRulingFromB": {
       const residentId = requireString(command.residentId, "residentId");
+      const viewportId = windowBOf(residentId);
       return ledger.append(
         residentId,
         {
@@ -191,22 +211,23 @@ async function execute(command: HostCommand): Promise<unknown> {
           kind: command.kind ?? "ruling",
           body: requireString(command.body, "body"),
         },
-        { kind: "viewport", viewportId: windowBOf(residentId) },
+        { kind: "viewport", residentId, viewportId, generation: generationBOf(viewportId) },
       );
     }
     case "supersede":
-      // 主线程解除：显式 system 来源。
-      return ledger.supersede(
+      // 主线程解除：同样走 system 能力写手。
+      return systemWriter.supersede(
         requireString(command.residentId, "residentId"),
         command.targetSeq ?? -1,
         {
           author: requireString(command.author, "author"),
           reason: requireString(command.reason, "reason"),
         },
-        { kind: "system", reason: "main-thread supersede" },
+        "main-thread supersede",
       );
     case "supersedeFromB": {
       const residentId = requireString(command.residentId, "residentId");
+      const viewportId = windowBOf(residentId);
       return ledger.supersede(
         residentId,
         command.targetSeq ?? -1,
@@ -214,7 +235,7 @@ async function execute(command: HostCommand): Promise<unknown> {
           author: requireString(command.author, "author"),
           reason: requireString(command.reason, "reason"),
         },
-        { kind: "viewport", viewportId: windowBOf(residentId) },
+        { kind: "viewport", residentId, viewportId, generation: generationBOf(viewportId) },
       );
     }
     case "entries":

--- a/tests/turn-gate-host.test.ts
+++ b/tests/turn-gate-host.test.ts
@@ -372,6 +372,111 @@ describe("turn-gate real host subprocess", () => {
     expect(await callHost<LedgerEntry[]>(child, { op: "currentSet", residentId })).toEqual([]);
   });
 
+  it("MV-C04 闸在非缺失方：落后窗直写裁定级条目被账侧拒收，账上一个字节不多；追平后放行", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { residentId } = await callHost<{ residentId: string }>(child, {
+      op: "createResident",
+      name: "placeholder-c04",
+    });
+    // B 窗开在空账上（baseline=0），随后主线程落一条裁定——B 落后一条，
+    // 且这条路径上没有任何窗自查：拦不拦全看账侧写路径。
+    const { windowId: windowB } = await callHost<{ windowId: string }>(child, {
+      op: "openWindowB",
+      residentId,
+    });
+    await callHost(child, {
+      op: "appendRuling",
+      residentId,
+      author: "main-thread",
+      kind: "ruling",
+      body: "placeholder ruling unseen by B",
+    });
+
+    // 落后窗写新裁定：拒收，且账上没有多出条目。
+    await expect(
+      callHost(child, {
+        op: "appendRulingFromB",
+        residentId,
+        author: "placeholder-resident",
+        kind: "ruling",
+        body: "placeholder stale write",
+      }),
+    ).rejects.toThrow(/StaleViewportError/);
+    // 落后窗解除它没见过的那条裁定：同样拒收。
+    await expect(
+      callHost(child, {
+        op: "supersedeFromB",
+        residentId,
+        targetSeq: 1,
+        author: "placeholder-resident",
+        reason: "placeholder stale supersede",
+      }),
+    ).rejects.toThrow(/StaleViewportError/);
+    expect(await callHost<LedgerEntry[]>(child, { op: "entries", residentId })).toHaveLength(1);
+
+    // B 过一轮开工闸追平缺口后，同一扇窗的写入放行——闸拦的是「落后」，
+    // 不是「窗」。
+    await callHost(child, { op: "sayOnB", residentId, message: "placeholder align turn" });
+    expect(await callHost<number>(child, { op: "ackedSeq", residentId, windowId: windowB })).toBe(
+      1,
+    );
+    const written = await callHost<LedgerEntry>(child, {
+      op: "appendRulingFromB",
+      residentId,
+      author: "placeholder-resident",
+      kind: "ruling",
+      body: "placeholder synced write",
+    });
+    expect(written).toMatchObject({ seq: 2, kind: "ruling" });
+  });
+
+  it("MV-C04 unknown 半格：查账失败时窗署名写入 fail-closed；非窗来源写入不受此闸", async () => {
+    const child = startHost();
+    await waitForReady(child);
+    const { residentId } = await callHost<{ residentId: string }>(child, {
+      op: "createResident",
+      name: "placeholder-c04-unknown",
+    });
+    await callHost(child, { op: "openWindowB", residentId });
+    await callHost(child, { op: "failProbe", on: true });
+
+    // 查不到 ≠ 没缺口：窗署名的裁定级写入 fail-closed。
+    await expect(
+      callHost(child, {
+        op: "appendRulingFromB",
+        residentId,
+        author: "placeholder-resident",
+        kind: "ruling",
+        body: "placeholder write under unknown",
+      }),
+    ).rejects.toThrow(/WriteGateUnavailableError/);
+    expect(await callHost<LedgerEntry[]>(child, { op: "entries", residentId })).toHaveLength(0);
+
+    // 非窗来源（主线程落账）不经 C04 闸——闸拦的是「落后的窗」，
+    // 不是「不是窗的写方」。
+    const mainWrite = await callHost<LedgerEntry>(child, {
+      op: "appendRuling",
+      residentId,
+      author: "main-thread",
+      kind: "ruling",
+      body: "placeholder main-thread write during outage",
+    });
+    expect(mainWrite).toMatchObject({ seq: 1, kind: "ruling" });
+
+    // 注入撤销后，追平的窗恢复写入——fail-closed 不是永久熔断。
+    await callHost(child, { op: "failProbe", on: false });
+    await callHost(child, { op: "sayOnB", residentId, message: "placeholder recovery turn" });
+    const recovered = await callHost<LedgerEntry>(child, {
+      op: "appendRulingFromB",
+      residentId,
+      author: "placeholder-resident",
+      kind: "ruling",
+      body: "placeholder recovered write",
+    });
+    expect(recovered).toMatchObject({ seq: 2, kind: "ruling" });
+  });
+
   it("宿主猝死不续接旧窗（PR #98 拍板）：同 dataDir 拉起新宿主，人与账原样恢复，新窗重新初始对齐", async () => {
     const dir = mkdtempSync(join(tmpdir(), "mist-gate-crash-"));
     directories.push(dir);

--- a/tests/turn-gate.test.ts
+++ b/tests/turn-gate.test.ts
@@ -37,7 +37,7 @@ function setup(options: { reply?: AssistantReply } = {}) {
   });
   store.createRoom(RESIDENT);
   const sessions = new SessionRegistry<null>();
-  const ledger = new FactLedger();
+  const { ledger, systemWriter: system } = FactLedger.create();
   ledger.createLedger(RESIDENT);
   const logger = new CollectingLogger();
   const gate = new ViewportTurnGate(ledger, {
@@ -63,7 +63,7 @@ function setup(options: { reply?: AssistantReply } = {}) {
   );
   const window = sessions.open(RESIDENT, { context: null });
   ledger.openViewport(RESIDENT, window.windowId);
-  return { store, sessions, ledger, logger, gate, service, prompts, window };
+  return { store, sessions, ledger, system, logger, gate, service, prompts, window };
 }
 
 describe("ViewportTurnGate 经 MessageTreeService.say", () => {
@@ -91,17 +91,9 @@ describe("ViewportTurnGate 经 MessageTreeService.say", () => {
   });
 
   it("有缺口：注入格式档位标注齐全，落树 user 仍是原文，落树后 ack 到 latestSeq", async () => {
-    const { service, ledger, prompts, logger, window } = setup();
-    ledger.append(
-      RESIDENT,
-      { author: "main-thread", kind: "ruling", body: "裁定甲" },
-      { kind: "system", reason: "test" },
-    );
-    ledger.append(
-      RESIDENT,
-      { author: "main-thread", kind: "active_rule", body: "规矩乙" },
-      { kind: "system", reason: "test" },
-    );
+    const { service, ledger, system, prompts, logger, window } = setup();
+    system.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" }, "test");
+    system.append(RESIDENT, { author: "main-thread", kind: "active_rule", body: "规矩乙" }, "test");
 
     await service.say(RESIDENT, "住户原话", window.windowId);
 
@@ -137,18 +129,14 @@ describe("ViewportTurnGate 经 MessageTreeService.say", () => {
 
   it("assistantReply 失败：不 ack 不落树，下轮原样重拉后正常 ack（MV-C05）", async () => {
     const prompts: string[] = [];
-    const { service, ledger, window } = setup({
+    const { service, ledger, system, window } = setup({
       reply: (_residentId, message) => {
         prompts.push(message);
         if (prompts.length === 1) throw new Error("model down");
         return "复原后的回应";
       },
     });
-    ledger.append(
-      RESIDENT,
-      { author: "main-thread", kind: "ruling", body: "裁定甲" },
-      { kind: "system", reason: "test" },
-    );
+    system.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" }, "test");
 
     await expect(service.say(RESIDENT, "第一句", window.windowId)).rejects.toThrow("model down");
     expect(ledger.ackedSeq(RESIDENT, window.windowId)).toBe(0);
@@ -191,13 +179,9 @@ describe("ViewportTurnGate 经 MessageTreeService.say", () => {
   });
 
   it("reviseNode 不过闸：有缺口时改口既不拉取也不 ack（改口不是开工）", async () => {
-    const { service, ledger, logger, window } = setup();
+    const { service, ledger, system, logger, window } = setup();
     const reply = await service.say(RESIDENT, "初稿", window.windowId);
-    ledger.append(
-      RESIDENT,
-      { author: "main-thread", kind: "ruling", body: "裁定甲" },
-      { kind: "system", reason: "test" },
-    );
+    system.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" }, "test");
     const eventsBefore = logger.events.length;
 
     await service.reviseNode(RESIDENT, reply.id, "改口", window.windowId);
@@ -221,12 +205,8 @@ describe("ViewportTurnGate.noteOrdinaryAction（MV-C03 普通半）", () => {
   });
 
   it("查账正常：什么都不记，什么都不做", () => {
-    const { gate, ledger, window, logger } = setup();
-    ledger.append(
-      RESIDENT,
-      { author: "main-thread", kind: "ruling", body: "裁定甲" },
-      { kind: "system", reason: "test" },
-    );
+    const { gate, ledger, system, window, logger } = setup();
+    system.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" }, "test");
 
     expect(() => gate.noteOrdinaryAction(RESIDENT, window.windowId)).not.toThrow();
 
@@ -247,12 +227,8 @@ describe("ViewportTurnGate.noteOrdinaryAction（MV-C03 普通半）", () => {
 
 describe("回执幂等", () => {
   it("同一轮 commit 重发不炸也不退（MV-C05：回执重发是传播机制的常态）", () => {
-    const { gate, ledger, window } = setup();
-    ledger.append(
-      RESIDENT,
-      { author: "main-thread", kind: "ruling", body: "裁定甲" },
-      { kind: "system", reason: "test" },
-    );
+    const { gate, ledger, system, window } = setup();
+    system.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" }, "test");
 
     const pass = gate.beforeTurn(RESIDENT, window.windowId);
     pass.commit();
@@ -314,7 +290,7 @@ describe("ack 落盘失败（MV-C05：回执未达不能否认本轮已交付）
     store.createRoom(RESIDENT);
     const sessions = new SessionRegistry<null>();
     // 真 FactLedger + 真 dataDir：注入的是磁盘写失败，不是 mocked 的账。
-    const ledger = new FactLedger({ dataDir: dir });
+    const { ledger, systemWriter: system } = FactLedger.create({ dataDir: dir });
     ledger.createLedger(RESIDENT);
     const logger = new CollectingLogger();
     const gate = new ViewportTurnGate(ledger, {
@@ -338,11 +314,7 @@ describe("ack 落盘失败（MV-C05：回执未达不能否认本轮已交付）
     );
     const window = sessions.open(RESIDENT, { context: null });
     ledger.openViewport(RESIDENT, window.windowId);
-    ledger.append(
-      RESIDENT,
-      { author: "main-thread", kind: "ruling", body: "裁定甲" },
-      { kind: "system", reason: "test" },
-    );
+    system.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" }, "test");
 
     // chmod 0555 让 ack 的落盘必败（同 tests/fact-ledger.test.ts 的装置）。
     let reply: HistoryNode | undefined;

--- a/tests/turn-gate.test.ts
+++ b/tests/turn-gate.test.ts
@@ -92,8 +92,16 @@ describe("ViewportTurnGate 经 MessageTreeService.say", () => {
 
   it("有缺口：注入格式档位标注齐全，落树 user 仍是原文，落树后 ack 到 latestSeq", async () => {
     const { service, ledger, prompts, logger, window } = setup();
-    ledger.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" });
-    ledger.append(RESIDENT, { author: "main-thread", kind: "active_rule", body: "规矩乙" });
+    ledger.append(
+      RESIDENT,
+      { author: "main-thread", kind: "ruling", body: "裁定甲" },
+      { kind: "system", reason: "test" },
+    );
+    ledger.append(
+      RESIDENT,
+      { author: "main-thread", kind: "active_rule", body: "规矩乙" },
+      { kind: "system", reason: "test" },
+    );
 
     await service.say(RESIDENT, "住户原话", window.windowId);
 
@@ -136,7 +144,11 @@ describe("ViewportTurnGate 经 MessageTreeService.say", () => {
         return "复原后的回应";
       },
     });
-    ledger.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" });
+    ledger.append(
+      RESIDENT,
+      { author: "main-thread", kind: "ruling", body: "裁定甲" },
+      { kind: "system", reason: "test" },
+    );
 
     await expect(service.say(RESIDENT, "第一句", window.windowId)).rejects.toThrow("model down");
     expect(ledger.ackedSeq(RESIDENT, window.windowId)).toBe(0);
@@ -181,7 +193,11 @@ describe("ViewportTurnGate 经 MessageTreeService.say", () => {
   it("reviseNode 不过闸：有缺口时改口既不拉取也不 ack（改口不是开工）", async () => {
     const { service, ledger, logger, window } = setup();
     const reply = await service.say(RESIDENT, "初稿", window.windowId);
-    ledger.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" });
+    ledger.append(
+      RESIDENT,
+      { author: "main-thread", kind: "ruling", body: "裁定甲" },
+      { kind: "system", reason: "test" },
+    );
     const eventsBefore = logger.events.length;
 
     await service.reviseNode(RESIDENT, reply.id, "改口", window.windowId);
@@ -206,7 +222,11 @@ describe("ViewportTurnGate.noteOrdinaryAction（MV-C03 普通半）", () => {
 
   it("查账正常：什么都不记，什么都不做", () => {
     const { gate, ledger, window, logger } = setup();
-    ledger.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" });
+    ledger.append(
+      RESIDENT,
+      { author: "main-thread", kind: "ruling", body: "裁定甲" },
+      { kind: "system", reason: "test" },
+    );
 
     expect(() => gate.noteOrdinaryAction(RESIDENT, window.windowId)).not.toThrow();
 
@@ -228,7 +248,11 @@ describe("ViewportTurnGate.noteOrdinaryAction（MV-C03 普通半）", () => {
 describe("回执幂等", () => {
   it("同一轮 commit 重发不炸也不退（MV-C05：回执重发是传播机制的常态）", () => {
     const { gate, ledger, window } = setup();
-    ledger.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" });
+    ledger.append(
+      RESIDENT,
+      { author: "main-thread", kind: "ruling", body: "裁定甲" },
+      { kind: "system", reason: "test" },
+    );
 
     const pass = gate.beforeTurn(RESIDENT, window.windowId);
     pass.commit();
@@ -314,7 +338,11 @@ describe("ack 落盘失败（MV-C05：回执未达不能否认本轮已交付）
     );
     const window = sessions.open(RESIDENT, { context: null });
     ledger.openViewport(RESIDENT, window.windowId);
-    ledger.append(RESIDENT, { author: "main-thread", kind: "ruling", body: "裁定甲" });
+    ledger.append(
+      RESIDENT,
+      { author: "main-thread", kind: "ruling", body: "裁定甲" },
+      { kind: "system", reason: "test" },
+    );
 
     // chmod 0555 让 ack 的落盘必败（同 tests/fact-ledger.test.ts 的装置）。
     let reply: HistoryNode | undefined;


### PR DESCRIPTION
认领楼：#80（【獭獭｜认领 MV-C04】，Bijou 一户）。**只开不合，main 归维护者。**

## 做了什么

MV-C04「闸在非缺失方」：未知悉裁定的窗发起裁定级写入（append/supersede）时，拦截由**账侧必经写路径**执行，不依赖窗自查。实现完全按楼内 Laurie 08:08 ①②与 Elio 08:10 1-3 的拍板形状：

- **公开写口只有 viewport 三元组**：`append/supersede` 的 origin 是必填的 `{ kind: "viewport", residentId, viewportId, generation }`——省略在类型层即编译错误（Laurie ①「动签名不包 wrapper」）；运行时半格对 JS 硬塞非三元组/自报 system 响亮拒绝。
- **账侧四道检查**（写前，闸先于目标校验）：形状 → residentId 与目标账一致 → `generationOf` 权威现查代际（构造选项注入，权威在 SessionRegistry 侧、账不反向依赖 registry；未接线/查不到 fail-closed `WriteGateUnavailableError`，旧代号 `StaleGenerationError`）→ `probeGap`（unknown fail-closed；`ackedSeq < latestSeq` 抛 `StaleViewportError`，零多写）。
  - 与 Laurie ① 草案的一处刻意偏差：viewport 分支带的是 `generation` 而不是自报 `ackedSeq`——ackedSeq 账自己就是权威（probeGap 现查），让写方自报等于再开一个可伪造字段；generation 才是账不知道、必须向 registry 权威核的那一半（Elio 1/2 的口径）。
- **system 豁免 = 不可伪造能力，不是联合字段**（Elio 3）：原子追加收为私有；`FactLedger.create()` 一次性铸出 `SystemLedgerWriter`（类不导出值、构造函数验模块私有 Symbol 铸造印，模块外 new 不出来仿不出来），由组装层持有；每次写入必须给非空 reason。
- **reason 落痕进不可变账目**（Laurie ②）：`LedgerEntry.origin` 与 author 并排持久化（system 落 reason，viewport 落 viewportId+generation），归档查询与进程重启恢复后均可审计。

## 提交链（红灯先行）

- `eddcecf` 红灯：落后窗/unknown 下的窗署名裁定级直写现状放行（6 passed / 2 failed，红的正是两条 [集成]）
- `9b88c69` 绿灯：账侧写闸落地（stale/unknown 拒收）
- `7f35a11` 家内审 P1：origin 改必填判别联合，堵「省略即当 system」
- `a7488a9` 家内审二轮三点：authority（能力化）/ generation（三元组+权威校验）/ reason（落痕入账）

## 证据

- 集成（`turn-gate-host` 子进程真宿主，#98 TurnGate 必经路径同一本账）：落后 B 窗直写被 `StaleViewportError` 拒收且零多写；probe unknown 时写路径 fail-closed；追平后放行、主线程显式 system 写成功。8/8。
- Elio 点名的红灯四支+1 对应常驻测试：旧代 generation 直写被拒（`StaleGenerationError`）；未知窗直写被拒（权威查不到 → fail-closed）；有缺口活窗直写被拒（[集成] StaleViewportError）；显式 host 写成功且归档可读 reason（含落盘重启复读）；结构探针以「`SystemLedgerWriter` 在模块值域不可达（import * 断言 undefined）+ 构造铸造印」落地——与你说的「exported raw append/supersede 一出现即红」形状不完全同，raw 口如今是 `#` 私有、导出即需改类本身，若还想要显式结构测试我可补。
- 变异探针六支（打完即复原，收据在家内工单）：A 拆整闸 / B unknown 放行 / C 拆落后判据 / E 闸顶加「自报 system 放行」→ 只红伪报那条（1/69）/ F 拆代际比对 → 只红旧 generation 那条（1/69）；Laurie 要的「origin 改可选缺省 system 必须红」（D）在现签名下已是**编译错误**，运行时半分身由 E 覆盖。
- Node22 全量：typecheck 0；biome 零修；44 files passed / 3 skipped，490 passed / 38 todo。

## 如实明示（家内审第三轮 PASS 时点名要求写清）

1. **快照 schema v1→v2 不是无感升级**：条目新增必填 `origin` 字段，v2 严格校验；v1 旧档启动时**显式失败等迁移**（沿用本文件「坏档不猜、不静默跳过」的既有口径）。按 Laurie 现场读数 `append/supersede` 在 src 零生产调用方、仓库 0.0.0，我判断此刻是改 schema 代价最低的时候；如维护者要迁移器或宽容读取，我补。
2. 两个 P3 清洁项（家内 reviewer 指出，非阻塞，随维护者意见修）：`#assertViewportOriginCurrent` 里 viewportId 的 runtime typeof 检查与类型层重复；restore 对 `origin.generation` 只验整数未显式验 ≥1。

## 与 B03（#79 墨安）的接缝

真实派发链归墨安，本 PR 不碰他的施工面；账侧闸的证据全部立在 #98 已落的 TurnGate 必经路径上。端到端（真实链上的落后窗被账侧拦下）待他的链落地后 rebase 取证——**acceptance/multi-viewport.md 的 C04 格本 PR 不勾**，链侧阻塞面如上，勾选留给接缝完成之后。

🤖 Generated with [Claude Code](https://claude.com/claude-code)