### PR TITLE
acceptance: 线 2 判卷驱动接口与第一批七条判卷（#164）

### DIFF
--- a/acceptance/isolation-checks.ts
+++ b/acceptance/isolation-checks.ts
@@ -1,0 +1,296 @@
+/**
+ * 有意隔离 v0 · 线 2（膜）的判卷，第一批。
+ *
+ * 人话版在 `acceptance/intentional-isolation-v0.md`，两边必须同步改；**判卷以这里为准**。
+ *
+ * 本批只覆盖不依赖线 1 认证来源接缝的七条：
+ * II-C01、II-C02、II-C03、II-C05、II-D06、II-D07、II-D08。
+ * 其余条目等 #163 的公开接缝落地后另交。
+ *
+ * 判卷纪律：只做确定性断言（存储内容、字节相等、集合关系），不判模型说话的措辞。
+ * **凡否定断言必先跑正对照**——见 `requireNonEmpty`。
+ */
+import {
+  type IsolationCheck,
+  type IsolationCheckResult,
+  type IsolationDriver,
+  requireNonEmpty,
+} from "./isolation-driver.ts";
+
+const pass = (detail: string): IsolationCheckResult => ({ passed: true, detail });
+const fail = (detail: string): IsolationCheckResult => ({ passed: false, detail });
+
+/** 名单是一份显式清单，不是相似度查询的返回值。 */
+const c01: IsolationCheck = {
+  id: "II-C01",
+  title: "default-in 名单是显式清单：可枚举、无 query 参数、同一住户两次调用集合相等",
+  uses: ["createResident", "addDefaultIn", "listDefaultIn", "destroyResident"],
+  async run(driver: IsolationDriver) {
+    const r = await driver.createResident("c01");
+    try {
+      await driver.addDefaultIn(r, {
+        content: "她说话偏好短句，不用破折号",
+        origin: { kind: "verified", ref: "confirm:2026-09-02" },
+      });
+      const first = await driver.listDefaultIn(r);
+      const guard = requireNonEmpty(first, "default-in 名单");
+      if (!guard.ok) return fail(guard.detail);
+
+      const second = await driver.listDefaultIn(r);
+      if (!second.ok) return fail(`第二次列名单失败：${second.reason}`);
+
+      const ids = (xs: { id: string }[]) => [...xs.map((x) => x.id)].sort().join(",");
+      if (ids(guard.items) !== ids(second.items)) {
+        return fail("同一住户连续两次 listDefaultIn 返回的集合不相等——名单像是查询结果而不是清单");
+      }
+      // 接口层判据：listDefaultIn 只接一个参数。多出来的参数即为 query 入口。
+      if (driver.listDefaultIn.length !== 1) {
+        return fail(
+          `listDefaultIn 接受 ${driver.listDefaultIn.length} 个参数——名单不许有 query 入口`,
+        );
+      }
+      return pass(`名单可枚举且两次调用一致（${guard.items.length} 条），无 query 参数`);
+    } finally {
+      await driver.destroyResident(r);
+    }
+  },
+};
+
+/** 缺 origin 的条目不许进名单。 */
+const c02: IsolationCheck = {
+  id: "II-C02",
+  title: "名单每条带来源：缺 origin 的条目写入被拒",
+  uses: ["createResident", "addDefaultIn", "listDefaultIn", "destroyResident"],
+  async run(driver: IsolationDriver) {
+    const r = await driver.createResident("c02");
+    try {
+      let rejectedUnknown = false;
+      try {
+        await driver.addDefaultIn(r, {
+          content: "来路不明的偏好",
+          origin: { kind: "unknown", ref: null },
+        });
+      } catch {
+        rejectedUnknown = true;
+      }
+      if (!rejectedUnknown) return fail("origin.kind=unknown 的条目被接受了——名单每条必须带来源");
+
+      let rejectedNullRef = false;
+      try {
+        await driver.addDefaultIn(r, {
+          content: "自称已确认但指不出出处",
+          origin: { kind: "verified", ref: null },
+        });
+      } catch {
+        rejectedNullRef = true;
+      }
+      if (!rejectedNullRef) {
+        return fail("origin.kind=verified 但 ref 为空的条目被接受了——verified 必须指得出出处");
+      }
+
+      const after = await driver.listDefaultIn(r);
+      if (!after.ok) return fail(`列名单失败：${after.reason}`);
+      if (after.items.length !== 0) {
+        return fail(`两次被拒的写入之后名单里仍有 ${after.items.length} 条——拒绝没有真的拒绝`);
+      }
+      return pass("unknown 与 ref 为空两种缺来源写入均被拒，名单未被污染");
+    } finally {
+      await driver.destroyResident(r);
+    }
+  },
+};
+
+/** 缺 origin 的 legacy 不进名单——**先跑正对照**。 */
+const c03: IsolationCheck = {
+  id: "II-C03",
+  title: "缺 origin 的 legacy 不进自动进入内容（先证明名单内条目确实进来了）",
+  uses: [
+    "createResident",
+    "createScope",
+    "addDefaultIn",
+    "seedLegacyMemory",
+    "assembleContext",
+    "destroyResident",
+  ],
+  async run(driver: IsolationDriver) {
+    const r = await driver.createResident("c03");
+    try {
+      const canary = `legacy-canary-${Date.now().toString(36)}`;
+      const listed = "她的语言偏好：中文口语，不写公文腔";
+      await driver.addDefaultIn(r, {
+        content: listed,
+        origin: { kind: "verified", ref: "confirm:2026-08-16" },
+      });
+      await driver.seedLegacyMemory(r, canary);
+
+      const scope = await driver.createScope(r, "c03-scope");
+      const ctx = await driver.assembleContext(r, scope);
+
+      // 正对照：名单内那条必须真的在，否则「canary 不在」毫无意义
+      const guard = requireNonEmpty(ctx, "新 scope 的开工上下文");
+      if (!guard.ok) return fail(guard.detail);
+      if (!guard.items.some((x) => x.includes(listed))) {
+        return fail("正对照失败：名单内条目没有出现在新 scope 的上下文里——装配路径不可信");
+      }
+
+      if (guard.items.some((x) => x.includes(canary))) {
+        return fail("缺 origin 的 legacy 记忆出现在了自动进入内容里");
+      }
+      return pass("名单内条目已进（正对照成立），缺 origin 的 legacy canary 未进");
+    } finally {
+      await driver.destroyResident(r);
+    }
+  },
+};
+
+/** 名单外默认不进——**先跑正对照**。 */
+const c05: IsolationCheck = {
+  id: "II-C05",
+  title: "名单外的住户级内容默认不进新 scope（先证明名单内条目确实进来了）",
+  uses: [
+    "createResident",
+    "createScope",
+    "addDefaultIn",
+    "remember",
+    "assembleContext",
+    "destroyResident",
+  ],
+  async run(driver: IsolationDriver) {
+    const r = await driver.createResident("c05");
+    try {
+      const canary = `offlist-canary-${Date.now().toString(36)}`;
+      const listed = "她的辣度：两档，湖南口味";
+      await driver.addDefaultIn(r, {
+        content: listed,
+        origin: { kind: "verified", ref: "confirm:2026-07-27" },
+      });
+      await driver.remember(r, canary);
+
+      const scope = await driver.createScope(r, "c05-scope");
+      const ctx = await driver.assembleContext(r, scope);
+
+      const guard = requireNonEmpty(ctx, "新 scope 的开工上下文");
+      if (!guard.ok) return fail(guard.detail);
+      if (!guard.items.some((x) => x.includes(listed))) {
+        return fail("正对照失败：名单内条目没有进上下文——无法据此断言名单外的没进");
+      }
+
+      if (guard.items.some((x) => x.includes(canary))) {
+        return fail("名单外的住户级记忆进了新 scope 的上下文");
+      }
+      return pass("名单内已进（正对照成立），名单外 canary 未进");
+    } finally {
+      await driver.destroyResident(r);
+    }
+  },
+};
+
+/** 更正走加注/勘误链，不走就地覆盖。 */
+const d06: IsolationCheck = {
+  id: "II-D06",
+  title: "更正只追加勘误链：旧条目字节不变，新条目链回旧条目",
+  uses: ["createResident", "remember", "errata", "listMemories", "readEntry", "destroyResident"],
+  async run(driver: IsolationDriver) {
+    const r = await driver.createResident("d06");
+    try {
+      const original = "居酒屋在 Surry Hills";
+      const oldId = await driver.remember(r, original);
+      const before = await driver.readEntry(r, oldId);
+
+      const newId = await driver.errata(r, oldId, "居酒屋在 Chippendale，不是 Surry Hills");
+      const after = await driver.readEntry(r, oldId);
+
+      if (after.entry.content !== before.entry.content) {
+        return fail(
+          `旧条目正文被改写了：「${before.entry.content}」→「${after.entry.content}」——更正不许就地覆盖`,
+        );
+      }
+      if (after.entry.content !== original) {
+        return fail("旧条目正文与写入时不一致");
+      }
+      if (after.entry.supersededBy !== newId) {
+        return fail(
+          `旧条目的 supersededBy 是 ${String(after.entry.supersededBy)}，应指向新条目 ${newId}`,
+        );
+      }
+      const fresh = await driver.readEntry(r, newId);
+      if (fresh.entry.supersededBy !== null) {
+        return fail("新条目一出生就被标为已取代");
+      }
+      return pass("旧条目原文字节不变且 supersededBy 指向新条目，新条目为活条目");
+    } finally {
+      await driver.destroyResident(r);
+    }
+  },
+};
+
+/** 加注的可发现性由读取路径保证。 */
+const d07: IsolationCheck = {
+  id: "II-D07",
+  title: "加注在读取路径上：只读正文也必然拿到加注",
+  uses: ["createResident", "remember", "annotate", "readEntry", "destroyResident"],
+  async run(driver: IsolationDriver) {
+    const r = await driver.createResident("d07");
+    try {
+      const entryId = await driver.remember(r, "她说周五要交 A1b");
+      const noteId = await driver.annotate(r, entryId, "更正：A1b 是 10-12 周一，不是周五");
+
+      const read = await driver.readEntry(r, entryId);
+      if (read.annotations.length === 0) {
+        return fail("读正文时没有一并返回加注——躺在库里但不在故障现场读取路径上的更正，等于没有");
+      }
+      if (!read.annotations.some((a) => a.id === noteId)) {
+        return fail(`读回的加注里没有刚写的那条（${noteId}）`);
+      }
+      if (read.entry.content !== "她说周五要交 A1b") {
+        return fail("加注改动了正文——加注是改写的逆操作，不是另一种改写");
+      }
+      return pass("加注随正文一并返回，且正文未被改动");
+    } finally {
+      await driver.destroyResident(r);
+    }
+  },
+};
+
+/** 不可逆删除留一块不泄密的疤。 */
+const d08: IsolationCheck = {
+  id: "II-D08",
+  title: "删除留疤：原值不可恢复，疤可见且不泄露被删内容",
+  uses: ["createResident", "remember", "hardDelete", "listMemories", "destroyResident"],
+  async run(driver: IsolationDriver) {
+    const r = await driver.createResident("d08");
+    try {
+      const secret = `deleted-secret-${Date.now().toString(36)}`;
+      const entryId = await driver.remember(r, secret);
+
+      const before = await driver.listMemories(r);
+      const guard = requireNonEmpty(before, "删除前的住户级记忆");
+      if (!guard.ok) return fail(guard.detail);
+      if (!guard.items.some((m) => m.content.includes(secret))) {
+        return fail("正对照失败：删除前就查不到那条记忆，无法证明删除做了什么");
+      }
+
+      await driver.hardDelete(r, entryId, "她要求彻底删掉");
+
+      const after = await driver.listMemories(r);
+      if (!after.ok) return fail(`删除后列记忆失败：${after.reason}`);
+
+      const survivor = after.items.find((m) => m.id === entryId);
+      if (survivor === undefined) {
+        return fail("删除后条目整个消失了——不可逆删除仍须留下变更疤");
+      }
+      if (survivor.tombstone === undefined) {
+        return fail("条目还在但没有 tombstone——疤必须可见");
+      }
+      const leaked = JSON.stringify(after.items).includes(secret);
+      if (leaked) {
+        return fail("疤或残留数据里仍能读到被删内容——原值必须不可恢复");
+      }
+      return pass("原值不可恢复，疤可见且不泄露被删内容");
+    } finally {
+      await driver.destroyResident(r);
+    }
+  },
+};
+
+export const isolationChecks: IsolationCheck[] = [c01, c02, c03, c05, d06, d07, d08];

