### PR TITLE
test(mv): recheck 28 clauses and retain 31 mutation receipts (#148)

### DIFF
--- a/acceptance/evidence/multi-viewport-148-2026-09-10.json
+++ b/acceptance/evidence/multi-viewport-148-2026-09-10.json
@@ -1,0 +1,700 @@
+{
+  "schema_version": 1,
+  "issue": 148,
+  "date": "2026-09-10",
+  "baseline": "21d3c451c6ee9ae877bdfeecb6425844e6137092",
+  "test_commit": "453e03b8c00814a0201bf6a8017c5a5cbeab4be0",
+  "status": "verification evidence; not an independent acceptance seal",
+  "provenance": "Each mutation was applied alone, a selected test was run, source was restored byte-for-byte, and the same test command was rerun. M04 uses the strengthened literal assertion. Some records retain full output; others retain the actual failure excerpt and exit status, not fabricated full logs. Checkout paths are normalized; unrelated host environment cleanup is omitted from repository commands.",
+  "counts": {
+    "mutations": 31,
+    "red_exit_1": 31,
+    "restored_exit_0": 31,
+    "selected_tests_failed_per_mutation": 1,
+    "implementation_mutations": 28,
+    "composition_mutations": 3,
+    "distinct_mv_criteria": 26,
+    "no_mutation": ["MV-B02", "MV-E02"],
+    "shared_criteria": ["OS-05"]
+  },
+  "limits": [
+    "Selected-test runs prove the corresponding failure, not absence of other failures under a mutant.",
+    "M18, M24 and M28 mutate fixture composition (usageOf, sudden-death boot context and canonical failure delivery), not production implementation.",
+    "MV-C02 has no push channel. M08 proves pull is load-bearing, not a dropped implemented push transport.",
+    "M24 simulates window death inside a real subprocess; it is not a process SIGKILL experiment.",
+    "The 38 root-suite todo cases are not passes or newly introduced by this change."
+  ],
+  "strengthened_full_suite": {
+    "command": "npm test",
+    "exit_code": 0,
+    "output": "\n> mist-agent@0.0.0 test\n> vitest run\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/fact-ledger.test.ts (77 tests) 88ms\n ✓ tests/breath-host.test.ts (14 tests) 3060ms\n   ✓ MV-D05 canonical handover recall (real host subprocess) > persists through the host path and a fresh process recalls the generation by title alone 507ms\n ✓ tests/resident-self-repair-runner.test.ts (21 tests) 12208ms\n   ✓ resident self-repair runner > runs C1 in a runner-owned sandbox and restores the injected baseline 472ms\n   ✓ resident self-repair runner > retains C2 raw evidence, redacts review surfaces, and exposes four diagnostics 654ms\n   ✓ resident self-repair runner > keeps the frozen C3 40 rejected + 1 ok timeline self-consistent 327ms\n   ✓ resident self-repair runner > passes C4 deterministic stop checks and catches a mutation 1555ms\n   ✓ resident self-repair runner > rejects evidence refs outside the runner workspace instead of trusting the receipt 865ms\n   ✓ resident self-repair runner > finalizes C1 after two matching blind reviews 557ms\n   ✓ resident self-repair runner > locks one blind pair across the run and permits per-item acceptance-seat recusal 381ms\n   ✓ resident self-repair runner > keeps both blind records and accepts a distinct arbitrator choosing one side 379ms\n   ✓ resident self-repair runner > fails G2s when a same-collect raw artifact disappears or its review projection changes 1518ms\n   ✓ resident self-repair runner > aggregates the public positive-control clause into a red verdict for C1 499ms\n   ✓ resident self-repair runner > aggregates the public positive-control clause into a red verdict for C2 867ms\n   ✓ resident self-repair runner > aggregates the public positive-control clause into a red verdict for C3 372ms\n   ✓ resident self-repair runner > rejects a passed control claim whose evidence was not retained 333ms\n   ✓ resident self-repair runner > keeps G5 escalation disposition separate from deterministic G2s 723ms\n   ✓ resident self-repair runner > lets the acceptance seat dispose a runner-signed G4 n/a dispute 634ms\n   ✓ resident self-repair runner > accepts a G4 dispute whenever the runner signed G4 n/a, independent of case id 942ms\n   ✓ resident self-repair runner > keeps equal escalation text distinct and keys identity independently from prose 504ms\n ✓ tests/installer-run.test.ts (20 tests) 81ms\n ✓ tests/plugin-runtime-readiness.test.ts (21 tests) 43ms\n ✓ tests/driver-ledger-wiring.test.ts (17 tests) 36ms\n ✓ tests/turn-gate-host.test.ts (8 tests) 2179ms\n   ✓ turn-gate real host subprocess > 宿主猝死不续接旧窗（PR #98 拍板）：同 dataDir 拉起新宿主，人与账原样恢复，新窗重新初始对齐 514ms\n ✓ tests/installer-controller.test.ts (29 tests) 83ms\n ✓ tests/pv0/pv0-a-manifest.test.ts (10 tests | 1 skipped) 82ms\n ✓ tests/one-stream-reply-router.test.ts (9 tests) 62ms\n ✓ tests/one-stream-workspace.test.ts (8 tests) 38ms\n ✓ tests/plugin-manifest.test.ts (19 tests) 15ms\n ✓ tests/pv0/pv0-c-transactions.test.ts (11 tests | 3 skipped) 80ms\n ✓ tests/pv0/pv0-c-recovery-process.test.ts (3 tests) 3053ms\n   ✓ PV0 series C — 跨进程生命周期恢复与权威投影 (RFC §3) > [PV0-C10] 生命周期中断可恢复 1420ms\n   ✓ PV0 series C — 跨进程生命周期恢复与权威投影 (RFC §3) > [PV0-C11] 权威状态先于公开索引 959ms\n   ✓ PV0 series C — 跨进程生命周期恢复与权威投影 (RFC §3) > [PV0-C14] 恢复凭据防模块漂移 672ms\n ✓ tests/resident-store.test.ts (26 tests) 273ms\n ✓ tests/session-registry.test.ts (17 tests) 28ms\n ✓ tests/one-stream-host.test.ts (4 tests) 1582ms\n   ✓ one canonical stream real host > recovers generation before durable write without duplicate or false effect 570ms\n   ✓ one canonical stream real host > recovers durable write before delivery receipt without duplicate or false effect 493ms\n ✓ tests/turn-gate.test.ts (11 tests) 19ms\n ✓ tests/pv0/pv0-a08-write-gate.test.ts (6 tests) 47ms\n ✓ tests/plugin-transaction-host.test.ts (3 tests) 24ms\n ✓ tests/handover-timeline.test.ts (5 tests) 54ms\n ✓ tests/handover-letter.test.ts (21 tests) 24ms\n ✓ tests/plugin-recovery-coordinator.test.ts (10 tests) 34ms\n ✓ tests/plugin-recovery-integration.test.ts (6 tests) 2060ms\n   ✓ PV0-C10 real process interruption recovery > persists operationId/moduleRef/recoveryKey before a resource effect receipt, then recovers without rerunning prepare/activate 471ms\n   ✓ PV0-C10 real process interruption recovery > rolls back all committed resources when killed inside the sole publication call 320ms\n   ✓ PV0-C10 real process interruption recovery > continues an interrupted dispose from durable receipts and ends disposed 321ms\n   ✓ PV0-C11 authority is durable before every public projection > keeps restarted indexes a subset of authority after SIGKILL at before-active-authority-commit 322ms\n   ✓ PV0-C11 authority is durable before every public projection > keeps restarted indexes a subset of authority after SIGKILL at active-authority-committed-before-publish 305ms\n   ✓ PV0-C11 authority is durable before every public projection > keeps restarted indexes a subset of authority after SIGKILL at published-before-operation-complete 318ms\n ✓ tests/message-tree-service-adversarial.test.ts (10 tests) 12ms\n ✓ tests/breath-cycle.test.ts (17 tests) 26ms\n ✓ tests/message-tree-service.test.ts (12 tests) 21ms\n ✓ tests/resident-migration-store.test.ts (6 tests) 28ms\n ✓ tests/multi-viewport-host.test.ts (1 test) 651ms\n   ✓ multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 650ms\n ✓ tests/message-tree-store.test.ts (14 tests) 12ms\n ✓ tests/message-tree-bulk-io.test.ts (13 tests) 12ms\n ✓ tests/intentional-isolation.test.ts (5 tests) 12ms\n ✓ tests/resident-migration.test.ts (7 tests) 45ms\n ✓ tests/one-stream-core.test.ts (5 tests) 19ms\n ✓ tests/persistence.test.ts (9 tests) 18ms\n ✓ tests/plugin-host-service-delivery.test.ts (5 tests) 28ms\n ✓ tests/bootpack.test.ts (10 tests) 11ms\n ✓ tests/dispatch-logging-host.test.ts (1 test) 277ms\n ✓ tests/acceptance-driver-options.test.ts (7 tests) 52ms\n ✓ tests/intentional-isolation-host.test.ts (1 test) 272ms\n ✓ tests/resident-migration-tree-bridge.test.ts (3 tests) 11ms\n ✓ tests/session-boundary.test.ts (8 tests) 15ms\n ✓ tests/pv0/pv0-f-readiness-semantics.test.ts (6 tests | 3 skipped) 8ms\n ✓ tests/message-tree-store-adversarial.test.ts (5 tests) 26ms\n ↓ tests/pv0/pv0-b-permissions-secrets.test.ts (14 tests | 14 skipped)\n ✓ tests/plugin-lifecycle.test.ts (7 tests) 17ms\n ✓ tests/breath-trigger.test.ts (4 tests) 15ms\n ✓ tests/one-stream-lifecycle.test.ts (2 tests) 11ms\n ✓ tests/resident-self-repair-schema.test.ts (3 tests) 130ms\n ✓ tests/memory-library.test.ts (4 tests) 9ms\n ✓ tests/pi-login.test.ts (3 tests) 10ms\n ↓ tests/pv0/pv0-d-bindings-credentials.test.ts (10 tests | 10 skipped)\n ↓ tests/pv0/pv0-e-upgrade-migration.test.ts (7 tests | 7 skipped)\n ✓ tests/smoke.test.ts (2 tests) 3ms\n\n Test Files  51 passed | 3 skipped (54)\n      Tests  539 passed | 38 todo (577)\n   Start at  13:10:34\n   Duration  48.13s (transform 2.01s, setup 0ms, collect 3.76s, tests 27.01s, environment 14ms, prepare 5.37s)\n\n"
+  },
+  "final_verification": [
+    {
+      "name": "root-final",
+      "cwd": ".",
+      "command": "npm test",
+      "started_at": "2026-09-10T05:29:38.642Z",
+      "finished_at": "2026-09-10T05:30:33.130Z",
+      "exit_code": 0,
+      "output": "\n> mist-agent@0.0.0 test\n> vitest run\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/fact-ledger.test.ts (77 tests) 134ms\n ✓ tests/breath-host.test.ts (14 tests) 5688ms\n   ✓ MV-D05 canonical handover recall (real host subprocess) > persists through the host path and a fresh process recalls the generation by title alone 640ms\n   ✓ 换气阈值硬闸与手动入口（real host subprocess） > MV-D01 阈值硬闸 + 回合容差：过线回合跑完，下一回合被拦，换气后放行 490ms\n   ✓ 换气阈值硬闸与手动入口（real host subprocess） > MV-D02 阈值只能开工时配：运行中修改一律 CONFIG_INVALID，换代后重新可配 513ms\n   ✓ 换气阈值硬闸与手动入口（real host subprocess） > MV-D04 后半：注入新代的交接信全文不计入窗口阈值核算 511ms\n   ✓ MV-D09 换气失败外显（real host subprocess） > 撞线先外显预告，换气失败外显；失败后的下一次阈值穿越重新预告 557ms\n   ✓ OS-05 宿主换气失败进入 canonical stream > 真实换气失败由宿主签发、明确未生效，并在下一次阈值穿越重新预告 445ms\n   ✓ OS-05 宿主换气失败进入 canonical stream > 真实 swap 失败把需要人捞窗的动作写进 canonical stream 440ms\n   ✓ 猝死与流水残骸（real host subprocess） > MV-D07 猝死不自动注入：新代无猝死窗流水，归档查询可达 337ms\n   ✓ 猝死与流水残骸（real host subprocess） > MV-D07b 合法残骸降级警告并记档：连续两次换气都完成，残骸不楔死状态机 310ms\n   ✓ 猝死与流水残骸（real host subprocess） > MV-D07b 畸形结构硬拦：换气失败外显，隔离记档后重试完成 340ms\n ✓ tests/resident-self-repair-runner.test.ts (21 tests) 12886ms\n   ✓ resident self-repair runner > runs C1 in a runner-owned sandbox and restores the injected baseline 815ms\n   ✓ resident self-repair runner > retains C2 raw evidence, redacts review surfaces, and exposes four diagnostics 1220ms\n   ✓ resident self-repair runner > keeps the frozen C3 40 rejected + 1 ok timeline self-consistent 411ms\n   ✓ resident self-repair runner > passes C4 deterministic stop checks and catches a mutation 1355ms\n   ✓ resident self-repair runner > rejects evidence refs outside the runner workspace instead of trusting the receipt 839ms\n   ✓ resident self-repair runner > finalizes C1 after two matching blind reviews 568ms\n   ✓ resident self-repair runner > locks one blind pair across the run and permits per-item acceptance-seat recusal 542ms\n   ✓ resident self-repair runner > keeps both blind records and accepts a distinct arbitrator choosing one side 390ms\n   ✓ resident self-repair runner > fails G2s when a same-collect raw artifact disappears or its review projection changes 1277ms\n   ✓ resident self-repair runner > aggregates the public positive-control clause into a red verdict for C1 529ms\n   ✓ resident self-repair runner > aggregates the public positive-control clause into a red verdict for C2 985ms\n   ✓ resident self-repair runner > aggregates the public positive-control clause into a red verdict for C3 503ms\n   ✓ resident self-repair runner > rejects a passed control claim whose evidence was not retained 360ms\n   ✓ resident self-repair runner > keeps G5 escalation disposition separate from deterministic G2s 663ms\n   ✓ resident self-repair runner > lets the acceptance seat dispose a runner-signed G4 n/a dispute 561ms\n   ✓ resident self-repair runner > accepts a G4 dispute whenever the runner signed G4 n/a, independent of case id 806ms\n   ✓ resident self-repair runner > keeps equal escalation text distinct and keys identity independently from prose 479ms\n ✓ tests/installer-run.test.ts (20 tests) 127ms\n ✓ tests/plugin-runtime-readiness.test.ts (21 tests) 47ms\n ✓ tests/driver-ledger-wiring.test.ts (17 tests) 39ms\n ✓ tests/turn-gate-host.test.ts (8 tests) 1863ms\n   ✓ turn-gate real host subprocess > 宿主猝死不续接旧窗（PR #98 拍板）：同 dataDir 拉起新宿主，人与账原样恢复，新窗重新初始对齐 512ms\n ✓ tests/installer-controller.test.ts (29 tests) 113ms\n ✓ tests/pv0/pv0-a-manifest.test.ts (10 tests | 1 skipped) 84ms\n ✓ tests/one-stream-reply-router.test.ts (9 tests) 64ms\n ✓ tests/one-stream-workspace.test.ts (8 tests) 47ms\n ✓ tests/plugin-manifest.test.ts (19 tests) 15ms\n ✓ tests/pv0/pv0-c-transactions.test.ts (11 tests | 3 skipped) 49ms\n ✓ tests/pv0/pv0-c-recovery-process.test.ts (3 tests) 3285ms\n   ✓ PV0 series C — 跨进程生命周期恢复与权威投影 (RFC §3) > [PV0-C10] 生命周期中断可恢复 1487ms\n   ✓ PV0 series C — 跨进程生命周期恢复与权威投影 (RFC §3) > [PV0-C11] 权威状态先于公开索引 1138ms\n   ✓ PV0 series C — 跨进程生命周期恢复与权威投影 (RFC §3) > [PV0-C14] 恢复凭据防模块漂移 658ms\n ✓ tests/resident-store.test.ts (26 tests) 169ms\n ✓ tests/session-registry.test.ts (17 tests) 27ms\n ✓ tests/one-stream-host.test.ts (4 tests) 1824ms\n   ✓ one canonical stream real host > recovers generation before durable write without duplicate or false effect 717ms\n   ✓ one canonical stream real host > recovers durable write before delivery receipt without duplicate or false effect 605ms\n ✓ tests/turn-gate.test.ts (11 tests) 19ms\n ✓ tests/pv0/pv0-a08-write-gate.test.ts (6 tests) 48ms\n ✓ tests/plugin-transaction-host.test.ts (3 tests) 24ms\n ✓ tests/handover-timeline.test.ts (5 tests) 37ms\n ✓ tests/handover-letter.test.ts (21 tests) 16ms\n ✓ tests/plugin-recovery-coordinator.test.ts (10 tests) 29ms\n ✓ tests/plugin-recovery-integration.test.ts (6 tests) 2392ms\n   ✓ PV0-C10 real process interruption recovery > persists operationId/moduleRef/recoveryKey before a resource effect receipt, then recovers without rerunning prepare/activate 484ms\n   ✓ PV0-C10 real process interruption recovery > rolls back all committed resources when killed inside the sole publication call 495ms\n   ✓ PV0-C10 real process interruption recovery > continues an interrupted dispose from durable receipts and ends disposed 430ms\n   ✓ PV0-C11 authority is durable before every public projection > keeps restarted indexes a subset of authority after SIGKILL at before-active-authority-commit 339ms\n   ✓ PV0-C11 authority is durable before every public projection > keeps restarted indexes a subset of authority after SIGKILL at active-authority-committed-before-publish 328ms\n   ✓ PV0-C11 authority is durable before every public projection > keeps restarted indexes a subset of authority after SIGKILL at published-before-operation-complete 313ms\n ✓ tests/message-tree-service-adversarial.test.ts (10 tests) 12ms\n ✓ tests/breath-cycle.test.ts (17 tests) 39ms\n ✓ tests/message-tree-service.test.ts (12 tests) 29ms\n ✓ tests/resident-migration-store.test.ts (6 tests) 28ms\n ✓ tests/multi-viewport-host.test.ts (1 test) 1065ms\n   ✓ multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 1064ms\n ✓ tests/message-tree-store.test.ts (14 tests) 16ms\n ✓ tests/message-tree-bulk-io.test.ts (13 tests) 16ms\n ✓ tests/intentional-isolation.test.ts (5 tests) 17ms\n ✓ tests/resident-migration.test.ts (7 tests) 55ms\n ✓ tests/one-stream-core.test.ts (5 tests) 33ms\n ✓ tests/persistence.test.ts (9 tests) 26ms\n ✓ tests/plugin-host-service-delivery.test.ts (5 tests) 28ms\n ✓ tests/bootpack.test.ts (10 tests) 11ms\n ✓ tests/dispatch-logging-host.test.ts (1 test) 175ms\n ✓ tests/acceptance-driver-options.test.ts (7 tests) 19ms\n ✓ tests/intentional-isolation-host.test.ts (1 test) 168ms\n ✓ tests/resident-migration-tree-bridge.test.ts (3 tests) 8ms\n ✓ tests/session-boundary.test.ts (8 tests) 18ms\n ✓ tests/pv0/pv0-f-readiness-semantics.test.ts (6 tests | 3 skipped) 6ms\n ✓ tests/message-tree-store-adversarial.test.ts (5 tests) 9ms\n ↓ tests/pv0/pv0-b-permissions-secrets.test.ts (14 tests | 14 skipped)\n ✓ tests/plugin-lifecycle.test.ts (7 tests) 9ms\n ✓ tests/breath-trigger.test.ts (4 tests) 15ms\n ✓ tests/one-stream-lifecycle.test.ts (2 tests) 11ms\n ✓ tests/resident-self-repair-schema.test.ts (3 tests) 143ms\n ✓ tests/memory-library.test.ts (4 tests) 8ms\n ✓ tests/pi-login.test.ts (3 tests) 9ms\n ↓ tests/pv0/pv0-d-bindings-credentials.test.ts (10 tests | 10 skipped)\n ↓ tests/pv0/pv0-e-upgrade-migration.test.ts (7 tests | 7 skipped)\n ✓ tests/smoke.test.ts (2 tests) 4ms\n\n Test Files  51 passed | 3 skipped (54)\n      Tests  539 passed | 38 todo (577)\n   Start at  13:29:40\n   Duration  52.92s (transform 2.07s, setup 0ms, collect 3.84s, tests 31.01s, environment 14ms, prepare 5.57s)\n\n",
+      "output_extent": "full"
+    },
+    {
+      "name": "webui-final",
+      "cwd": "webui",
+      "command": "corepack pnpm exec vitest run apps/dev-server/tests/mist-session-wire-adapter.spec.ts apps/dev-server/tests/mist-session-wire-host.spec.ts packages/host/apiproxy/tests/rpc-schemas.spec.ts apps/dev-server/tests/mist-plugin-host-composition.spec.ts apps/dev-server/tests/mist-plugin.spec.ts",
+      "started_at": "2026-09-10T05:29:38.898Z",
+      "finished_at": "2026-09-10T05:29:51.043Z",
+      "exit_code": 0,
+      "output": "The plugin \"vite-tsconfig-paths\" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.\nThe plugin \"vite-tsconfig-paths\" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.\nThe plugin \"vite-tsconfig-paths\" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.\n\n RUN  v4.1.8 <repo>/webui\n\n\n Test Files  5 passed (5)\n      Tests  49 passed (49)\n   Start at  13:29:42\n   Duration  7.96s (transform 1.89s, setup 1.28s, import 2.67s, tests 2.50s, environment 2ms)\n\n",
+      "output_extent": "full"
+    },
+    {
+      "name": "acceptance-final",
+      "cwd": ".",
+      "command": "npm run acceptance",
+      "started_at": "2026-09-10T05:29:38.434Z",
+      "finished_at": "2026-09-10T05:29:39.780Z",
+      "exit_code": 0,
+      "output": "\n> mist-agent@0.0.0 acceptance\n> tsx acceptance/run.ts\n\nmist 第一里程碑判卷 —— 最小垂直闭环\n\n  🟢 C1 杀会话不丢人：会话真的死了，记忆和树一个字节没少\n       会话连续性成立；kill 未动树；kill 后新 say 开新根；生前记忆在新启动包里\n\n  🟢 C2 凭启动包醒来：包里有我是谁和我答应过什么\n       启动包由存储生成，身份在场，写入的承诺原文在包里\n\n  🟢 C3 不改史：改口只长新枝，旧枝一个字节不动\n       say 双节点成形；旧节点 hash 不变；改口同父分叉；改口后新枝续话；跨房改口被拒\n\n  🟢 C4 勘误留底：错的标记被取代但留在原地，新旧链得上\n       旧条目原文留底并指向新条目，新条目为活条目\n\n  🟢 C5 不串房：A 的记忆不出现在 B 的启动包和检索里\n       跨住户检索、启动包、消息树均无泄漏\n\n  🟢 C6 迁移可回滚：启动包与消息树都逐字节等价，原件不动\n       启动包与消息树均等价，销毁导入件后原件完好\n\n真绿 6/6。六盏真绿。里程碑判定进入复验——独立复验通过、决策台账落章后才算达成、才解锁 H1。判卷机只报灯色，不宣布胜利。\n",
+      "output_extent": "full"
+    },
+    {
+      "name": "webui-build-complete",
+      "cwd": "webui",
+      "command": "corepack pnpm run build",
+      "started_at": "2026-09-10T05:28:17.264Z",
+      "finished_at": "2026-09-10T05:29:13.831Z",
+      "exit_code": 0,
+      "output": "dist/assets/langs/scss-D5BDwBP9.js                           27.25 kB │ gzip:   4.24 kB │ map:    38.35 kB\ndist/assets/langs/java-CylS5w8V.js                           27.26 kB │ gzip:   4.30 kB │ map:    38.66 kB\ndist/assets/langs/go-C27-OAKa.js                             46.86 kB │ gzip:   5.22 kB │ map:    66.63 kB\ndist/assets/langs/css-CLj8gQPS.js                            49.08 kB │ gzip:  11.90 kB │ map:    60.67 kB\ndist/assets/langs/markdown-Cvjx9yec.js                       59.38 kB │ gzip:   5.68 kB │ map:    82.36 kB\ndist/assets/langs/python-B6aJPvgy.js                         70.00 kB │ gzip:   9.17 kB │ map:    95.27 kB\ndist/assets/langs/c-BIGW1oBm.js                              72.15 kB │ gzip:  10.54 kB │ map:    95.41 kB\ndist/assets/langs/swift-D82vCrfD.js                          86.73 kB │ gzip:  14.77 kB │ map:   114.54 kB\ndist/assets/langs/csharp-DSvCPggb.js                         90.23 kB │ gzip:  10.79 kB │ map:   126.38 kB\ndist/assets/langs/less-B1dDrJ26.js                           97.68 kB │ gzip:  14.74 kB │ map:   131.88 kB\ndist/assets/langs/php-D-uCvoST.js                           113.11 kB │ gzip:  28.78 kB │ map:   142.07 kB\ndist/assets/langs/mdx-Cmh6b_Ma.js                           136.16 kB │ gzip:  23.39 kB │ map:   176.75 kB\ndist/assets/langs/html-CfGypltT.js                          232.16 kB │ gzip:  28.35 kB │ map:   308.96 kB\ndist/assets/index-BCeScS1Q.js                               424.61 kB │ gzip: 142.74 kB │ map: 1,287.78 kB\ndist/assets/langs/ruby-DEItuUFs.js                          425.79 kB │ gzip:  41.34 kB │ map:   579.27 kB\ndist/assets/langs/cpp-DIPi6g--.js                           637.59 kB │ gzip:  47.26 kB │ map:   831.50 kB\ndist/assets/vendor-Cjbwl5VI.js                              744.87 kB │ gzip: 180.73 kB │ map: 2,513.49 kB\n\n(!) Some chunks are larger than 500 kB after minification. Consider:\n- Using dynamic import() to code-split the application\n- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks\n- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.\n✓ built in 10.77s\n",
+      "output_extent": "last 24 lines"
+    }
+  ],
+  "mutations": [
+    {
+      "id": "M01",
+      "criteria": ["MV-A01"],
+      "path": "src/session/session-registry.ts",
+      "before": "    const windowId = options.windowId ?? this.#mintWindowId();",
+      "after": "    const windowId = options.windowId ?? this.windowsOf(residentId)[0]?.windowId ?? this.#mintWindowId();",
+      "testFile": "tests/multi-viewport-host.test.ts",
+      "pattern": "",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/multi-viewport-host.test.ts",
+      "red": {
+        "exit_code": 1,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/multi-viewport-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ❯ tests/multi-viewport-host.test.ts (1 test | 1 failed) 377ms\n   × multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 375ms\n     → expected 'w_01M24VR7TPJV67VMRKWMPT98HG' not to be 'w_01M24VR7TPJV67VMRKWMPT98HG' // Object.is equality\n\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/multi-viewport-host.test.ts > multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live\nAssertionError: expected 'w_01M24VR7TPJV67VMRKWMPT98HG' not to be 'w_01M24VR7TPJV67VMRKWMPT98HG' // Object.is equality\n ❯ tests/multi-viewport-host.test.ts:152:29\n    150|       scopeId: \"room-1\",\n    151|     });\n    152|     expect(w1.windowId).not.toBe(w2.windowId);\n       |                             ^\n    153|     expect([w1.generation, w2.generation]).toEqual([1, 1]);\n    154| \n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\n Test Files  1 failed (1)\n      Tests  1 failed (1)\n   Start at  13:13:21\n   Duration  973ms (transform 187ms, setup 0ms, collect 181ms, tests 377ms, environment 0ms, prepare 119ms)\n\n"
+      },
+      "restored": {
+        "exit_code": 0,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/multi-viewport-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/multi-viewport-host.test.ts (1 test) 459ms\n   ✓ multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 458ms\n\n Test Files  1 passed (1)\n      Tests  1 passed (1)\n   Start at  13:13:23\n   Duration  845ms (transform 75ms, setup 0ms, collect 76ms, tests 459ms, environment 0ms, prepare 93ms)\n\n"
+      }
+    },
+    {
+      "id": "M02",
+      "criteria": ["MV-A02"],
+      "path": "src/session/session-registry.ts",
+      "before": "    const window = this.#active.get(receipt.windowId);",
+      "after": "    const window = this.windowsOf(receipt.residentId)[0];",
+      "testFile": "tests/multi-viewport-host.test.ts",
+      "pattern": "",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/multi-viewport-host.test.ts",
+      "red": {
+        "exit_code": 1,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/multi-viewport-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ❯ tests/multi-viewport-host.test.ts (1 test | 1 failed) 241ms\n   × multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 240ms\n     → expected true to be false // Object.is equality\n\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/multi-viewport-host.test.ts > multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live\nAssertionError: expected true to be false // Object.is equality\n\n- Expected\n+ Received\n\n- false\n+ true\n\n ❯ tests/multi-viewport-host.test.ts:176:67\n    174|       firstArchive,\n    175|     );\n    176|     expect(await callHost(child, { op: \"belongs\", receipt: r1 })).toBe…\n       |                                                                   ^\n    177|     expect(await callHost(child, { op: \"belongs\", receipt: r2 })).toBe…\n    178|     expect(await callHost<WindowRecord>(child, { op: \"get\", windowId: …\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\n Test Files  1 failed (1)\n      Tests  1 failed (1)\n   Start at  13:13:26\n   Duration  703ms (transform 79ms, setup 0ms, collect 71ms, tests 241ms, environment 0ms, prepare 89ms)\n\n"
+      },
+      "restored": {
+        "exit_code": 0,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/multi-viewport-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/multi-viewport-host.test.ts (1 test) 698ms\n   ✓ multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 696ms\n\n Test Files  1 passed (1)\n      Tests  1 passed (1)\n   Start at  13:13:28\n   Duration  1.08s (transform 74ms, setup 0ms, collect 68ms, tests 698ms, environment 0ms, prepare 86ms)\n\n"
+      }
+    },
+    {
+      "id": "M03",
+      "criteria": ["MV-A03"],
+      "path": "src/session/session-registry.ts",
+      "before": "  setHead(windowId: string, headId: string | null): void {\n    this.#requireLive(windowId).headId = headId;",
+      "after": "  setHead(windowId: string, headId: string | null): void {\n    if (this.#archived.has(windowId)) return;\n    this.#requireLive(windowId).headId = headId;",
+      "testFile": "tests/multi-viewport-host.test.ts",
+      "pattern": "",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/multi-viewport-host.test.ts",
+      "red": {
+        "exit_code": 1,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/multi-viewport-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ❯ tests/multi-viewport-host.test.ts (1 test | 1 failed) 247ms\n   × multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 245ms\n     → promise resolved \"null\" instead of rejecting\n\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/multi-viewport-host.test.ts > multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live\nAssertionError: promise resolved \"null\" instead of rejecting\n\n- Expected: \n[Error: rejected promise]\n\n+ Received: \nnull\n\n ❯ tests/multi-viewport-host.test.ts:169:5\n    167|     await expect(\n    168|       callHost(child, { op: \"setHead\", windowId: w1.windowId, headId: …\n    169|     ).rejects.toThrow(\"WINDOW_ARCHIVED\");\n       |     ^\n    170|     await expect(callHost(child, { op: \"issueDispatch\", windowId: w1.w…\n    171|       \"WINDOW_ARCHIVED\",\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\n Test Files  1 failed (1)\n      Tests  1 failed (1)\n   Start at  13:13:30\n   Duration  627ms (transform 73ms, setup 0ms, collect 79ms, tests 247ms, environment 0ms, prepare 84ms)\n\n"
+      },
+      "restored": {
+        "exit_code": 0,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/multi-viewport-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/multi-viewport-host.test.ts (1 test) 670ms\n   ✓ multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 668ms\n\n Test Files  1 passed (1)\n      Tests  1 passed (1)\n   Start at  13:13:32\n   Duration  1.25s (transform 142ms, setup 0ms, collect 114ms, tests 670ms, environment 0ms, prepare 157ms)\n\n"
+      }
+    },
+    {
+      "id": "M04",
+      "criteria": ["MV-A04"],
+      "path": "src/session/session-registry.ts",
+      "before": "export const PRIVATE_SCOPE = \"private\" as const;",
+      "after": "export const PRIVATE_SCOPE = \"global\" as const;",
+      "testFile": "tests/session-registry.test.ts",
+      "pattern": "MV-A04",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/session-registry.test.ts -t 'MV-A04'",
+      "old_test_false_green": {
+        "exit_code": 0,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/session-registry.test.ts -t MV-A04\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/session-registry.test.ts (17 tests | 16 skipped) 5ms\n\n Test Files  1 passed (1)\n      Tests  1 passed | 16 skipped (17)\n   Start at  13:09:50\n   Duration  685ms (transform 223ms, setup 0ms, collect 217ms, tests 5ms, environment 0ms, prepare 150ms)\n\n"
+      },
+      "red": {
+        "exit_code": 1,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/session-registry.test.ts -t MV-A04\n\n\n RUN  v2.1.9 <repo>\n\n ❯ tests/session-registry.test.ts (17 tests | 1 failed | 16 skipped) 22ms\n   × SessionRegistry：多窗语义 > MV-A04 缺省 scope 落私聊，不落全局 20ms\n     → expected 'global' to be 'private' // Object.is equality\n\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/session-registry.test.ts > SessionRegistry：多窗语义 > MV-A04 缺省 scope 落私聊，不落全局\nAssertionError: expected 'global' to be 'private' // Object.is equality\n\nExpected: \"private\"\nReceived: \"global\"\n\n ❯ tests/session-registry.test.ts:31:68\n     29| \n     30|     // 不拿实现导出的常量造期望：常量错成 global 时，测试也必须转红。\n     31|     expect(sessions.open(\"resident-a\", { context: null }).scopeId).toB…\n       |                                                                    ^\n     32|     expect(sessions.open(\"resident-a\", { scopeId: \"room-1\", context: n…\n     33|       \"room-1\",\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\n Test Files  1 failed (1)\n      Tests  1 failed | 16 skipped (17)\n   Start at  13:10:01\n   Duration  796ms (transform 289ms, setup 0ms, collect 282ms, tests 22ms, environment 0ms, prepare 152ms)\n\n"
+      },
+      "restored": {
+        "exit_code": 0,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/session-registry.test.ts -t MV-A04\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/session-registry.test.ts (17 tests | 16 skipped) 3ms\n\n Test Files  1 passed (1)\n      Tests  1 passed | 16 skipped (17)\n   Start at  13:10:04\n   Duration  475ms (transform 161ms, setup 0ms, collect 178ms, tests 3ms, environment 0ms, prepare 85ms)\n\n"
+      }
+    },
+    {
+      "id": "M05",
+      "criteria": ["MV-A05"],
+      "path": "src/store/fact-ledger.ts",
+      "before": "    const row: ViewportAckRow = { baselineSeq, ackedSeq: baselineSeq, pendingInitial };",
+      "after": "    const row: ViewportAckRow = { baselineSeq, ackedSeq: 0, pendingInitial };",
+      "testFile": "tests/turn-gate-host.test.ts",
+      "pattern": "MV-A05",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/turn-gate-host.test.ts -t 'MV-A05'",
+      "red": {
+        "exit_code": 1,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/turn-gate-host.test.ts -t MV-A05\n\n\n RUN  v2.1.9 <repo>\n\n ❯ tests/turn-gate-host.test.ts (8 tests | 1 failed | 7 skipped) 283ms\n   × turn-gate real host subprocess > MV-A05 新窗不背全史：baseline=50，缺口为零，启动包带现行有效集 281ms\n     → expected '[权威事实账缺口 | kind=ruling | seq=1 | auth…' to be 'placeholder first turn' // Object.is equality\n\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/turn-gate-host.test.ts > turn-gate real host subprocess > MV-A05 新窗不背全史：baseline=50，缺口为零，启动包带现行有效集\nAssertionError: expected '[权威事实账缺口 | kind=ruling | seq=1 | auth…' to be 'placeholder first turn' // Object.is equality\n\n- Expected\n+ Received\n\n+ [权威事实账缺口 | kind=ruling | seq=1 | author=main-thread] placeholder ruling 1\n+\n+ [权威事实账缺口 | kind=ruling | seq=2 | author=main-thread] placeholder ruling 2\n+\n+ [权威事实账缺口 | kind=ruling | seq=3 | author=main-thread] placeholder ruling 3\n+\n+ [权威事实账缺口 | kind=ruling | seq=4 | author=main-thread] placeholder ruling 4\n+\n+ [权威事实账缺口 | kind=ruling | seq=5 | author=main-thread] placeholder ruling 5\n+\n+ [权威事实账缺口 | kind=ruling | seq=6 | author=main-thread] placeholder ruling 6\n+\n+ [权威事实账缺口 | kind=ruling | seq=7 | author=main-thread] placeholder ruling 7\n+\n+ [权威事实账缺口 | kind=ruling | seq=8 | author=main-thread] placeholder ruling 8\n+\n+ [权威事实账缺口 | kind=ruling | seq=9 | author=main-thread] placeholder ruling 9\n+\n+ [权威事实账缺口 | kind=ruling | seq=10 | author=main-thread] placeholder ruling 10\n+\n+ [权威事实账缺口 | kind=ruling | seq=11 | author=main-thread] placeholder ruling 11\n+\n+ [权威事实账缺口 | kind=ruling | seq=12 | author=main-thread] placeholder ruling 12\n+\n+ [权威事实账缺口 | kind=ruling | seq=13 | author=main-thread] placeholder ruling 13\n+\n+ [权威事实账缺口 | kind=ruling | seq=14 | author=main-thread] placeholder ruling 14\n+\n+ [权威事实账缺口 | kind=ruling | seq=15 | author=main-thread] placeholder ruling 15\n+\n+ [权威事实账缺口 | kind=ruling | seq=16 | author=main-thread] placeholder ruling 16\n+\n+ [权威事实账缺口 | kind=ruling | seq=17 | author=main-thread] placeholder ruling 17\n+\n+ [权威事实账缺口 | kind=ruling | seq=18 | author=main-thread] placeholder ruling 18\n+\n+ [权威事实账缺口 | kind=ruling | seq=19 | author=main-thread] placeholder ruling 19\n+\n+ [权威事实账缺口 | kind=ruling | seq=20 | author=main-thread] placeholder ruling 20\n+\n+ [权威事实账缺口 | kind=ruling | seq=21 | author=main-thread] placeholder ruling 21\n+\n+ [权威事实账缺口 | kind=ruling | seq=22 | author=main-thread] placeholder ruling 22\n+\n+ [权威事实账缺口 | kind=ruling | seq=23 | author=main-thread] placeholder ruling 23\n+\n+ [权威事实账缺口 | kind=ruling | seq=24 | author=main-thread] placeholder ruling 24\n+\n+ [权威事实账缺口 | kind=ruling | seq=25 | author=main-thread] placeholder ruling 25\n+\n+ [权威事实账缺口 | kind=ruling | seq=26 | author=main-thread] placeholder ruling 26\n+\n+ [权威事实账缺口 | kind=ruling | seq=27 | author=main-thread] placeholder ruling 27\n+\n+ [权威事实账缺口 | kind=ruling | seq=28 | author=main-thread] placeholder ruling 28\n+\n+ [权威事实账缺口 | kind=ruling | seq=29 | author=main-thread] placeholder ruling 29\n+\n+ [权威事实账缺口 | kind=ruling | seq=30 | author=main-thread] placeholder ruling 30\n+\n+ [权威事实账缺口 | kind=ruling | seq=31 | author=main-thread] placeholder ruling 31\n+\n+ [权威事实账缺口 | kind=ruling | seq=32 | author=main-thread] placeholder ruling 32\n+\n+ [权威事实账缺口 | kind=ruling | seq=33 | author=main-thread] placeholder ruling 33\n+\n+ [权威事实账缺口 | kind=ruling | seq=34 | author=main-thread] placeholder ruling 34\n+\n+ [权威事实账缺口 | kind=ruling | seq=35 | author=main-thread] placeholder ruling 35\n+\n+ [权威事实账缺口 | kind=ruling | seq=36 | author=main-thread] placeholder ruling 36\n+\n+ [权威事实账缺口 | kind=ruling | seq=37 | author=main-thread] placeholder ruling 37\n+\n+ [权威事实账缺口 | kind=ruling | seq=38 | author=main-thread] placeholder ruling 38\n+\n+ [权威事实账缺口 | kind=ruling | seq=39 | author=main-thread] placeholder ruling 39\n+\n+ [权威事实账缺口 | kind=ruling | seq=40 | author=main-thread] placeholder ruling 40\n+\n+ [权威事实账缺口 | kind=ruling | seq=41 | author=main-thread] placeholder ruling 41\n+\n+ [权威事实账缺口 | kind=ruling | seq=42 | author=main-thread] placeholder ruling 42\n+\n+ [权威事实账缺口 | kind=ruling | seq=43 | author=main-thread] placeholder ruling 43\n+\n+ [权威事实账缺口 | kind=ruling | seq=44 | author=main-thread] placeholder ruling 44\n+\n+ [权威事实账缺口 | kind=ruling | seq=45 | author=main-thread] placeholder ruling 45\n+\n+ [权威事实账缺口 | kind=ruling | seq=46 | author=main-thread] placeholder ruling 46\n+\n+ [权威事实账缺口 | kind=ruling | seq=47 | author=main-thread] placeholder ruling 47\n+\n+ [权威事实账缺口 | kind=ruling | seq=48 | author=main-thread] placeholder ruling 48\n+\n+ [权威事实账缺口 | kind=ruling | seq=49 | author=main-thread] placeholder ruling 49\n+\n+ [权威事实账缺口 | kind=ruling | seq=50 | author=main-thread] placeholder ruling 50\n+\n  placeholder first turn\n\n ❯ tests/turn-gate-host.test.ts:168:25\n    166|       message: \"placeholder first turn\",\n    167|     });\n    168|     expect(said.prompt).toBe(\"placeholder first turn\");\n       |                         ^\n    169| \n    170|     const windowId = await driverWindowId(child);\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\n Test Files  1 failed (1)\n      Tests  1 failed | 7 skipped (8)\n   Start at  13:13:35\n   Duration  699ms (transform 121ms, setup 0ms, collect 121ms, tests 283ms, environment 0ms, prepare 82ms)\n\n"
+      },
+      "restored": {
+        "exit_code": 0,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/turn-gate-host.test.ts -t MV-A05\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/turn-gate-host.test.ts (8 tests | 7 skipped) 186ms\n\n Test Files  1 passed (1)\n      Tests  1 passed | 7 skipped (8)\n   Start at  13:13:37\n   Duration  795ms (transform 180ms, setup 0ms, collect 169ms, tests 186ms, environment 0ms, prepare 131ms)\n\n"
+      }
+    },
+    {
+      "id": "M06",
+      "criteria": ["MV-B01"],
+      "path": "src/session/session-registry.ts",
+      "before": "      window.generation === receipt.generation",
+      "after": "      true",
+      "testFile": "tests/multi-viewport-host.test.ts",
+      "pattern": "",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/multi-viewport-host.test.ts",
+      "red": {
+        "exit_code": 1,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/multi-viewport-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ❯ tests/multi-viewport-host.test.ts (1 test | 1 failed) 516ms\n   × multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 514ms\n     → expected true to be false // Object.is equality\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/multi-viewport-host.test.ts > multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live\n\nAssertionError: expected true to be false // Object.is equality\n\n- Expected\n+ Received\n\n- false\n+ true\n\n ❯ tests/multi-viewport-host.test.ts:208:71\n    206|     });\n    207|     expect(reopened.generation).toBe(2);\n    208|     expect(await callHost(restarted, { op: \"belongs\", receipt: r1 })).…\n       |                                                                       ^\n    209|     const otherWindow = await callHost<WindowRecord>(restarted, {\n    210|       op: \"open\",\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\n Test Files  1 failed (1)\n      Tests  1 failed (1)\n   Start at  13:13:39\n   Duration  889ms (transform 72ms, setup 0ms, collect 69ms, tests 516ms, environment 0ms, prepare 83ms)\n\n"
+      },
+      "restored": {
+        "exit_code": 0,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/multi-viewport-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/multi-viewport-host.test.ts (1 test) 451ms\n   ✓ multi-viewport real host subprocess > opens two windows, kills and reopens one generation, and keeps the other live 450ms\n\n Test Files  1 passed (1)\n      Tests  1 passed (1)\n   Start at  13:13:42\n   Duration  831ms (transform 93ms, setup 0ms, collect 73ms, tests 451ms, environment 0ms, prepare 93ms)\n\n"
+      }
+    },
+    {
+      "id": "M07",
+      "criteria": ["MV-B03"],
+      "path": "src/message-tree/service.ts",
+      "before": "    this.#dispatchEventLogger?.log({ event, ...receipt, detail });",
+      "after": "    this.#dispatchEventLogger?.log({ event, ...receipt, generation: undefined as never, detail });",
+      "testFile": "tests/dispatch-logging-host.test.ts",
+      "pattern": "",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/dispatch-logging-host.test.ts",
+      "red": {
+        "exit_code": 1,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/dispatch-logging-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ❯ tests/dispatch-logging-host.test.ts (1 test | 1 failed) 392ms\n   × MV-B03 dispatch logging (real host subprocess) > logs complete triples for dispatch/receipt/drop and leaves a late result out of history 391ms\n     → expected { event: 'dropped', …(4) } to match object { residentId: 'resident-000001', …(3) }\n(2 matching properties omitted from actual)\n\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/dispatch-logging-host.test.ts > MV-B03 dispatch logging (real host subprocess) > logs complete triples for dispatch/receipt/drop and leaves a late result out of history\nAssertionError: expected { event: 'dropped', …(4) } to match object { residentId: 'resident-000001', …(3) }\n(2 matching properties omitted from actual)\n\n- Expected\n+ Received\n\n  Object {\n    \"dispatchId\": \"dispatch-000001\",\n-   \"generation\": undefined,\n    \"residentId\": \"resident-000001\",\n    \"windowId\": \"w_01M24VRXWC20Q0P32Q8WBZPMRK\",\n  }\n\n ❯ tests/dispatch-logging-host.test.ts:132:26\n    130|     const afterDrop = await callHost<DispatchEvent[]>(child, { op: \"ev…\n    131|     expect(afterDrop.map((event) => event.event)).toEqual([\"dispatch\",…\n    132|     expect(afterDrop[1]).toMatchObject({\n       |                          ^\n    133|       residentId,\n    134|       windowId: afterDrop[0]?.windowId,\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\n Test Files  1 failed (1)\n      Tests  1 failed (1)\n   Start at  13:13:44\n   Duration  987ms (transform 193ms, setup 0ms, collect 183ms, tests 392ms, environment 0ms, prepare 127ms)\n\n"
+      },
+      "restored": {
+        "exit_code": 0,
+        "output": "\n> mist-agent@0.0.0 test\n> vitest run tests/dispatch-logging-host.test.ts\n\n\n RUN  v2.1.9 <repo>\n\n ✓ tests/dispatch-logging-host.test.ts (1 test) 174ms\n\n Test Files  1 passed (1)\n      Tests  1 passed (1)\n   Start at  13:13:46\n   Duration  624ms (transform 118ms, setup 0ms, collect 139ms, tests 174ms, environment 0ms, prepare 90ms)\n\n"
+      }
+    },
+    {
+      "id": "M08",
+      "criteria": ["MV-C01", "MV-C02"],
+      "path": "src/session/turn-gate.ts",
+      "before": "      contextPrefix: [...initialLines, ...entries.map(formatGapEntry)],",
+      "after": "      contextPrefix: initialLines,",
+      "testFile": "tests/turn-gate-host.test.ts",
+      "pattern": "MV-C01/C02",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/turn-gate-host.test.ts -t 'MV-C01/C02'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected 'placeholder B turn' to contain '[权威事实账缺口 | kind=ruling | seq=1 | auth…'"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M09",
+      "criteria": ["MV-C03"],
+      "path": "src/session/turn-gate.ts",
+      "before": "      throw new GateUnavailableError(residentId, windowId, probe.cause);",
+      "after": "      return { contextPrefix: [], commit: () => {} };",
+      "testFile": "tests/turn-gate-host.test.ts",
+      "pattern": "MV-C03",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/turn-gate-host.test.ts -t 'MV-C03'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "promise resolved \"{ node: { …(5) }, …(1) }\" instead of rejecting"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M10",
+      "criteria": ["MV-C04"],
+      "path": "src/store/fact-ledger.ts",
+      "before": "    if (probe.ackedSeq < probe.latestSeq) {",
+      "after": "    if (false) {",
+      "testFile": "tests/turn-gate-host.test.ts",
+      "pattern": "MV-C04 闸在非缺失方",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/turn-gate-host.test.ts -t 'MV-C04 闸在非缺失方'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "promise resolved \"{ seq: 2, …(6) }\" instead of rejecting"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M11",
+      "criteria": ["MV-C05"],
+      "path": "src/session/turn-gate.ts",
+      "before": "    this.#markTurnStarted(windowId);\n    return {\n      contextPrefix: [...initialLines, ...entries.map(formatGapEntry)],",
+      "after": "    this.#markTurnStarted(windowId);\n    this.#ledger.ack(residentId, windowId, probe.latestSeq);\n    return {\n      contextPrefix: [...initialLines, ...entries.map(formatGapEntry)],",
+      "testFile": "tests/turn-gate-host.test.ts",
+      "pattern": "MV-C05",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/turn-gate-host.test.ts -t 'MV-C05'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected 1 to be +0 // Object.is equality"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M12",
+      "criteria": ["MV-C06"],
+      "path": "src/store/fact-ledger.ts",
+      "before": "    return ledger.entries.filter((entry) => entry.seq > row.ackedSeq).map(copyEntry);",
+      "after": "    return ledger.entries.filter((entry) => Date.parse(entry.ts) > Date.parse(ledger.entries[row.ackedSeq - 1]?.ts ?? \"1970-01-01T00:00:00.000Z\")).map(copyEntry);",
+      "testFile": "tests/fact-ledger.test.ts",
+      "pattern": "MV-C06",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/fact-ledger.test.ts -t 'MV-C06'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected [ { seq: 1, …(6) } ] to deeply equal []"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M13",
+      "criteria": ["MV-C07"],
+      "path": "src/store/fact-ledger.ts",
+      "before": "  currentSet(residentId: string): LedgerEntry[] {\n    const ledger = this.#ledger(residentId);\n    return ledger.entries\n      .filter((entry) => entry.kind !== \"supersede\" && !ledger.supersededSeqs.has(entry.seq))",
+      "after": "  currentSet(residentId: string): LedgerEntry[] {\n    const ledger = this.#ledger(residentId);\n    return ledger.entries\n      .filter((entry) => entry.kind !== \"supersede\")",
+      "testFile": "tests/turn-gate-host.test.ts",
+      "pattern": "MV-C07",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/turn-gate-host.test.ts -t 'MV-C07'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected [ { seq: 1, …(6) } ] to deeply equal []"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M14",
+      "criteria": ["MV-D01"],
+      "path": "src/session/turn-gate.ts",
+      "before": "      if (usage >= threshold) {",
+      "after": "      if (false) {",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "MV-D01",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t 'MV-D01'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "promise resolved \"{ node: { …(5) }, prompt: '过线后的第二句' }\" instead of rejecting"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M15",
+      "criteria": ["MV-D02"],
+      "path": "src/session/turn-gate.ts",
+      "before": "    if (this.#turnStarted.get(windowId) === generation) {",
+      "after": "    if (false) {",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "MV-D02",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t 'MV-D02'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "promise resolved \"null\" instead of rejecting"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M16",
+      "criteria": ["MV-D03"],
+      "path": "src/session/breath-trigger.ts",
+      "before": "    (candidate) => normalized === candidate || normalized.startsWith(`${candidate} `),",
+      "after": "    (candidate) => candidate !== \"/compact\" && (normalized === candidate || normalized.startsWith(`${candidate} `)),",
+      "testFile": "tests/breath-trigger.test.ts",
+      "pattern": "全部映射",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-trigger.test.ts -t '全部映射'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected null not to be null"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M17",
+      "criteria": ["MV-D04"],
+      "path": "src/session/breath-cycle.ts",
+      "before": "        nextContext = injectLetter(current.context, letter);",
+      "after": "        nextContext = current.context;",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "MV-D04",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t 'MV-D04'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected undefined to be 'D04 阈值核算不含交接信的验证信，标题也参与长度' // Object.is equality"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M18",
+      "criteria": ["MV-D04"],
+      "path": "tests/fixtures/breath-host.ts",
+      "before": "  return flowTokens + noteTokens;",
+      "after": "  return flowTokens + noteTokens + estimateTokens(JSON.stringify(window.context.letter ?? \"\"));",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "MV-D04",
+      "kind": "composition",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t 'MV-D04'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected 159 to be less than 20"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M19",
+      "criteria": ["MV-D05"],
+      "path": "src/session/handover-letter.ts",
+      "before": "  assertTitle(draft.title);",
+      "after": "  // mutation: title validation disconnected",
+      "testFile": "tests/handover-letter.test.ts",
+      "pattern": "无标题的信写入被拒",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/handover-letter.test.ts -t '无标题的信写入被拒'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected function to throw an error, but it didn't"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M20",
+      "criteria": ["MV-D05"],
+      "path": "src/one-stream/handover-letters.ts",
+      "before": "      ({ letter }) => letter.title === anchor.title,",
+      "after": "      ({ letter }) => letter.title === `${anchor.title}-wrong`,",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "MV-D05",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t 'MV-D05'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected { kind: 'not-found', anchor: { …(2) } } to match object { kind: 'found', letter: { …(5) } }"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M21",
+      "criteria": ["MV-D06"],
+      "path": "src/session/handover-letter.ts",
+      "before": "  return `${residentId}#${generation}`;",
+      "after": "  return residentId;",
+      "testFile": "tests/handover-letter.test.ts",
+      "pattern": "intent 半每条盖当刻亲笔章",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/handover-letter.test.ts -t 'intent 半每条盖当刻亲笔章'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected 'resident-a' to be 'resident-a#3' // Object.is equality"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M22",
+      "criteria": ["MV-D06"],
+      "path": "src/session/handover-letter.ts",
+      "before": "  if (Array.isArray((candidate as { tiers?: unknown }).tiers)) {",
+      "after": "  if (false) {",
+      "testFile": "tests/handover-letter.test.ts",
+      "pattern": "一条只装一档",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/handover-letter.test.ts -t '一条只装一档'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected [Function] to throw an error"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M23",
+      "criteria": ["MV-D06"],
+      "path": "src/session/handover-letter.ts",
+      "before": "  assertCommitmentShape(candidate, at);",
+      "after": "  // mutation: commitment shape validation disconnected",
+      "testFile": "tests/handover-letter.test.ts",
+      "pattern": "承诺在信里不可被作废",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/handover-letter.test.ts -t '承诺在信里不可被作废'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected function to throw an error, but it didn't"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M24",
+      "criteria": ["MV-D07"],
+      "path": "tests/fixtures/breath-host.ts",
+      "before": "        headId: archived.headId,\n        context: { notes: [] },",
+      "after": "        headId: archived.headId,\n        context: { notes: store.history(archived.residentId).map((node) => node.content) },",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "MV-D07 猝死",
+      "kind": "composition",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t 'MV-D07 猝死'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected { notes: [ '猝死窗的流水甲', …(3) ] } to deeply equal { notes: [] }"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M25",
+      "criteria": ["MV-D07b"],
+      "path": "src/session/breath-cycle.ts",
+      "before": "        if (inspection.malformed.length > 0) {",
+      "after": "        if (inspection.malformed.length > 0 || inspection.remnants.length > 0) {",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "MV-D07b 合法残骸",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t 'MV-D07b 合法残骸'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "BREATH_CYCLE_FAILED: BREATH_CYCLE_FAILED[hygiene]: 流水卫生检查硬拦："
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M26",
+      "criteria": ["MV-D08"],
+      "path": "src/session/handover-letter.ts",
+      "before": "  if (actual > limit) {",
+      "after": "  if (false) {",
+      "testFile": "tests/handover-letter.test.ts",
+      "pattern": "超上限被拒",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/handover-letter.test.ts -t '超上限被拒'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected undefined to be an instance of LetterSchemaError"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M27",
+      "criteria": ["MV-D09"],
+      "path": "src/session/breath-cycle.ts",
+      "before": "  ): void {\n    this.#announced.delete(windowId);\n    this.#options.notify({",
+      "after": "  ): void {\n    // mutation: failed cycle retains its announcement latch\n    this.#options.notify({",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "撞线先外显预告",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t '撞线先外显预告'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected [ { kind: 'announced', …(2) } ] to deeply equal [ ObjectContaining{…}, …(1) ]"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M28",
+      "criteria": ["MV-D09", "OS-05"],
+      "path": "tests/fixtures/breath-host.ts",
+      "before": "        await lifecycleFailures.submit({",
+      "after": "        await Promise.resolve({",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "撞线先外显预告",
+      "kind": "composition",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t '撞线先外显预告'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected [] to have a length of 1 but got +0"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M29",
+      "criteria": ["MV-D10"],
+      "path": "src/session/breath-cycle.ts",
+      "before": "        reopened = registry.open(residentId, {\n          windowId,",
+      "after": "        reopened = registry.open(residentId, {",
+      "testFile": "tests/breath-host.test.ts",
+      "pattern": "windowId 逐字不变",
+      "kind": "implementation",
+      "cwd": ".",
+      "command": "npm test -- tests/breath-host.test.ts -t 'windowId 逐字不变'",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected 'w_01M24W0ZBT1QNRCXCWDDTCRV2E' to be 'w_01M24W0ZAS3KQXS949W9HJYFYY' // Object.is equality"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M30",
+      "criteria": ["MV-E01"],
+      "path": "webui/apps/dev-server/src/mist-session-wire-adapter.ts",
+      "before": "      ...this.#sessions.archivedWindowsOf(this.#residentId).map(window => ({ window, archived: true })),",
+      "after": "      // mutation: archived windows omitted",
+      "testFile": "apps/dev-server/tests/mist-session-wire-host.spec.ts",
+      "pattern": "",
+      "kind": "webui",
+      "cwd": "webui",
+      "command": "corepack pnpm exec vitest run apps/dev-server/tests/mist-session-wire-host.spec.ts",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected [ { …(7) } ] to deeply equal ArrayContaining{…}"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "M31",
+      "criteria": ["MV-E01"],
+      "path": "webui/apps/dev-server/src/mist-session-wire-adapter.ts",
+      "before": "    if (window === undefined || window.residentId !== this.#residentId) {",
+      "after": "    if (window === undefined) {",
+      "testFile": "apps/dev-server/tests/mist-session-wire-host.spec.ts",
+      "pattern": "",
+      "kind": "webui",
+      "cwd": "webui",
+      "command": "corepack pnpm exec vitest run apps/dev-server/tests/mist-session-wire-host.spec.ts",
+      "red": {
+        "exit_code": 1,
+        "failed_tests": 1,
+        "failure_excerpt": "expected { ok: true, value: { …(2) } } to match object { ok: false, …(1) }"
+      },
+      "restored": {
+        "exit_code": 0
+      }
+    }
+  ]
+}

--- a/acceptance/multi-viewport.md
+++ b/acceptance/multi-viewport.md
@@ -45,3 +45,103 @@
 
 - [x] **MV-E01 session 映射**：`session.list/create/history` 三个端点的行为与本图纸 §5 映射表一致；webui 侧不需要感知住户级概念。[集成]
 - [x] **MV-E02 文档同步**：实现合入的同一 PR 更新 docs/design/session-api.md §1.1（「将要变成什么」降为已实现语义，差距段清零）。人工勾。
+
+## 2026-09-10 逐条复验附注（#148）
+
+核验施工：小卷（Codex / chaodeng060-source）。本节不是独立验收署名。
+上方勾选保留既有合入与主笔授权记录；截至本轮查验，#148 楼内尚未指定独立验收席，
+因此不写“独立复验落章”，也不宣布 D13 解锁。
+
+### 基线、命令和结果
+
+- 干净起点：`origin/main = 21d3c451c6ee9ae877bdfeecb6425844e6137092`；
+  测试补强提交 `453e03b`。本轮收尾读取远端 main 仍为同一 SHA，没有混入其他版本。
+- 基线完整 `npm test`：539 passed / 38 todo；补强后完整重跑仍为
+  539 passed / 38 todo（51 passed files / 3 skipped files，48.13 s）；31 次变异全部恢复后
+  最终全量重跑同样 539 passed / 38 todo（52.92 s）。
+  todo 不计通过。根 Vitest 排除了 `webui/**`，不能用这份结果替 E01 背书。
+- `npm run acceptance`：六盏真绿。这是第一里程碑的六条，不是本页 28 条的自动判卷。
+  `npm run lint`、`npm run typecheck` 均退出 0。
+- E01 单独运行（在 `webui/`）：`corepack pnpm exec vitest run
+  apps/dev-server/tests/mist-session-wire-adapter.spec.ts
+  apps/dev-server/tests/mist-session-wire-host.spec.ts
+  packages/host/apiproxy/tests/rpc-schemas.spec.ts`：3 files / 37 passed。
+- 补建完整 webui 后，再将 `apps/dev-server/tests/mist-plugin-host-composition.spec.ts`
+  和 `apps/dev-server/tests/mist-plugin.spec.ts` 加入上面同一命令：**5 files / 49 passed**
+  （7.96 s）。覆盖官方插件经真实事务宿主取得 handler、HTTP 三端点可用、缺服务不发布。
+  `corepack pnpm run build` 完整退出 0，包含 host/client 库与网页构建。
+  初跑的 8 failed / 41 passed 不隐去：新副本缺编译产物；只 build:web 又缺 vendor lib，
+  完整构建到末段还暴露 shell 找不到 pnpm。按 host → client → web 正常顺序构建、
+  将 Corepack 的 pnpm shim 加入本次 shell PATH 后通过；没有用空 dist 或 mock 绕过。
+- Node `v22.23.1`；根依赖按 `npm ci --ignore-scripts --no-audit --no-fund`，
+  webui 按锁定的 pnpm `11.7.0` 安装。运行时输出中的绝对 checkout 路径在公开附件中
+  归一成 `<repo>`；宿主无关环境清理前缀不进入项目复现命令。
+
+[机器可读证据与逐个变异配方](evidence/multi-viewport-148-2026-09-10.json) 保存每个
+M 编号的文件、原行、替换行、工作目录、实际仓库测试命令、失败断言和恢复退出码。
+共 **31 次单点变异：31 次对应专项退出 1，31 次恢复后退出 0；每次专项恰有一个测试失败**。
+其中 28 次改实现，3 次改宿主测试装配（M18/M24/M28，不能冒充实现内部闸门）。
+为 26 个 MV 条目提供变异证据；B02 的“不存在 API”另有单测与静态核对，E02 人工核对文档。
+一次变异只跑该专项，不声称其他测试在变异状态下仍绿；恢复后才跑完整回归。
+
+复现时以附件 `baseline` 加测试补强提交为准，一次仅替换一个 `before → after`，
+在指定 `cwd` 运行 `command`，检查所记失败，再原样恢复并重复同一命令。
+不要把多个变异叠在一起，也不要留下变异源码用于正常测试。
+
+### 28 条证据账
+
+下表“通过”指本轮所列证据通过，不改写独立验收身份。PR 是实现来源；
+具体命令与判红位置由 M 编号链接到同一附件，避免再造第二套判据。
+
+| 条目 | 来源 PR | 本轮证据与结果 | 拔闸／边界 |
+|---|---|---|---|
+| MV-A01 | #86 | `tests/multi-viewport-host.test.ts`：同住户同 scope 两次 open，id 不同、generation 都为 1，两窗皆活；通过。 | M01 复用首窗 id，id 不等断言红。 |
+| MV-A02 | #86 | 同上及 `tests/session-registry.test.ts`：杀一窗后另一窗 head、dispatch 仍可用；静态索引盘点见下；通过。 | M02 按 residentId 取首窗，回执归属断言红。 |
+| MV-A03 | #86 / #88 | 同上：重复 kill 同结果、归档后 setHead/issueDispatch 均拒 `WINDOW_ARCHIVED`、归档快照不变；unit 另验 killResident 不动另一住户；通过。 | M03 归档 setHead 静默返回，拒写断言红。 |
+| MV-A04 | #86；本轮补强 | `tests/session-registry.test.ts` 的 MV-A04：默认值独立断言字面 `private`，显式 scope 不变；通过。 | M04 将实现常量改 global：旧测试仍绿；修正期望来源后明确红，恢复绿。 |
+| MV-A05 | #85 / #98 | `tests/turn-gate-host.test.ts` 的 MV-A05：50 条历史、baseline=ackedSeq=50、无全史 gap、初始有效集一次性交付；通过。 | M05 ackedSeq 从 0 起，baseline 断言红。 |
+| MV-B01 | #86 / #88 | `tests/multi-viewport-host.test.ts`：两窗同代回执均有效，依次重开后各自旧代无效／新代有效，另一窗不被连坐；通过。 | M06 不验 generation，旧代回执断言红。 |
+| MV-B02 | #86 | `tests/session-registry.test.ts` 的 MV-B02：同住户两窗同时为 generation 1、2，实例无 `currentGeneration`；公开方法和索引静态核对通过。 | 无可摘运行闸；不为“不存在 API”伪造拔闸计数。 |
+| MV-B03 | #135 | `tests/dispatch-logging-host.test.ts`：issued / accepted / dropped 全部逐字段带 residentId、windowId、generation；通过。 | M07 日志 generation 缺失，三元组断言红。 |
+| MV-C01 | #85 / #98；本轮补强 | `tests/turn-gate-host.test.ts` 的 C01/C02：明确 hold A 的 responder，确认仍在途后落 ruling；B 下一轮 prompt 带裁定并 ack；通过。 | M08 不注入 gap，B prompt 缺裁定而红。 |
+| MV-C02 | #98 | 与 C01 共用真实宿主拉取断言；通过现有 pull 路径。 | 仓内无 push 通道，“丢全部推送”仍是原注所说的 vacuous 条件；M08 不冒充真实 push 故障试验。引入 push 后须重验。 |
+| MV-C03 | #85 / #98 | `tests/turn-gate-host.test.ts` 的 MV-C03：unknown 时普通动作可过且有日志，裁定级动作拒绝；与零缺口区分；通过。 | M09 查询失败放行裁定级动作，reject 断言红。 |
+| MV-C04 | #141 | `tests/turn-gate-host.test.ts` 的“闸在非缺失方”及 `tests/fact-ledger.test.ts`：账侧拒落后／unknown，追平放行；身份、代际与 system 能力不由窗自报；通过。 | M10 摘账侧 seq 闸，落后写入被收而红。 |
+| MV-C05 | #85 / #98 | `tests/turn-gate-host.test.ts` 的 MV-C05：丢 ack 不推进已知序号，下一轮重拉后才 ack；通过。 | M11 提前 ack，0 变 1 而红。 |
+| MV-C06 | #85 | `tests/fact-ledger.test.ts` 的 MV-C06：时钟倒行也只按 seq 判 gap；通过。 | M12 改用时间戳，已 ack 后仍残留旧条而红。 |
+| MV-C07 | #85 / #98 | `tests/turn-gate-host.test.ts` 的 MV-C07：supersede 追加、旧条字节不变、下一轮见解除、currentSet 排除旧条；通过。 | M13 不排除被 supersede 的项，有效集断言红。 |
+| MV-D01 | #117 | `tests/breath-host.test.ts` 的 MV-D01：过线当前回合落树、下回合零写入、threshold_reached 三元组、换代后可开工；通过。 | M14 摘阈值硬闸，下回合错误放行而红。 |
+| MV-D02 | #117 | 同文件 MV-D02：开工时配置有效、回合开始后修改拒 `CONFIG_INVALID`、换代后重新可配；通过。 | M15 摘本代已开工闸，修改请求不再拒绝而红。 |
+| MV-D03 | #105 / #117 | `tests/breath-trigger.test.ts`：/new、/clear、/compact 同入口及归一化，driver 不走普通 say；4 条通过。 | M16 排除 /compact，统一入口断言红。 |
+| MV-D04 | #105 / #117 | `tests/breath-host.test.ts` 的 MV-D04：新代含全文肥信，usage 不含信、首回合可过；通过。 | M17 断注入使信缺失；M18 装配计量误加信使 159 不小于 20，分别红。计量口契约不是原生模型 tokenizer 实验。 |
+| MV-D05 | #105 / #142 | `tests/handover-letter.test.ts`、`tests/handover-timeline.test.ts`、`tests/breath-host.test.ts`：无标题／重复标题拒绝，新进程仅按 title 召回原代细节；通过。 | M19 摘标题校验、M20 错改 title 查找，分别红。 |
+| MV-D06 | #105 | `tests/handover-letter.test.ts`：条目只一档、intent 的 residentId#generation 与时间戳、承诺不能在信内作废；通过。 | M21 章缺代际、M22 放过多档、M23 放过承诺作废，分别红。 |
+| MV-D07 | #117 | `tests/breath-host.test.ts` 的 MV-D07：suddenKill 后新 context 空、usage=0，旧流水可查，新代可开工；通过。 | M24 装配时误把旧流水注入新 context，空上下文断言红。这里模拟窗死亡，不声称杀了 OS 进程。 |
+| MV-D07b | #117 | 同文件 MV-D07b：合法残骸降警告并记档，连续两次换气可完成；畸形硬拦／隔离后恢复，生产分档规则另验；通过。 | M25 把合法残骸升级硬拦，正常换气报 `BREATH_CYCLE_FAILED[hygiene]` 而红。 |
+| MV-D08 | #105 | `tests/handover-letter.test.ts` 的 MV-D08：越界拒绝，错误含 limit 与 actual，边界可过；通过。 | M26 摘长度闸，不再有 LetterSchemaError 而红。默认是保守字符估算和可注入 measure，不冒充精确 tokenizer。 |
+| MV-D09 | #136 / #138 | `tests/breath-host.test.ts`：timeline append／swap 失败均有 notice 和 host 签发 canonical event，effect 明确未生效，自动重试／需人处理分档，失败后重发预告；通过。 | M27 保留预告锁，第二次预告缺失；M28 装配断 canonical 提交，只剩 notice，分别红。与 OS-05 用同一断言来源。 |
+| MV-D10 | #105 / #134 | 同文件的 MV-D10 三条：真换气 id 不变、旧代回执淘汰／新代有效、连续三次 generation 递增、时间线锚点可查；通过。 | M29 换代不传原 id，新发 id 而红。external binding 是夹具中的 Map 引用解析，不是 TG 等外部系统联调。 |
+| MV-E01 | #112 / #121 | `webui/apps/dev-server/tests/mist-session-wire-{adapter,host}.spec.ts` 与 `webui/packages/host/apiproxy/tests/rpc-schemas.spec.ts`：真实 HTTP list/create/history、活／归档列表、默认 scope、拒客户端 id、住户隔离；37 条通过。加入同目录 `mist-plugin-host-composition.spec.ts`、`mist-plugin.spec.ts` 后 49 条通过。 | M30 列表漏归档窗、M31 取消住户归属检查，真实 HTTP 对应断言各红。history 端口是 fixture，不能替 #120 持久化判卷。 |
+| MV-E02 | #112 / #113；本轮订正 #121 / #139 后的旧文 | `git show 0ef8925 -- docs/design/session-api.md` 可核 #112 同 PR 对齐；本轮 §1.1 映射逐项对照实现，并订正固定 mock／延期 v0.1／#84 方向未定的过期说明。 | 人工文档核对，不计为变异。 |
+
+### 静态补证、真实缺口与未关闭边界
+
+- A02/B02：`SessionRegistry` 的 active、archived、windowIdentity、lastGeneration 都以
+  windowId 为键；`windowsOf(residentId)` 明确返数组，没有住户级当前代际 API。
+  `ViewportTurnGate` 的 thresholds、turnStarted 和 generationOf 都以窗为键；
+  `FactLedger` 是 resident → viewport ack 行，不是一住户一活会话。
+  `MistDriver.#driverWindows` 是调用方显式拥有的单窗绑定，代码不让注册表猜“当前窗”。
+  resident store、message tree、canonical stream 的住户级 Map 是持久住户数据／写入队列，
+  不能为凑“清零”把它们误改成窗级。one-stream reply/workspace 路由也按 windowId 查注册表。
+- 本轮发现并修复的是**验收漏洞**：A04 原来拿实现的 `PRIVATE_SCOPE` 常量作期望，
+  常量错成 global 时测试仍绿。改独立字面量断言后，同一变异真实转红；业务默认值未改。
+  另补真实子进程归档拒写／两窗回执四象限，以及 C01 的 A 确在途时序，不增加新产品语义。
+- E02 的旧文“固定 mock、等 v0.1”被 #121 的 `webui/mist-plugin.ts` 服务注入实现推翻；
+  #139 的 first-party read model／证据能力面也已落地。已据源码订正文档，仍保留
+  history fixture、生产持久化和产品面验收之间的界线。
+- 数字：本页确为 A=5、B=3、C=7、D=11（含 D07b）、E=2，合计 28。
+  当前 H1 与 #78 **标题已经是 28**，不重复改成另一版；#78 正文仍写“25 条”，
+  且 D 泳道仍只列 D01～D08，须更新为“28 条”及“D01～D10（含 D07b）”。
+  本地记录不冒充 GitHub 已修改。
+- 最终落章仍需 #148 楼内明确指定独立验收席，再由该席审阅本表、复跑与署名。
+  本地施工、自审、CI、主笔授权勾、独立验收署名是不同事实。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -16,7 +16,8 @@
 ## 进行中
 
 - **H1 能力契约工作稿**（#2/#8/#11）：2026-09-09 主笔改写。多 viewport 验收 28 条
-  已勾齐，但独立复验尚未落章；one-stream 六灯实现已合 main，2026-09-10 主笔授权勾
+  已勾齐，但独立复验尚未落章（#148 的逐条施工证据见
+  [多 viewport 复验附注](../acceptance/multi-viewport.md#2026-09-10-逐条复验附注148)，不代替指定验收席署名）；one-stream 六灯实现已合 main，2026-09-10 主笔授权勾
   （见 [acceptance/one-stream.md](../acceptance/one-stream.md)），独立复验同样尚未落章；
   window-history 判卷仍红——地基还在动，
   现在「定稿」等于给推翻自己留账。改为两步：**先出 v0 工作稿**（从 driver、账、

--- a/docs/design/session-api.md
+++ b/docs/design/session-api.md
@@ -1,6 +1,6 @@
 # 会话 API（session API）· 给 external 前端的接入说明
 
-状态：v0.3（refs #58 第 3 条、#82）。会话模型与线协议三端点已经按 D7 多活窗对齐；`SessionRegistry` 的窗口语义在 §1，`session.list / session.create / session.history` 的窗口映射唯一以 §1.1 为准。HTTP/WS 信封、鉴权与下行流的真源是本仓 `webui/docs/research/mist-wire-contract.md`；frontend 插件当前仍固定使用 mock，真实 handler 的交付通道延期至插件协议 v0.1，不在本页冒充已经接通。
+状态：v0.4（refs #58 第 3 条、#82、#121；#148 复验订正）。会话模型与线协议三端点已经按 D7 多活窗对齐；`SessionRegistry` 的窗口语义在 §1，`session.list / session.create / session.history` 的窗口映射唯一以 §1.1 为准。HTTP/WS 信封、鉴权与下行流的真源是本仓 `webui/docs/research/mist-wire-contract.md`。#121 已交付真实 handler 的宿主服务通道：官方 frontend 插件从 `context.services` 获取 `mist.session-handler@^1.0.0`，缺服务在 prepare 前被拒，不再固定创建 mock。通道可用不代表生产 history port、浏览器交互或完整 P1 产品面已验收。
 
 ## 0. 一句话
 
@@ -35,9 +35,9 @@ mist 不替前端保管任何东西。线协议里的一个 session 对应一扇
 - `session.create`：调用 `open(residentId, scopeId)`；`residentId` 来自 handler 绑定，`scopeId` 可省略并落私聊。返回宿主签发的 `sessionId=windowId` 与 generation；客户端预分配 sessionId 被拒绝。共享 schema 中没有明确窗模型映射的 `workspaceId / cwd / agentPreset` 也在 Mist adapter 边界显式返回 `bad-request`，不静默猜测。
 - `session.history`：以 `sessionId=windowId` 读取该窗的只读流水；活窗和归档窗走同一读口，读取不得复活或改写窗。具体流水字节由只读 history port 提供，窗口注册表只负责身份、代际与归档状态。
 
-这三个端点属于 control/evidence 能力面，“协议可接线”不自动等于 “P1-conformant”。P1-conformant 用户面只有一条 canonical user-visible stream：可以进入仍有行动意义的活工作区，但不把 `session.list` 渲染成永久聊天列表，也不把归档窗的 `session.history` 变成第二本权威 transcript；关闭后主流只留 typed closure/result 与权威证据指针（方向未定，待 #84 收口）。
+这三个端点属于 control/evidence 能力面，“协议可接线”不自动等于 “P1-conformant”。P1-conformant 用户面只有一条 canonical user-visible stream：可以进入仍有行动意义的活工作区，但不把 `session.list` 渲染成永久聊天列表，也不把归档窗的 `session.history` 变成第二本权威 transcript；关闭后主流只留 typed closure/result 与权威证据指针。#139 已交付 first-party read model 与只读证据能力面，行为及授权边界见 [OS-03](../../acceptance/one-stream.md)；不再标成“方向未定”。
 
-**代价**：列表需要同时读活窗与归档窗；history 必须由窗流水的权威存储提供只读端口，不能拿 `residentId` 级整棵消息树冒充某一窗的流水。真实 handler 如何交到 frontend 插件仍待协议 v0.1，本次映射不改变 mock 默认边界。
+**代价**：列表需要同时读活窗与归档窗；history 必须由窗流水的权威存储提供只读端口，不能拿 `residentId` 级整棵消息树冒充某一窗的流水。宿主须显式注册所声明版本的 session handler 服务，并随插件事务撤销服务句柄。`mist-plugin-host-composition.spec.ts` 使用真实事务宿主、官方插件、HTTP 和 SessionRegistry，但 history 是 fixture；它证明交付通道，不替生产窗流水持久化判卷（#120）。
 
 ## 2. 线协议（端点 / 鉴权 / 信封）
 

--- a/tests/fixtures/turn-gate-host.ts
+++ b/tests/fixtures/turn-gate-host.ts
@@ -51,12 +51,19 @@ const logger: TurnEventLogger = {
 
 // --- A 窗通道：生产 MistDriver，say 的注入文本经捕获型 reply 留给父进程断言 ---
 let lastDriverPrompt: string | null = null;
+let holdDriverReply = false;
+let releaseDriverReply: (() => void) | null = null;
 const driver = createDriver({
   ...(dataDir === undefined ? {} : { dataDir }),
   factLedger: ledger,
   turnEventLogger: logger,
-  reply: (_residentId, message) => {
+  reply: async (_residentId, message) => {
     lastDriverPrompt = message;
+    if (holdDriverReply) {
+      await new Promise<void>((resolve) => {
+        releaseDriverReply = resolve;
+      });
+    }
     return "司机窗哑回应";
   },
 });
@@ -123,6 +130,9 @@ type HostCommand = {
     | "logEvents"
     | "failProbe"
     | "dropCommit"
+    | "holdDriverReply"
+    | "driverReplyPending"
+    | "releaseDriverReply"
     | "stop";
   residentId?: string;
   windowId?: string;
@@ -286,6 +296,16 @@ async function execute(command: HostCommand): Promise<unknown> {
       return null;
     case "dropCommit":
       commitDropped = command.on === true;
+      return null;
+    case "holdDriverReply":
+      holdDriverReply = true;
+      return null;
+    case "driverReplyPending":
+      return releaseDriverReply !== null;
+    case "releaseDriverReply":
+      holdDriverReply = false;
+      releaseDriverReply?.();
+      releaseDriverReply = null;
       return null;
     case "stop":
       return null;

--- a/tests/multi-viewport-host.test.ts
+++ b/tests/multi-viewport-host.test.ts
@@ -156,10 +156,23 @@ describe("multi-viewport real host subprocess", () => {
     await callHost(child, { op: "setHead", windowId: w2.windowId, headId: "node-w2" });
     const r1 = await callHost<Receipt>(child, { op: "issueDispatch", windowId: w1.windowId });
     const r2 = await callHost<Receipt>(child, { op: "issueDispatch", windowId: w2.windowId });
+    // 两窗同代的回执各自有效；不能只验 kill 后的单个阴性分支。
+    expect(await callHost(child, { op: "belongs", receipt: r1 })).toBe(true);
+    expect(await callHost(child, { op: "belongs", receipt: r2 })).toBe(true);
 
     const firstArchive = await callHost(child, { op: "kill", windowId: w1.windowId });
     const secondArchive = await callHost(child, { op: "kill", windowId: w1.windowId });
     expect(secondArchive).toEqual(firstArchive);
+    // MV-A03 的拒写半格也必须穿过真实子进程，而不只靠 registry 单测。
+    await expect(
+      callHost(child, { op: "setHead", windowId: w1.windowId, headId: "forbidden-write" }),
+    ).rejects.toThrow("WINDOW_ARCHIVED");
+    await expect(callHost(child, { op: "issueDispatch", windowId: w1.windowId })).rejects.toThrow(
+      "WINDOW_ARCHIVED",
+    );
+    expect(await callHost(child, { op: "getArchived", windowId: w1.windowId })).toEqual(
+      firstArchive,
+    );
     expect(await callHost(child, { op: "belongs", receipt: r1 })).toBe(false);
     expect(await callHost(child, { op: "belongs", receipt: r2 })).toBe(true);
     expect(await callHost<WindowRecord>(child, { op: "get", windowId: w2.windowId })).toMatchObject(
@@ -193,10 +206,23 @@ describe("multi-viewport real host subprocess", () => {
     });
     expect(reopened.generation).toBe(2);
     expect(await callHost(restarted, { op: "belongs", receipt: r1 })).toBe(false);
+    const otherWindow = await callHost<WindowRecord>(restarted, {
+      op: "open",
+      residentId: "resident-a",
+      scopeId: "room-1",
+      windowId: w2.windowId,
+    });
+    const otherReceipt = await callHost<Receipt>(restarted, {
+      op: "issueDispatch",
+      windowId: otherWindow.windowId,
+    });
+    expect(await callHost(restarted, { op: "belongs", receipt: r2 })).toBe(false);
+    expect(await callHost(restarted, { op: "belongs", receipt: otherReceipt })).toBe(true);
     const generation2Receipt = await callHost<Receipt>(restarted, {
       op: "issueDispatch",
       windowId: w1.windowId,
     });
+    expect(await callHost(restarted, { op: "belongs", receipt: generation2Receipt })).toBe(true);
     await stopHost(restarted);
 
     // 活窗在未归档时正常停机；第三个进程必须从发号水位继续到 generation 3，

--- a/tests/session-registry.test.ts
+++ b/tests/session-registry.test.ts
@@ -27,7 +27,8 @@ describe("SessionRegistry：多窗语义", () => {
   it("MV-A04 缺省 scope 落私聊，不落全局", () => {
     const sessions = new SessionRegistry<null>();
 
-    expect(sessions.open("resident-a", { context: null }).scopeId).toBe(PRIVATE_SCOPE);
+    // 不拿实现导出的常量造期望：常量错成 global 时，测试也必须转红。
+    expect(sessions.open("resident-a", { context: null }).scopeId).toBe("private");
     expect(sessions.open("resident-a", { scopeId: "room-1", context: null }).scopeId).toBe(
       "room-1",
     );

--- a/tests/turn-gate-host.test.ts
+++ b/tests/turn-gate-host.test.ts
@@ -199,34 +199,47 @@ describe("turn-gate real host subprocess", () => {
     // A 窗先开工（driver 懒开窗路径）。MV-C02 的正确性来源只有拉：
     // 本实现不存在推送通道（无可模拟、无可丢弃），B 窗能看到的每一条裁定
     // 都只能是开工闸拉来的。
-    await callHost(child, { op: "sayOn", residentId, message: "placeholder A turn" });
-    const { windowId: windowB, baseline } = await callHost<{ windowId: string; baseline: number }>(
-      child,
-      { op: "openWindowB", residentId },
-    );
-    expect(baseline).toBe(0);
-
-    await callHost(child, {
-      op: "appendRuling",
+    await callHost(child, { op: "holdDriverReply" });
+    const pendingA = callHost<SayResult>(child, {
+      op: "sayOn",
       residentId,
-      author: "main-thread",
-      kind: "ruling",
-      body: "placeholder cross-window ruling",
+      message: "placeholder A turn",
     });
+    // A 的 responder 被固定在途：裁定确实落在 A 开工中，而不是 A 已结束之后。
+    try {
+      expect(await callHost(child, { op: "driverReplyPending" })).toBe(true);
+      const { windowId: windowB, baseline } = await callHost<{
+        windowId: string;
+        baseline: number;
+      }>(child, { op: "openWindowB", residentId });
+      expect(baseline).toBe(0);
 
-    const saidB = await callHost<SayResult>(child, {
-      op: "sayOnB",
-      residentId,
-      message: "placeholder B turn",
-    });
-    expect(saidB.prompt).toContain(
-      "[权威事实账缺口 | kind=ruling | seq=1 | author=main-thread] placeholder cross-window ruling",
-    );
-    // B 窗的 user 节点仍只落原话。
-    expect(saidB.node.role).toBe("assistant");
-    expect(await callHost<number>(child, { op: "ackedSeq", residentId, windowId: windowB })).toBe(
-      1,
-    );
+      await callHost(child, {
+        op: "appendRuling",
+        residentId,
+        author: "main-thread",
+        kind: "ruling",
+        body: "placeholder cross-window ruling",
+      });
+
+      const saidB = await callHost<SayResult>(child, {
+        op: "sayOnB",
+        residentId,
+        message: "placeholder B turn",
+      });
+      expect(saidB.prompt).toContain(
+        "[权威事实账缺口 | kind=ruling | seq=1 | author=main-thread] placeholder cross-window ruling",
+      );
+      // B 窗的 user 节点仍只落原话。
+      expect(saidB.node.role).toBe("assistant");
+      expect(await callHost<number>(child, { op: "ackedSeq", residentId, windowId: windowB })).toBe(
+        1,
+      );
+      expect(await callHost(child, { op: "driverReplyPending" })).toBe(true);
+    } finally {
+      await callHost(child, { op: "releaseDriverReply" });
+      await pendingA;
+    }
   });
 
   it("MV-C03 查账失败按缺处理：say fail-closed，history 放行且日志记「缺口未知」", async () => {


### PR DESCRIPTION
Refs #148. This is verification work and an evidence handoff, not an independent acceptance seal. Please do not auto-close #148 before the maintainer-designated acceptance seat has reviewed and signed.

Baseline: `21d3c451c6ee9ae877bdfeecb6425844e6137092`; upstream main was unchanged at the final check. Commits: `453e03b8c00814a0201bf6a8017c5a5cbeab4be0`, `539577cdbff944c13c870944220e4b807d65484c`.

## Changes

- Add a 28-row source-PR/test/result ledger to `acceptance/multi-viewport.md`, with reproducible single-point mutation recipes and actual failure/restoration receipts in `acceptance/evidence/multi-viewport-148-2026-09-10.json`.
- Repair the MV-A04 oracle: changing PRIVATE_SCOPE to global incorrectly passed the old test because the expectation imported the same constant. The independent literal assertion turns that same mutant red.
- Strengthen real-host archive write rejection and two-window receipt quadrants; hold window A's responder in flight while the C01 ruling is written and pulled by B.
- Correct `session-api.md`: #121 already delivers the real session handler through host services; #139 already implements the first-party/evidence split. Keep production history and product acceptance boundaries explicit.
- H1 already says 28; add the evidence link without claiming independent sign-off.

No production implementation changes remain. All mutations were restored. Only eight task-specific test/evidence/document files changed.

## Verification

- Full root suite, before and after: 539 passed / 38 todo; final 51 passed files / 3 skipped files, 52.92 s.
- `npm run acceptance`: six true green milestone checks (not a 28-clause MV runner).
- `npm run lint`, `npm run typecheck`: exit 0.
- Complete webui `pnpm run build`: exit 0.
- Webui adapter, real HTTP host, RPC schemas, official plugin composition and lifecycle: 49 passed across five files, 7.96 s. Root Vitest excludes webui, so this was run separately.
- 31 isolated mutations: each selected test failed, each restored rerun passed. There are 28 implementation mutations and three explicitly labeled fixture-composition mutations (M18/M24/M28), covering 26 MV clauses plus the shared OS-05 assertion. B02 has unit/static checks; E02 is manual documentation review.
- Initial missing-build and pnpm-shell setup failures are disclosed in the appendix; they were resolved by the normal host/client/web build sequence, without dummy dist or bypassing assertions.

## Boundaries requiring review

- C02 has no push implementation to drop; the load-bearing pull test is real, but push-loss remains the pre-existing vacuous condition.
- D04 tests the usageOf assembly contract, not a provider tokenizer. D07's suddenKill is a simulated window death inside a subprocess, not process SIGKILL.
- D10 external binding is a fixture Map, not a live external-channel integration. E01 uses fixture history ports, not #120 production persistence acceptance.
- MV-D09 and OS-05 reuse the existing host/canonical failure assertions.
- Maintainer designation of the independent acceptance seat is still absent from #148. This PR does not declare D13 unlocked.

