### PR TITLE
ci: 判卷转 strict 拦 merge（收 2026-08-14「六绿后转 strict」拍板）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm test
-      # 报告模式：闭环建成前红灯是常态，只看板不拦门。
-      # 六绿之后把这行换成 acceptance:strict，红灯开始拦 merge。
-      - run: npm run acceptance
+      # 闭环已建成：第一里程碑自 2026-08-14 六盏真绿（STUBBED 已清、独立复验
+      # 已落章），按当日拍板「六绿后判卷转 strict」收口——灯变红即拦 merge。
+      - run: npm run acceptance:strict


### PR DESCRIPTION
收 2026-08-14 的拍板：「CI 三件套拦门、判卷报告不拦门，**六绿后判卷转 strict 开始拦 merge**」。

## 为什么现在能收

- 第一里程碑 2026-08-14 起**六盏真绿**，`src/acceptance-driver.ts` 的 `STUBBED` 已是空数组（桩清零）；
- 实测 `npm run acceptance:strict` **退出码 0**（本地刚跑）；
- 本地 `lint` / `typecheck` / `test`（539 过）全绿，YAML 解析校验通过。

## 改了什么

`.github/workflows/ci.yml` 最后一步由 `npm run acceptance`（报告模式，永远退 0、只看板）换成 `npm run acceptance:strict`，并把那段「六绿之后把这行换成 strict」的注释改成收口记录。

## 让哪盏灯变色

不新增灯；把既有六盏真绿的灯从「只看板」升为「拦门」——验收灯变红从此拦 merge。

## 代价

CI 从「只看板」变「拦门」后，任何让六盏灯变红的改动都会被 CI 挡住，包括有意为之的中间态提交；这类改动需要走一次明确的「先修灯再提交」或调整本步骤。判卷驱动的重构期间会感到摩擦——这是把验收从看板升成闸门的必要成本。