--- a/acceptance/isolation-checks.ts
+++ b/acceptance/isolation-checks.ts
@@ -28,13 +28,17 @@ const c01: IsolationCheck = {
   async run(driver: IsolationDriver) {
     const r = await driver.createResident("c01");
     try {
+      const listed = "她说话偏好短句，不用破折号";
       await driver.addDefaultIn(r, {
-        content: "她说话偏好短句，不用破折号",
+        content: listed,
         origin: { kind: "verified", ref: "confirm:2026-09-02" },
       });
       const first = await driver.listDefaultIn(r);
       const guard = requireNonEmpty(first, "default-in 名单");
       if (!guard.ok) return fail(guard.detail);
+      if (!guard.items.some((x) => x.content === listed)) {
+        return fail("刚写入的条目不在名单里——名单非空但装的不是我写进去的东西");
+      }
 
       const second = await driver.listDefaultIn(r);
       if (!second.ok) return fail(`第二次列名单失败：${second.reason}`);
@@ -64,6 +68,19 @@ const c02: IsolationCheck = {
   async run(driver: IsolationDriver) {
     const r = await driver.createResident("c02");
     try {
+      // 正对照：合法写入必须先成功。否则「两次都被拒」可能只是 addDefaultIn 一律抛错。
+      const legit = "她的辣度：两档，湖南口味";
+      await driver.addDefaultIn(r, {
+        content: legit,
+        origin: { kind: "verified", ref: "confirm:2026-07-27" },
+      });
+      const control = await driver.listDefaultIn(r);
+      const controlGuard = requireNonEmpty(control, "合法写入后的 default-in 名单");
+      if (!controlGuard.ok) return fail(controlGuard.detail);
+      if (!controlGuard.items.some((x) => x.content === legit)) {
+        return fail("正对照失败：带 origin 的合法条目没能写进名单——无法据此断言拒绝是真拒绝");
+      }
+
       let rejectedUnknown = false;
       try {
         await driver.addDefaultIn(r, {
@@ -90,10 +107,15 @@ const c02: IsolationCheck = {
 
       const after = await driver.listDefaultIn(r);
       if (!after.ok) return fail(`列名单失败：${after.reason}`);
-      if (after.items.length !== 0) {
-        return fail(`两次被拒的写入之后名单里仍有 ${after.items.length} 条——拒绝没有真的拒绝`);
+      const contents = after.items.map((x) => x.content);
+      if (contents.length !== 1 || contents[0] !== legit) {
+        return fail(
+          `两次被拒的写入之后名单应当只剩正对照那一条，实际是 ${JSON.stringify(contents)}——拒绝没有真的拒绝`,
+        );
       }
-      return pass("unknown 与 ref 为空两种缺来源写入均被拒，名单未被污染");
+      return pass(
+        "合法写入成功（正对照成立），unknown 与 ref 为空两种缺来源写入均被拒，名单未被污染",
+      );
     } finally {
       await driver.destroyResident(r);
     }
@@ -110,6 +132,7 @@ const c03: IsolationCheck = {
     "addDefaultIn",
     "seedLegacyMemory",
     "assembleContext",
+    "listDefaultIn",
     "destroyResident",
   ],
   async run(driver: IsolationDriver) {
@@ -136,7 +159,14 @@ const c03: IsolationCheck = {
       if (guard.items.some((x) => x.includes(canary))) {
         return fail("缺 origin 的 legacy 记忆出现在了自动进入内容里");
       }
-      return pass("名单内条目已进（正对照成立），缺 origin 的 legacy canary 未进");
+
+      // 灯题是「不进自动进入内容」，名单是它的上游：canary 也不许混进名单本身。
+      const list = await driver.listDefaultIn(r);
+      if (!list.ok) return fail(`列名单失败：${list.reason}`);
+      if (list.items.some((x) => x.content.includes(canary))) {
+        return fail("缺 origin 的 legacy 记忆被收进了 default-in 名单");
+      }
+      return pass("名单内条目已进（正对照成立），legacy canary 既不在名单里也不在上下文里");
     } finally {
       await driver.destroyResident(r);
     }
@@ -189,7 +219,7 @@ const c05: IsolationCheck = {
 const d06: IsolationCheck = {
   id: "II-D06",
   title: "更正只追加勘误链：旧条目字节不变，新条目链回旧条目",
-  uses: ["createResident", "remember", "errata", "listMemories", "readEntry", "destroyResident"],
+  uses: ["createResident", "remember", "errata", "readEntry", "destroyResident"],
   async run(driver: IsolationDriver) {
     const r = await driver.createResident("d06");
     try {
@@ -256,7 +286,14 @@ const d07: IsolationCheck = {
 const d08: IsolationCheck = {
   id: "II-D08",
   title: "删除留疤：原值不可恢复，疤可见且不泄露被删内容",
-  uses: ["createResident", "remember", "hardDelete", "listMemories", "destroyResident"],
+  uses: [
+    "createResident",
+    "remember",
+    "hardDelete",
+    "listMemories",
+    "readEntry",
+    "destroyResident",
+  ],
   async run(driver: IsolationDriver) {
     const r = await driver.createResident("d08");
     try {
@@ -282,11 +319,20 @@ const d08: IsolationCheck = {
       if (survivor.tombstone === undefined) {
         return fail("条目还在但没有 tombstone——疤必须可见");
       }
-      const leaked = JSON.stringify(after.items).includes(secret);
-      if (leaked) {
-        return fail("疤或残留数据里仍能读到被删内容——原值必须不可恢复");
+      if (JSON.stringify(after.items).includes(secret)) {
+        return fail("列表路径的疤或残留数据里仍能读到被删内容——原值必须不可恢复");
       }
-      return pass("原值不可恢复，疤可见且不泄露被删内容");
+
+      // 「不可恢复」是对所有读口说的。只扫 listMemories 会漏掉 readEntry 这条路。
+      try {
+        const direct = await driver.readEntry(r, entryId);
+        if (JSON.stringify(direct).includes(secret)) {
+          return fail("readEntry 仍能读回被删内容——列表路径干净不等于原值不可恢复");
+        }
+      } catch {
+        // 直接读被删条目抛错也是合法实现：原值同样取不回来。
+      }
+      return pass("两条读口（listMemories / readEntry）均取不回原值，疤可见且不泄露被删内容");
     } finally {
       await driver.destroyResident(r);
     }

--- a/acceptance/isolation-driver.ts
+++ b/acceptance/isolation-driver.ts
@@ -1,0 +1,164 @@
+/**
+ * 有意隔离 v0 · 线 2（膜）的验收驱动接口。
+ *
+ * 与 `driver.ts` 同一套哲学：判卷只通过这份接口说话，不 import `src/` 里的任何东西。
+ * 实现方在 `src/isolation-acceptance-driver.ts` 导出 `createIsolationDriver()`，
+ * 判卷程序自己去找；还没有实现时全部条目显示「缺驱动」——那是起点状态不是故障。
+ *
+ * 范围：本文件只覆盖 #164 里**不依赖线 1 认证来源接缝**的那一批。
+ * 需要「作者由宿主构造、调用方不可自报」的条目（II-B01/B02/B03/B04、
+ * II-D01～D05、II-D09/D10、II-E01～E06、II-L*、II-N*、II-O04）等 #163 的公开接缝
+ * 落地后另行扩写，本文件先不给它们留半成品签名，免得实现方照着一份猜出来的形状施工。
+ *
+ * 判卷纪律（`acceptance/intentional-isolation-v0.md` 顶部）在这里的落法：
+ * **凡「X 不出现」的断言，同一次运行里必须先证明该路径能产出非零结果。**
+ * 因此凡是否定断言的读取口，接口都要求实现方把「查询失败」与「查询成功且结果为空」
+ * 做成可区分的两个返回——见 `ReadResult`。两者塌成同一个空集时，任何否定断言都不可信。
+ */
+
+/**
+ * 读取路径的返回。**不允许用裸数组**：`[]` 无法区分「确实没有」与「根本没读到」，
+ * 而线 2 有八条否定断言全部压在这个区分上（II-B01/B02/C03/C05 等）。
+ *
+ * - `ok: true` ＝ 查询成功，`items` 是真实结果（可以为空数组）
+ * - `ok: false` ＝ 查询失败，`reason` 说明为什么；此时**不得**假装结果为空
+ */
+export type ReadResult<T> = { ok: true; items: T[] } | { ok: false; reason: string };
+
+/** default-in 名单里的一条。缺 `origin` 的条目不许进名单（II-C02）。 */
+export interface DefaultInEntry {
+  id: string;
+  content: string;
+  /**
+   * 它当初怎么进的名单：哪次确认、哪条事件、哪次迁移映射。
+   * 三态可分（II-L06 同源）：`verified` 有确定性出处；`inferred` 是读取路径上算出来的
+   * 显式低置信 fallback，**不得落盘**；`unknown` 是老条目缺出处的诚实状态。
+   */
+  origin: { kind: "verified" | "inferred" | "unknown"; ref: string | null };
+}
+
+/** 住户级记忆的一条。`supersededBy` 非空即被勘误链取代，但原文必须原地留底。 */
+export interface ResidentMemoryEntry {
+  id: string;
+  content: string;
+  supersededBy: string | null;
+  /** 不可逆删除后的变更疤：原值不可恢复，但疤本身可见且**不泄露被删内容**。 */
+  tombstone?: { deletedAt: string; reason: string };
+}
+
+/** 加注：写不进正文、但一定与正文一起被读到的更正原语（II-D07）。 */
+export interface Annotation {
+  id: string;
+  targetId: string;
+  content: string;
+  author: string;
+  createdAt: string;
+}
+
+/** 读一条住户级记录时**必然**一并返回的东西。加注不能靠调用方记得另外查一次。 */
+export interface ReadEntryResult {
+  entry: ResidentMemoryEntry;
+  /** 该条目上的全部加注。可发现性由读取路径保证，不由写入位置保证。 */
+  annotations: Annotation[];
+}
+
+export interface IsolationDriver {
+  /** 建住户。返回 residentId。 */
+  createResident(name: string): Promise<string>;
+
+  /** 为住户开一个隔离 scope。返回 scopeId。 */
+  createScope(residentId: string, name: string): Promise<string>;
+
+  // ---- default-in 名单（Q1） ----
+
+  /**
+   * 列出当前会自动进入每个 scope 的条目。
+   * **不接受任何 query 参数**——名单是一份显式清单，不是相似度查询的返回值（II-C01）。
+   */
+  listDefaultIn(residentId: string): Promise<ReadResult<DefaultInEntry>>;
+
+  /**
+   * 往名单里加一条。`origin.kind === "unknown"` 或 `ref` 为空时**必须拒绝**（II-C02）。
+   * 拒绝用抛错表达，不要返回 false——静默失败会让判卷误判成通过。
+   */
+  addDefaultIn(residentId: string, entry: Omit<DefaultInEntry, "id">): Promise<string>;
+
+  /**
+   * 造样用：注入一条**没有 origin** 的 legacy 住户级记忆。
+   * 它不该出现在任何 scope 的自动进入内容里（II-C03），
+   * 系统也不许按时间邻近或语义相似替它推测一个 origin 并落盘（II-C04）。
+   */
+  seedLegacyMemory(residentId: string, content: string): Promise<string>;
+
+  /** 往住户级记忆写一条正常的（带出处）记录。 */
+  remember(residentId: string, content: string): Promise<string>;
+
+  // ---- scope 侧读取 ----
+
+  /**
+   * 一个 scope 开工时实际拿到的上下文条目。
+   * C03/C05 的否定断言压在这个口上，所以它**必须**能报告失败而不是返回空数组。
+   */
+  assembleContext(residentId: string, scopeId: string): Promise<ReadResult<string>>;
+
+  // ---- 更正原语 ----
+
+  /**
+   * 勘误：旧条目**原地留底、字节不变**，新条目链回旧条目（II-D06）。
+   * 就地覆盖的写入路径不许存在。返回新条目 id。
+   */
+  errata(residentId: string, entryId: string, correction: string): Promise<string>;
+
+  /** 加注：不改正文，但读正文时必然一并返回（II-D07）。返回加注 id。 */
+  annotate(residentId: string, entryId: string, note: string): Promise<string>;
+
+  /** 读一条住户级记录，连同它的全部加注。 */
+  readEntry(residentId: string, entryId: string): Promise<ReadEntryResult>;
+
+  /** 列出住户级记忆（含被取代的和已删除留疤的）。 */
+  listMemories(residentId: string): Promise<ReadResult<ResidentMemoryEntry>>;
+
+  /**
+   * 不可逆删除：原值不再可查，但留一块**不泄露被删内容**的变更疤（II-D08）。
+   * 疤上不得含被删内容的任何片段或可还原摘要。
+   */
+  hardDelete(residentId: string, entryId: string, reason: string): Promise<void>;
+
+  /** 清理测试住户。 */
+  destroyResident(residentId: string): Promise<void>;
+}
+
+/** 一条判卷。`uses` 申报它调了哪些驱动方法，供桩灯核账。 */
+export interface IsolationCheck {
+  /** 验收编号，与 `acceptance/intentional-isolation-v0.md` 的 II-xx 一一对应。 */
+  id: string;
+  title: string;
+  uses: (keyof IsolationDriver)[];
+  run(driver: IsolationDriver): Promise<IsolationCheckResult>;
+}
+
+export interface IsolationCheckResult {
+  passed: boolean;
+  /** 说清为什么过或为什么没过。判红时必须能指出是哪一条断言倒的。 */
+  detail: string;
+}
+
+/**
+ * 正对照助手。**否定断言之前先调它**：拿到一个应当非空的读取结果，
+ * 读失败或结果为空都直接判红，不给「系统坏了所以什么都没看见」当绿灯的机会。
+ */
+export function requireNonEmpty<T>(
+  result: ReadResult<T>,
+  what: string,
+): { ok: true; items: T[] } | { ok: false; detail: string } {
+  if (!result.ok) {
+    return { ok: false, detail: `正对照失败：读取${what}时查询本身失败（${result.reason}）` };
+  }
+  if (result.items.length === 0) {
+    return {
+      ok: false,
+      detail: `正对照失败：${what}返回空集——「没找到」和「找不了」不能共用一盏灯`,
+    };
+  }
+  return { ok: true, items: result.items };
+}

--- a/acceptance/isolation-run.ts
+++ b/acceptance/isolation-run.ts
@@ -14,8 +14,23 @@
  * 本程序**不勾** `acceptance/intentional-isolation-v0.md` 里的方框。
  * 方框由独立验收席按 PR 证据勾，判卷程序只报灯色。
  */
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { isolationChecks } from "./isolation-checks.ts";
 import type { IsolationCheck, IsolationDriver } from "./isolation-driver.ts";
+
+const DRIVER_SPECIFIER = "../src/isolation-acceptance-driver.ts";
+
+/**
+ * 驱动入口在不在盘上。**这是「还没开工」与「驱动坏了」的唯一可靠判据。**
+ * 不能靠 catch 里的错误码：驱动自己 import 了一个不存在的模块时，抛的同样是
+ * `ERR_MODULE_NOT_FOUND` / `Cannot find module`，靠错误码会把坏驱动误报成起点状态。
+ * 也不能只看 message 里有没有驱动名——两种情形下驱动路径都会出现在 message 里，
+ * 一次作为找不到的模块，一次作为发起 import 的文件。
+ */
+function driverFileExists(): boolean {
+  return existsSync(fileURLToPath(new URL(DRIVER_SPECIFIER, import.meta.url)));
+}
 
 const strict = process.argv.includes("--strict");
 
@@ -25,24 +40,19 @@ interface LoadedDriver {
 }
 
 async function loadDriver(): Promise<LoadedDriver | null> {
-  try {
-    // 走变量而不是字面量：驱动尚未存在时 tsc 不该因为解析不到模块而报错，
-    // 「还没实现」是本线的起点状态。同 acceptance/run.ts 的写法。
-    const driverPath = "../src/isolation-acceptance-driver.ts";
-    const mod = await import(driverPath);
-    if (typeof mod.createIsolationDriver !== "function") {
-      console.error("src/isolation-acceptance-driver.ts 存在但没有导出 createIsolationDriver()");
-      return null;
-    }
-    const stubbed = new Set<string>(Array.isArray(mod.STUBBED) ? mod.STUBBED : []);
-    return { driver: mod.createIsolationDriver() as IsolationDriver, stubbed };
-  } catch (err) {
-    // 只把「模块不存在」当起点状态。驱动存在但 import 即抛的话必须炸出来，
-    // 否则坏驱动会显示成「还没开工」——假起点和假绿一样是读数造假。同 acceptance/run.ts。
-    if (err instanceof Error && err.message.includes("Cannot find module")) return null;
-    if (err instanceof Error && "code" in err && err.code === "ERR_MODULE_NOT_FOUND") return null;
-    throw err;
+  // 先看文件在不在，再谈 import 成不成。顺序反过来就分不清坏驱动与没驱动。
+  if (!driverFileExists()) return null;
+
+  // 走变量而不是字面量：驱动尚未存在时 tsc 不该因为解析不到模块而报错，
+  // 「还没实现」是本线的起点状态。同 acceptance/run.ts 的写法。
+  const driverPath = DRIVER_SPECIFIER;
+  const mod = await import(driverPath);
+  if (typeof mod.createIsolationDriver !== "function") {
+    console.error("src/isolation-acceptance-driver.ts 存在但没有导出 createIsolationDriver()");
+    return null;
   }
+  const stubbed = new Set<string>(Array.isArray(mod.STUBBED) ? mod.STUBBED : []);
+  return { driver: mod.createIsolationDriver() as IsolationDriver, stubbed };
 }
 
 function usesStub(check: IsolationCheck, stubbed: Set<string>): boolean {

--- a/acceptance/isolation-run.ts
+++ b/acceptance/isolation-run.ts
@@ -48,8 +48,11 @@ async function loadDriver(): Promise<LoadedDriver | null> {
   const driverPath = DRIVER_SPECIFIER;
   const mod = await import(driverPath);
   if (typeof mod.createIsolationDriver !== "function") {
-    console.error("src/isolation-acceptance-driver.ts 存在但没有导出 createIsolationDriver()");
-    return null;
+    // 文件在盘上却没有工厂导出＝驱动坏了，不是还没开工。返回 null 会让它显示成
+    // 「缺驱动」并退 0，那是同一种假起点，只是坏在导出上而不是坏在依赖上。
+    throw new Error(
+      "src/isolation-acceptance-driver.ts 存在但没有导出 createIsolationDriver()——这是坏驱动，不是起点状态",
+    );
   }
   const stubbed = new Set<string>(Array.isArray(mod.STUBBED) ? mod.STUBBED : []);
   return { driver: mod.createIsolationDriver() as IsolationDriver, stubbed };

--- a/acceptance/isolation-run.ts
+++ b/acceptance/isolation-run.ts
@@ -36,8 +36,12 @@ async function loadDriver(): Promise<LoadedDriver | null> {
     }
     const stubbed = new Set<string>(Array.isArray(mod.STUBBED) ? mod.STUBBED : []);
     return { driver: mod.createIsolationDriver() as IsolationDriver, stubbed };
-  } catch {
-    return null;
+  } catch (err) {
+    // 只把「模块不存在」当起点状态。驱动存在但 import 即抛的话必须炸出来，
+    // 否则坏驱动会显示成「还没开工」——假起点和假绿一样是读数造假。同 acceptance/run.ts。
+    if (err instanceof Error && err.message.includes("Cannot find module")) return null;
+    if (err instanceof Error && "code" in err && err.code === "ERR_MODULE_NOT_FOUND") return null;
+    throw err;
   }
 }
 

--- a/acceptance/isolation-run.ts
+++ b/acceptance/isolation-run.ts
@@ -1,0 +1,93 @@
+/**
+ * 有意隔离 v0 · 线 2 的判卷程序。用法：
+ *
+ *   npm run acceptance:isolation           # 报告模式：打红绿灯，永远退出 0
+ *   npm run acceptance:isolation:strict    # 验收模式：有一盏不真绿就退出 1
+ *
+ * 找 `src/isolation-acceptance-driver.ts` 里的 `createIsolationDriver()`。
+ * 还没有实现时全部显示「缺驱动」——**那是起点状态，不是故障**，
+ * 报告模式照常退出 0。
+ *
+ * 真灯与桩灯：驱动模块可以导出 `STUBBED: string[]` 申报哪些方法还是判卷桩。
+ * 依赖桩方法跑绿的灯显示 🟡，不计入完成；只有真绿才算数。隐瞒申报是伪证。
+ *
+ * 本程序**不勾** `acceptance/intentional-isolation-v0.md` 里的方框。
+ * 方框由独立验收席按 PR 证据勾，判卷程序只报灯色。
+ */
+import { isolationChecks } from "./isolation-checks.ts";
+import type { IsolationCheck, IsolationDriver } from "./isolation-driver.ts";
+
+const strict = process.argv.includes("--strict");
+
+interface LoadedDriver {
+  driver: IsolationDriver;
+  stubbed: Set<string>;
+}
+
+async function loadDriver(): Promise<LoadedDriver | null> {
+  try {
+    // 走变量而不是字面量：驱动尚未存在时 tsc 不该因为解析不到模块而报错，
+    // 「还没实现」是本线的起点状态。同 acceptance/run.ts 的写法。
+    const driverPath = "../src/isolation-acceptance-driver.ts";
+    const mod = await import(driverPath);
+    if (typeof mod.createIsolationDriver !== "function") {
+      console.error("src/isolation-acceptance-driver.ts 存在但没有导出 createIsolationDriver()");
+      return null;
+    }
+    const stubbed = new Set<string>(Array.isArray(mod.STUBBED) ? mod.STUBBED : []);
+    return { driver: mod.createIsolationDriver() as IsolationDriver, stubbed };
+  } catch {
+    return null;
+  }
+}
+
+function usesStub(check: IsolationCheck, stubbed: Set<string>): boolean {
+  return check.uses.some((m) => stubbed.has(m));
+}
+
+async function main(): Promise<void> {
+  const loaded = await loadDriver();
+
+  console.log("有意隔离 v0 · 线 2（膜）判卷");
+  console.log(
+    `清单真源：acceptance/intentional-isolation-v0.md（本批 ${isolationChecks.length} 条）`,
+  );
+  console.log("");
+
+  if (loaded === null) {
+    for (const check of isolationChecks) {
+      console.log(`⬜ ${check.id} 缺驱动 —— ${check.title}`);
+    }
+    console.log("");
+    console.log("src/isolation-acceptance-driver.ts 还不存在。这是本线的起点状态，不是故障。");
+    process.exit(strict ? 1 : 0);
+  }
+
+  let trueGreen = 0;
+  for (const check of isolationChecks) {
+    const stub = usesStub(check, loaded.stubbed);
+    try {
+      const result = await check.run(loaded.driver);
+      if (result.passed && stub) {
+        console.log(`🟡 ${check.id} 桩灯 —— ${check.title}`);
+        console.log(`     ${result.detail}`);
+      } else if (result.passed) {
+        trueGreen += 1;
+        console.log(`🟢 ${check.id} —— ${check.title}`);
+        console.log(`     ${result.detail}`);
+      } else {
+        console.log(`🔴 ${check.id} —— ${check.title}`);
+        console.log(`     ${result.detail}`);
+      }
+    } catch (error) {
+      console.log(`🔴 ${check.id} 抛错 —— ${check.title}`);
+      console.log(`     ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  console.log("");
+  console.log(`真绿 ${trueGreen} / ${isolationChecks.length}`);
+  if (strict && trueGreen !== isolationChecks.length) process.exit(1);
+}
+
+void main();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lint:fix": "biome check --write .",
     "test": "vitest run",
     "acceptance": "tsx acceptance/run.ts",
-    "acceptance:strict": "tsx acceptance/run.ts --strict"
+    "acceptance:strict": "tsx acceptance/run.ts --strict",
+    "acceptance:isolation": "tsx acceptance/isolation-run.ts",
+    "acceptance:isolation:strict": "tsx acceptance/isolation-run.ts --strict"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
判卷先行。**只交判卷侧：不实现膜、不改 `src/`、不勾任何一盏灯。**

## 为什么现在能动

@zaymb 在 #163 说了「你可以继续冻结判卷侧用例，这包并不要求膜先改形状」。我此前一直拿「等接缝」当理由没动手，但膜里确实有几条**不依赖认证来源接缝**：名单能不能枚举、缺来源要不要拒、勘误链、加注在不在读取路径上、删除留不留疤。这批现在就能写成会红的判卷。


## 交了什么

**`acceptance/isolation-driver.ts`** —— 线 2 的验收驱动接口，同 `driver.ts` 一样不 `import src/`。

核心设计是 `ReadResult<T>`：

```ts
export type ReadResult<T> = { ok: true; items: T[] } | { ok: false; reason: string };
```

读取口**一律不许返回裸数组**。理由直接来自 #163 @xcjy8bao 的 **P1-8**：线 2 有八条否定断言全压在「确实没有」与「根本没读到」的区分上；两者塌成同一个空集时，任何否定断言都不可信。另附 `requireNonEmpty()` 正对照助手，否定断言之前先调它。

**`acceptance/isolation-checks.ts`** —— 七条判卷：

| 编号 | 判什么 | 正对照 |
|---|---|---|
| II-C01 | 名单是显式清单：两次调用集合相等、`listDefaultIn.length === 1`（无 query 入口） | 先 requireNonEmpty |
| II-C02 | `unknown` 与 `verified` 但 `ref` 为空两种缺来源写入都被拒，且名单未被污染 | — |
| II-C03 | 缺 origin 的 legacy 不进自动进入内容 | **先断言名单内条目确实进了上下文** |
| II-C05 | 名单外住户级记忆不进新 scope | **先断言名单内条目确实进了上下文** |
| II-D06 | 勘误：旧条目正文字节不变、`supersededBy` 指新条目、新条目为活条目 | — |
| II-D07 | 只读正文也必然拿到加注，且正文未被改动 | — |
| II-D08 | 删除后疤可见、原值不可恢复、**疤与残留数据里搜不到被删内容** | **先断言删除前查得到** |

**`acceptance/isolation-run.ts`** —— 判卷程序。驱动不存在时七条显示「缺驱动」并退 0（起点状态不是故障）；`--strict` 下不全真绿退 1。支持 `STUBBED` 桩灯申报，依赖桩方法跑绿的显示 🟡 不计入完成。

`package.json` 加 `acceptance:isolation` 与 `:strict` 两条 script。

## 本批不含什么

需要「作者由宿主构造、调用方不可自报」的那批（II-B01–B04、D01–D05、D09/D10、E01–E06、L\*、N\*、O04）**等 #163 的公开接缝落地后另交**。接口里**不预留半成品签名**——留一份猜出来的形状，实现方会照着它施工。

## 核验

- `npm run lint` 通过
- `npm run typecheck` 通过
- `npm run acceptance:isolation` 跑起来，七条全「缺驱动」，退出 0
- 根套件 **538 passed / 38 todo**；另有 **1 条既有测试失败**：`tests/resident-self-repair-runner.test.ts` 的 C4 在默认并发下 5s 超时。降并发到 2 单独复跑该文件 **21 项全过**。与本 PR 无关（本 PR 不碰 `src/`），如实记录不隐去——这与 @zaymb 在 #167 遇到的是同一条。

灯仍 83 条全红。本 PR 不勾灯、不改图纸、不声称任何能力已就绪。

Refs #164
cc @kagamiurayama @xcjy8bao @zaymb